### PR TITLE
Add Spark / Microsoft Fabric distributed execution layer

### DIFF
--- a/forecasting-platform/configs/fabric_config.yaml
+++ b/forecasting-platform/configs/fabric_config.yaml
@@ -1,0 +1,80 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# Microsoft Fabric / Spark Layer Configuration
+# ═══════════════════════════════════════════════════════════════════════════════
+# This file configures the Fabric/Spark execution layer.
+# Platform forecasting settings (models, hierarchy, backtest) continue to be
+# driven by platform_config.yaml (or an LOB override in configs/lob/).
+#
+# Environment variable overrides:
+#   FABRIC_WORKSPACE      Workspace name or GUID
+#   FABRIC_LAKEHOUSE      Lakehouse name or GUID
+#   FABRIC_ENVIRONMENT    development | staging | production
+
+fabric:
+  # ── Identity ────────────────────────────────────────────────────────────────
+  workspace: ""                        # Set via FABRIC_WORKSPACE or override here
+  lakehouse: ""                        # Set via FABRIC_LAKEHOUSE or override here
+  onelake_host: "onelake.dfs.fabric.microsoft.com"
+  environment: "development"           # development | staging | production
+
+  # ── Storage layout ──────────────────────────────────────────────────────────
+  # All managed Delta tables live under: abfss://<workspace>@<host>/<lakehouse>/Tables/
+  # Unmanaged files live under:          abfss://<workspace>@<host>/<lakehouse>/Files/
+  tables_root: "Tables"
+  files_root: "Files"
+
+  # ── Delta Lake retention ─────────────────────────────────────────────────────
+  enable_delta_log_retention: true
+  delta_log_retention_days: 30
+  delta_data_retention_days: 7
+
+# ── Spark session settings ───────────────────────────────────────────────────
+spark:
+  app_name: "ForecastingPlatform"
+  executor_memory: "8g"
+  executor_cores: 4
+  # Number of shuffle partitions.
+  # Rule of thumb: ~2-3× total executor cores for medium clusters.
+  shuffle_partitions: 400
+  # Parallelism for the per-series pandas_udf fan-out.
+  # Set to number of distinct series (or leave 0 for auto-detect).
+  series_parallelism: 0
+
+# ── Table names ──────────────────────────────────────────────────────────────
+# These are sub-paths under the Lakehouse Tables/ root.
+tables:
+  actuals:         "actuals"
+  product_master:  "product_master"
+  forecasts:       "forecasts"
+  backtest_results: "backtest_results"
+  leaderboard:     "leaderboard"
+  sku_mappings:    "sku_mappings"
+  overrides:       "overrides"
+
+# ── Write strategy ────────────────────────────────────────────────────────────
+write:
+  # "upsert" runs MERGE INTO (idempotent, safe for re-runs).
+  # "overwrite_partition" replaces the (lob, forecast_origin) partition.
+  # "append" adds rows (use only when you are sure there are no duplicates).
+  forecast_mode: "upsert"
+  backtest_mode: "overwrite_partition"
+  # Partition columns for the forecasts table
+  forecast_partition_by:
+    - lob
+    - forecast_origin
+  # Z-ORDER columns for query acceleration
+  forecast_zorder_by:
+    - series_id
+    - week
+
+# ── Feature engineering ───────────────────────────────────────────────────────
+features:
+  lag_periods:      [1, 7, 14, 30]
+  rolling_windows:  [7, 14, 30]
+
+# ── Data sources (used by SparkDataLoader when not reading Delta tables) ──────
+data:
+  # Relative to fabric.files_root
+  actuals_path:        "raw/actuals"
+  product_master_path: "raw/product_master"
+  format: "parquet"    # delta | parquet | csv

--- a/forecasting-platform/notebooks/01_data_prep.py
+++ b/forecasting-platform/notebooks/01_data_prep.py
@@ -1,0 +1,145 @@
+# Fabric Notebook: 01 — Data Ingestion & Feature Engineering
+# ============================================================
+# Run this notebook first to:
+#   1. Read raw actuals from the Lakehouse Files area (CSV / Parquet).
+#   2. Apply distributed feature engineering with SparkFeatureEngineer.
+#   3. Write the processed actuals Delta table to the Lakehouse.
+#
+# Fabric usage:
+#   - Open in a Microsoft Fabric Lakehouse Notebook.
+#   - Attach to a Spark pool (Medium or larger recommended).
+#   - Set FABRIC_WORKSPACE and FABRIC_LAKEHOUSE env-vars or fill in below.
+
+# %% [markdown]
+# ## 0 — Configuration
+
+# %%
+import os
+import sys
+
+# ── Add platform src to path ─────────────────────────────────────────────────
+# In Fabric, mount the repo via the Lakehouse Git integration or upload the
+# forecasting-platform/ folder.  Adjust the path below as needed.
+PLATFORM_ROOT = "/lakehouse/default/Files/forecasting-platform"
+if PLATFORM_ROOT not in sys.path:
+    sys.path.insert(0, PLATFORM_ROOT)
+
+# ── Fabric / Lakehouse identifiers ───────────────────────────────────────────
+WORKSPACE  = os.environ.get("FABRIC_WORKSPACE", "my-workspace")
+LAKEHOUSE  = os.environ.get("FABRIC_LAKEHOUSE", "my-lakehouse")
+LOB        = os.environ.get("FORECAST_LOB", "rossmann")
+ENVIRONMENT = os.environ.get("FABRIC_ENVIRONMENT", "development")
+
+print(f"Workspace : {WORKSPACE}")
+print(f"Lakehouse : {LAKEHOUSE}")
+print(f"LOB       : {LOB}")
+print(f"Environment: {ENVIRONMENT}")
+
+# %% [markdown]
+# ## 1 — Spark Session
+
+# %%
+from src.spark.session import get_or_create_spark
+
+spark = get_or_create_spark(app_name=f"ForecastingPlatform-DataPrep-{LOB}")
+spark.sparkContext.setLogLevel("WARN")
+print(f"Spark version: {spark.version}")
+
+# %% [markdown]
+# ## 2 — Load raw data
+
+# %%
+from src.spark.loader import SparkDataLoader
+from src.spark.utils import abfss_uri
+
+# Build the ABFSS base path for the Lakehouse
+base_path = abfss_uri(WORKSPACE, LAKEHOUSE)
+loader = SparkDataLoader(spark, base_path=base_path)
+
+# For local / dev mode, read from Files/raw/
+# For Rossmann Kaggle data specifically:
+train_sdf, test_sdf, store_sdf = loader.read_rossmann_all()
+
+print(f"Train rows : {train_sdf.count():,}")
+print(f"Test rows  : {test_sdf.count():,}")
+print(f"Store rows : {store_sdf.count():,}")
+
+# %% [markdown]
+# ## 3 — Merge with store metadata
+
+# %%
+actuals_sdf = train_sdf.join(store_sdf, on="Store", how="left")
+print(f"Actuals after store join: {actuals_sdf.count():,} rows")
+actuals_sdf.printSchema()
+
+# %% [markdown]
+# ## 4 — Distributed feature engineering
+
+# %%
+from src.spark.feature_engineering import SparkFeatureEngineer
+
+eng = SparkFeatureEngineer(
+    lag_periods=[1, 7, 14, 30],
+    rolling_windows=[7, 14, 30],
+)
+
+actuals_features_sdf = eng.fit_transform(
+    actuals_sdf,
+    date_col="Date",
+    target_col="Sales",
+    group_col="Store",
+)
+
+print(f"Feature columns ({len(actuals_features_sdf.columns)}): {actuals_features_sdf.columns}")
+actuals_features_sdf.show(5, truncate=False)
+
+# %% [markdown]
+# ## 5 — Quality checks
+
+# %%
+from pyspark.sql import functions as F
+
+# Missing values summary
+null_counts = actuals_features_sdf.select(
+    [F.count(F.when(F.col(c).isNull(), c)).alias(c) for c in actuals_features_sdf.columns]
+)
+print("Null counts per column:")
+null_counts.show(truncate=False)
+
+# Date range
+actuals_features_sdf.select(
+    F.min("Date").alias("min_date"),
+    F.max("Date").alias("max_date"),
+    F.countDistinct("Store").alias("n_stores"),
+).show()
+
+# %% [markdown]
+# ## 6 — Write processed actuals to Lakehouse (Delta)
+
+# %%
+from src.fabric.config import FabricConfig
+from src.fabric.lakehouse import FabricLakehouse
+
+fabric_cfg = FabricConfig(
+    workspace=WORKSPACE,
+    lakehouse=LAKEHOUSE,
+    environment=ENVIRONMENT,
+)
+lh = FabricLakehouse(spark, fabric_cfg)
+
+lh.write_table(
+    actuals_features_sdf,
+    table_name="actuals",
+    mode="overwrite",
+    partition_by=["Store"],
+    merge_schema=True,
+)
+
+print(f"Actuals Delta table written to: {fabric_cfg.table_path('actuals')}")
+
+# %% [markdown]
+# ## 7 — (Optional) Optimize the Delta table
+
+# %%
+lh.optimize("actuals", z_order_by=["Date"])
+print("OPTIMIZE complete.")

--- a/forecasting-platform/notebooks/02_backtest.py
+++ b/forecasting-platform/notebooks/02_backtest.py
@@ -1,0 +1,171 @@
+# Fabric Notebook: 02 — Distributed Backtest & Champion Selection
+# ================================================================
+# Run this notebook after 01_data_prep.py to:
+#   1. Read processed actuals from the Lakehouse Delta table.
+#   2. Run walk-forward backtest across all configured models in parallel.
+#   3. Select the champion model per LOB.
+#   4. Write backtest results and leaderboard to the Lakehouse.
+#
+# Prerequisites: 01_data_prep.py must have run successfully.
+
+# %% [markdown]
+# ## 0 — Configuration
+
+# %%
+import os
+import sys
+
+PLATFORM_ROOT = "/lakehouse/default/Files/forecasting-platform"
+if PLATFORM_ROOT not in sys.path:
+    sys.path.insert(0, PLATFORM_ROOT)
+
+WORKSPACE   = os.environ.get("FABRIC_WORKSPACE", "my-workspace")
+LAKEHOUSE   = os.environ.get("FABRIC_LAKEHOUSE", "my-lakehouse")
+LOB         = os.environ.get("FORECAST_LOB", "rossmann")
+CONFIG_PATH = os.environ.get("FORECAST_CONFIG", "configs/platform_config.yaml")
+ENVIRONMENT = os.environ.get("FABRIC_ENVIRONMENT", "development")
+
+print(f"Workspace  : {WORKSPACE}")
+print(f"LOB        : {LOB}")
+print(f"Config     : {CONFIG_PATH}")
+
+# %% [markdown]
+# ## 1 — Spark Session
+
+# %%
+from src.spark.session import get_or_create_spark
+
+spark = get_or_create_spark(app_name=f"ForecastingPlatform-Backtest-{LOB}")
+spark.sparkContext.setLogLevel("WARN")
+print(f"Spark version: {spark.version}")
+
+# %% [markdown]
+# ## 2 — Load platform config
+
+# %%
+from src.config.loader import load_config
+
+config = load_config(CONFIG_PATH)
+config.lob = LOB
+print(f"Models to evaluate : {config.forecast.forecasters}")
+print(f"Backtest folds     : {config.backtest.n_folds}")
+print(f"Validation weeks   : {config.backtest.val_weeks}")
+
+# %% [markdown]
+# ## 3 — Read actuals from Lakehouse
+
+# %%
+from src.fabric.config import FabricConfig
+from src.fabric.lakehouse import FabricLakehouse
+
+fabric_cfg = FabricConfig(workspace=WORKSPACE, lakehouse=LAKEHOUSE, environment=ENVIRONMENT)
+lh = FabricLakehouse(spark, fabric_cfg)
+
+actuals_sdf = lh.read_table("actuals")
+print(f"Actuals loaded: {actuals_sdf.count():,} rows")
+actuals_sdf.printSchema()
+
+# %% [markdown]
+# ## 4 — Prepare series-level data
+#
+# The SparkForecastPipeline expects:
+#   - A ``series_id`` column (Store + product key).
+#   - A ``week`` column (weekly period date).
+#   - A ``quantity`` column (target).
+
+# %%
+from pyspark.sql import functions as F
+
+# For Rossmann: series_id = Store, week = truncated Date, quantity = Sales
+actuals_series_sdf = (
+    actuals_sdf
+    .filter(F.col("Open") == 1)             # exclude closed days
+    .withColumn("series_id", F.col("Store").cast("string"))
+    .withColumn("week", F.date_trunc("week", F.col("Date")))
+    .groupby("series_id", "week")
+    .agg(F.sum("Sales").alias("quantity"))
+    .orderBy("series_id", "week")
+)
+
+print(f"Series rows: {actuals_series_sdf.count():,}")
+print(f"Series count: {actuals_series_sdf.select('series_id').distinct().count():,}")
+actuals_series_sdf.show(5)
+
+# %% [markdown]
+# ## 5 — Run distributed backtest
+
+# %%
+from src.spark.pipeline import SparkForecastPipeline
+
+pipeline = SparkForecastPipeline(spark, config)
+
+backtest_results_sdf = pipeline.run_backtest(
+    actuals_sdf=actuals_series_sdf,
+    model_names=config.forecast.forecasters,
+)
+backtest_results_sdf.cache()
+print(f"Backtest result rows: {backtest_results_sdf.count():,}")
+backtest_results_sdf.show(20)
+
+# %% [markdown]
+# ## 6 — Select champion model
+
+# %%
+leaderboard_sdf = pipeline.select_champion(
+    backtest_results_sdf,
+    primary_metric=config.backtest.primary_metric,
+)
+leaderboard_sdf.show(truncate=False)
+
+champion_model = leaderboard_sdf.filter(F.col("rank") == 1).select("model").collect()[0][0]
+print(f"\nChampion model: {champion_model}")
+
+# %% [markdown]
+# ## 7 — Write results to Lakehouse
+
+# %%
+from src.fabric.delta_writer import DeltaWriter
+from pyspark.sql import functions as F as _F
+
+writer = DeltaWriter(spark, fabric_cfg)
+
+# Backtest results
+from datetime import date
+run_date = date.today().isoformat()
+
+backtest_results_sdf_out = (
+    backtest_results_sdf
+    .withColumn("lob", _F.lit(LOB))
+    .withColumn("run_date", _F.lit(run_date))
+)
+writer.append(
+    backtest_results_sdf_out,
+    table_name="backtest_results",
+    partition_by=["lob", "run_date"],
+)
+print("Backtest results written.")
+
+# Leaderboard
+leaderboard_out = (
+    leaderboard_sdf
+    .withColumn("lob", _F.lit(LOB))
+    .withColumn("run_date", _F.lit(run_date))
+    .withColumn("champion_model", _F.lit(champion_model))
+)
+writer.upsert(
+    leaderboard_out,
+    table_name="leaderboard",
+    merge_keys=["lob", "run_date", "model"],
+)
+print("Leaderboard written.")
+
+# %% [markdown]
+# ## 8 — Summary
+
+# %%
+print("=" * 60)
+print(f"LOB            : {LOB}")
+print(f"Run date       : {run_date}")
+print(f"Champion model : {champion_model}")
+leaderboard_sdf.show(truncate=False)
+print("Backtest notebook complete.")

--- a/forecasting-platform/notebooks/03_forecast.py
+++ b/forecasting-platform/notebooks/03_forecast.py
@@ -1,0 +1,178 @@
+# Fabric Notebook: 03 — Distributed Production Forecast
+# =======================================================
+# Run this notebook (typically weekly) to:
+#   1. Read the champion model from the leaderboard table.
+#   2. Fit the champion on all available actuals.
+#   3. Generate forecasts for the full horizon.
+#   4. Write forecasts to the Lakehouse Delta table (upsert).
+#   5. (Optional) Optimize the forecasts table for BI query performance.
+#
+# Prerequisites: 01_data_prep.py and 02_backtest.py must have run.
+
+# %% [markdown]
+# ## 0 — Configuration
+
+# %%
+import os
+import sys
+from datetime import date
+
+PLATFORM_ROOT = "/lakehouse/default/Files/forecasting-platform"
+if PLATFORM_ROOT not in sys.path:
+    sys.path.insert(0, PLATFORM_ROOT)
+
+WORKSPACE       = os.environ.get("FABRIC_WORKSPACE", "my-workspace")
+LAKEHOUSE       = os.environ.get("FABRIC_LAKEHOUSE", "my-lakehouse")
+LOB             = os.environ.get("FORECAST_LOB", "rossmann")
+CONFIG_PATH     = os.environ.get("FORECAST_CONFIG", "configs/platform_config.yaml")
+ENVIRONMENT     = os.environ.get("FABRIC_ENVIRONMENT", "development")
+# Override champion model (empty = read from leaderboard table)
+CHAMPION_OVERRIDE = os.environ.get("CHAMPION_MODEL", "")
+
+FORECAST_ORIGIN = date.today().isoformat()
+
+print(f"Workspace       : {WORKSPACE}")
+print(f"LOB             : {LOB}")
+print(f"Forecast origin : {FORECAST_ORIGIN}")
+print(f"Champion override: {CHAMPION_OVERRIDE or '(from leaderboard)'}")
+
+# %% [markdown]
+# ## 1 — Spark Session
+
+# %%
+from src.spark.session import get_or_create_spark
+
+spark = get_or_create_spark(app_name=f"ForecastingPlatform-Forecast-{LOB}")
+spark.sparkContext.setLogLevel("WARN")
+print(f"Spark version: {spark.version}")
+
+# %% [markdown]
+# ## 2 — Platform config
+
+# %%
+from src.config.loader import load_config
+
+config = load_config(CONFIG_PATH)
+config.lob = LOB
+print(f"Horizon : {config.forecast.horizon_weeks} weeks")
+
+# %% [markdown]
+# ## 3 — Fabric Lakehouse client
+
+# %%
+from src.fabric.config import FabricConfig
+from src.fabric.lakehouse import FabricLakehouse
+
+fabric_cfg = FabricConfig(workspace=WORKSPACE, lakehouse=LAKEHOUSE, environment=ENVIRONMENT)
+lh = FabricLakehouse(spark, fabric_cfg)
+
+# %% [markdown]
+# ## 4 — Resolve champion model
+
+# %%
+from pyspark.sql import functions as F
+
+if CHAMPION_OVERRIDE:
+    champion_model = CHAMPION_OVERRIDE
+    print(f"Using overridden champion: {champion_model}")
+else:
+    leaderboard_sdf = lh.read_table("leaderboard")
+    champion_model = (
+        leaderboard_sdf
+        .filter(F.col("lob") == LOB)
+        .orderBy(F.col("run_date").desc(), F.col("rank").asc())
+        .select("champion_model")
+        .limit(1)
+        .collect()[0][0]
+    )
+    print(f"Champion model from leaderboard: {champion_model}")
+
+# %% [markdown]
+# ## 5 — Load actuals
+
+# %%
+actuals_raw_sdf = lh.read_table("actuals")
+
+actuals_series_sdf = (
+    actuals_raw_sdf
+    .filter(F.col("Open") == 1)
+    .withColumn("series_id", F.col("Store").cast("string"))
+    .withColumn("week", F.date_trunc("week", F.col("Date")))
+    .groupby("series_id", "week")
+    .agg(F.sum("Sales").alias("quantity"))
+    .orderBy("series_id", "week")
+)
+
+print(f"Actuals rows   : {actuals_series_sdf.count():,}")
+print(f"Series count   : {actuals_series_sdf.select('series_id').distinct().count():,}")
+actuals_series_sdf.show(5)
+
+# %% [markdown]
+# ## 6 — Run distributed forecast
+
+# %%
+from src.spark.pipeline import SparkForecastPipeline
+
+pipeline = SparkForecastPipeline(spark, config)
+
+forecasts_sdf = pipeline.run_forecast(
+    actuals_sdf=actuals_series_sdf,
+    champion_model=champion_model,
+    horizon=config.forecast.horizon_weeks,
+)
+forecasts_sdf.cache()
+print(f"Forecast rows: {forecasts_sdf.count():,}")
+forecasts_sdf.show(10)
+
+# %% [markdown]
+# ## 7 — Write forecasts to Lakehouse
+
+# %%
+from src.fabric.delta_writer import DeltaWriter
+
+writer = DeltaWriter(spark, fabric_cfg)
+
+writer.write_forecasts(
+    df=forecasts_sdf,
+    lob=LOB,
+    forecast_origin=FORECAST_ORIGIN,
+    mode="upsert",
+)
+print(f"Forecasts written: lob={LOB}, origin={FORECAST_ORIGIN}")
+
+# %% [markdown]
+# ## 8 — Optimize forecasts table for BI
+
+# %%
+lh.optimize(
+    "forecasts",
+    z_order_by=["series_id", "week"],
+)
+print("OPTIMIZE complete.")
+
+# %% [markdown]
+# ## 9 — Spot-check: sample forecast output
+
+# %%
+(
+    lh.read_table("forecasts")
+    .filter((F.col("lob") == LOB) & (F.col("forecast_origin") == FORECAST_ORIGIN))
+    .orderBy("series_id", "week")
+    .show(20)
+)
+
+# %% [markdown]
+# ## 10 — Summary
+
+# %%
+forecast_count = (
+    lh.read_table("forecasts")
+    .filter((F.col("lob") == LOB) & (F.col("forecast_origin") == FORECAST_ORIGIN))
+    .count()
+)
+print("=" * 60)
+print(f"LOB             : {LOB}")
+print(f"Champion model  : {champion_model}")
+print(f"Forecast origin : {FORECAST_ORIGIN}")
+print(f"Forecast rows   : {forecast_count:,}")
+print("Forecast notebook complete.")

--- a/forecasting-platform/requirements.txt
+++ b/forecasting-platform/requirements.txt
@@ -26,3 +26,16 @@ seaborn>=0.11.0
 
 # ── Testing ──────────────────────────────────────────────────────────────────
 pytest>=7.0.0
+
+# ── Spark / Microsoft Fabric layer ──────────────────────────────────────────
+# PySpark (use the version that matches your Fabric Spark runtime)
+pyspark>=3.4.0
+
+# Delta Lake (open-source; Fabric uses the managed Delta runtime automatically)
+# Install only for local development / testing outside Fabric.
+delta-spark>=2.4.0
+
+# Microsoft Fabric / Azure SDK (optional — needed only for REST API calls,
+# token-based auth, or notebookutils alternatives outside Fabric notebooks)
+# azure-identity>=1.15.0
+# azure-storage-file-datalake>=12.14.0

--- a/forecasting-platform/scripts/spark_backtest.py
+++ b/forecasting-platform/scripts/spark_backtest.py
@@ -1,0 +1,174 @@
+"""
+spark_backtest.py — CLI entry point for distributed backtest on Spark.
+
+Submits a Spark job that runs walk-forward cross-validation across all
+configured models and series, then writes results to the Lakehouse.
+
+Usage (local / dev)
+-------------------
+python scripts/spark_backtest.py \
+    --config   configs/platform_config.yaml \
+    --data-dir data/ \
+    --lob      rossmann \
+    --models   naive_seasonal lgbm_direct xgboost_direct
+
+Usage (Fabric / spark-submit)
+-----------------------------
+spark-submit \
+    --master yarn \
+    --deploy-mode cluster \
+    scripts/spark_backtest.py \
+    --config   configs/platform_config.yaml \
+    --lob      surface \
+    --workspace my-fabric-ws \
+    --lakehouse my-lakehouse \
+    --models   naive_seasonal lgbm_direct xgboost_direct
+"""
+
+import argparse
+import logging
+import sys
+from datetime import date
+from pathlib import Path
+
+# ── ensure platform src is importable ────────────────────────────────────────
+_HERE = Path(__file__).resolve().parent.parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s — %(message)s",
+)
+logger = logging.getLogger("spark_backtest")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Distributed backtest on Spark")
+    p.add_argument("--config",    default="configs/platform_config.yaml",
+                   help="Path to platform_config.yaml")
+    p.add_argument("--lob",       default="rossmann",
+                   help="Line-of-business identifier")
+    p.add_argument("--data-dir",  default="data/",
+                   help="Local data directory (CSV files, dev mode)")
+    p.add_argument("--workspace", default="",
+                   help="Fabric workspace name (overrides env FABRIC_WORKSPACE)")
+    p.add_argument("--lakehouse", default="",
+                   help="Fabric lakehouse name (overrides env FABRIC_LAKEHOUSE)")
+    p.add_argument("--models",    nargs="*",
+                   help="Model names to backtest (default: from config)")
+    p.add_argument("--write-lakehouse", action="store_true",
+                   help="Write results to Fabric Lakehouse (requires --workspace/--lakehouse)")
+    p.add_argument("--output-dir", default="data/backtest_results/",
+                   help="Local output directory for backtest results (non-Fabric mode)")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # ── 1. Spark session ──────────────────────────────────────────────────────
+    from src.spark.session import get_or_create_spark
+    spark = get_or_create_spark(app_name=f"BacktestPipeline-{args.lob}")
+    logger.info("SparkSession ready (version=%s)", spark.version)
+
+    # ── 2. Platform config ────────────────────────────────────────────────────
+    from src.config.loader import load_config
+    config = load_config(args.config)
+    config.lob = args.lob
+    model_names = args.models or config.forecast.forecasters
+    logger.info("Models: %s | Folds: %d", model_names, config.backtest.n_folds)
+
+    # ── 3. Load actuals ───────────────────────────────────────────────────────
+    from pyspark.sql import functions as F
+
+    if args.write_lakehouse and (args.workspace or args.lakehouse):
+        import os
+        ws = args.workspace or os.environ.get("FABRIC_WORKSPACE", "")
+        lh_name = args.lakehouse or os.environ.get("FABRIC_LAKEHOUSE", "")
+        from src.spark.utils import abfss_uri
+        from src.spark.loader import SparkDataLoader
+        base_path = abfss_uri(ws, lh_name)
+        loader = SparkDataLoader(spark, base_path)
+        actuals_raw = loader.read_actuals(format="delta")
+    else:
+        from src.spark.loader import SparkDataLoader
+        loader = SparkDataLoader(spark, args.data_dir)
+        train_sdf, _, store_sdf = loader.read_rossmann_all()
+        actuals_raw = train_sdf.join(store_sdf, on="Store", how="left")
+
+    # Build series-level weekly aggregation
+    actuals_sdf = (
+        actuals_raw
+        .filter(F.col("Open") == 1)
+        .withColumn("series_id", F.col("Store").cast("string"))
+        .withColumn("week", F.date_trunc("week", F.col("Date")))
+        .groupby("series_id", "week")
+        .agg(F.sum("Sales").alias("quantity"))
+        .orderBy("series_id", "week")
+    )
+    logger.info("Series rows: %d | Series: %d",
+                actuals_sdf.count(),
+                actuals_sdf.select("series_id").distinct().count())
+
+    # ── 4. Feature engineering ────────────────────────────────────────────────
+    # (Series pipeline uses the polars-based models — no Spark features needed here)
+
+    # ── 5. Run backtest ───────────────────────────────────────────────────────
+    from src.spark.pipeline import SparkForecastPipeline
+    pipeline = SparkForecastPipeline(spark, config)
+
+    backtest_results_sdf = pipeline.run_backtest(actuals_sdf, model_names=model_names)
+    backtest_results_sdf.cache()
+    logger.info("Backtest result rows: %d", backtest_results_sdf.count())
+
+    # ── 6. Champion selection ─────────────────────────────────────────────────
+    leaderboard_sdf = pipeline.select_champion(
+        backtest_results_sdf,
+        primary_metric=config.backtest.primary_metric,
+    )
+    leaderboard_sdf.show(truncate=False)
+
+    champion = leaderboard_sdf.filter(F.col("rank") == 1).select("model").collect()[0][0]
+    logger.info("Champion model: %s", champion)
+
+    # ── 7. Write results ──────────────────────────────────────────────────────
+    run_date = date.today().isoformat()
+
+    if args.write_lakehouse:
+        from src.fabric.config import FabricConfig
+        from src.fabric.delta_writer import DeltaWriter
+        import os
+        ws = args.workspace or os.environ.get("FABRIC_WORKSPACE", "")
+        lh_name = args.lakehouse or os.environ.get("FABRIC_LAKEHOUSE", "")
+        fabric_cfg = FabricConfig(workspace=ws, lakehouse=lh_name)
+        writer = DeltaWriter(spark, fabric_cfg)
+
+        out_sdf = (
+            backtest_results_sdf
+            .withColumn("lob", F.lit(args.lob))
+            .withColumn("run_date", F.lit(run_date))
+        )
+        writer.append(out_sdf, "backtest_results", partition_by=["lob", "run_date"])
+
+        lb_out = (
+            leaderboard_sdf
+            .withColumn("lob", F.lit(args.lob))
+            .withColumn("run_date", F.lit(run_date))
+            .withColumn("champion_model", F.lit(champion))
+        )
+        writer.upsert(lb_out, "leaderboard", merge_keys=["lob", "run_date", "model"])
+        logger.info("Results written to Lakehouse.")
+    else:
+        output_path = Path(args.output_dir) / args.lob / run_date
+        output_path.mkdir(parents=True, exist_ok=True)
+        backtest_results_sdf.toPandas().to_parquet(output_path / "backtest_results.parquet", index=False)
+        leaderboard_sdf.toPandas().to_parquet(output_path / "leaderboard.parquet", index=False)
+        logger.info("Results written locally to %s", output_path)
+
+    logger.info("spark_backtest.py complete. Champion: %s", champion)
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/forecasting-platform/scripts/spark_forecast.py
+++ b/forecasting-platform/scripts/spark_forecast.py
@@ -1,0 +1,192 @@
+"""
+spark_forecast.py — CLI entry point for distributed production forecast on Spark.
+
+Reads actuals from the Lakehouse (or local CSV), fits the champion model on
+all series in parallel, and writes forecasts back to the Lakehouse.
+
+Usage (local / dev)
+-------------------
+python scripts/spark_forecast.py \
+    --config       configs/platform_config.yaml \
+    --data-dir     data/ \
+    --lob          rossmann \
+    --model        naive_seasonal
+
+Usage (Fabric / spark-submit)
+-----------------------------
+spark-submit \
+    --master yarn \
+    --deploy-mode cluster \
+    scripts/spark_forecast.py \
+    --config       configs/platform_config.yaml \
+    --lob          surface \
+    --workspace    my-fabric-ws \
+    --lakehouse    my-lakehouse \
+    --write-lakehouse \
+    --model        lgbm_direct
+"""
+
+import argparse
+import logging
+import sys
+from datetime import date
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent.parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s — %(message)s",
+)
+logger = logging.getLogger("spark_forecast")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Distributed production forecast on Spark")
+    p.add_argument("--config",    default="configs/platform_config.yaml",
+                   help="Path to platform_config.yaml")
+    p.add_argument("--lob",       default="rossmann",
+                   help="Line-of-business identifier")
+    p.add_argument("--data-dir",  default="data/",
+                   help="Local data directory (dev mode)")
+    p.add_argument("--workspace", default="",
+                   help="Fabric workspace name")
+    p.add_argument("--lakehouse", default="",
+                   help="Fabric lakehouse name")
+    p.add_argument("--model",     default="",
+                   help="Champion model name (empty = read from leaderboard table)")
+    p.add_argument("--horizon",   type=int, default=0,
+                   help="Forecast horizon in weeks (0 = from config)")
+    p.add_argument("--write-lakehouse", action="store_true",
+                   help="Write forecasts to Fabric Lakehouse")
+    p.add_argument("--write-mode", default="upsert",
+                   choices=["upsert", "overwrite_partition", "append"],
+                   help="Write strategy for the forecasts Delta table")
+    p.add_argument("--output-dir", default="data/forecasts/",
+                   help="Local output directory (non-Fabric mode)")
+    return p.parse_args()
+
+
+def _resolve_champion(args, spark, lh):
+    """Read champion model from leaderboard or use CLI override."""
+    from pyspark.sql import functions as F
+
+    if args.model:
+        logger.info("Using CLI-supplied champion model: %s", args.model)
+        return args.model
+
+    leaderboard_sdf = lh.read_table("leaderboard")
+    champion = (
+        leaderboard_sdf
+        .filter(F.col("lob") == args.lob)
+        .orderBy(F.col("run_date").desc(), F.col("rank").asc())
+        .select("champion_model")
+        .limit(1)
+        .collect()
+    )
+    if not champion:
+        raise RuntimeError(
+            f"No champion model found for lob='{args.lob}' in leaderboard table.  "
+            "Run spark_backtest.py first, or supply --model."
+        )
+    return champion[0][0]
+
+
+def main():
+    args = parse_args()
+
+    # ── 1. Spark session ──────────────────────────────────────────────────────
+    from src.spark.session import get_or_create_spark
+    spark = get_or_create_spark(app_name=f"ForecastPipeline-{args.lob}")
+    logger.info("SparkSession ready (version=%s)", spark.version)
+
+    # ── 2. Platform config ────────────────────────────────────────────────────
+    from src.config.loader import load_config
+    config = load_config(args.config)
+    config.lob = args.lob
+    horizon = args.horizon or config.forecast.horizon_weeks
+    logger.info("Horizon: %d weeks", horizon)
+
+    # ── 3. Fabric / Lakehouse client (optional) ───────────────────────────────
+    import os
+    lh = None
+    if args.write_lakehouse:
+        from src.fabric.config import FabricConfig
+        from src.fabric.lakehouse import FabricLakehouse
+        ws = args.workspace or os.environ.get("FABRIC_WORKSPACE", "")
+        lh_name = args.lakehouse or os.environ.get("FABRIC_LAKEHOUSE", "")
+        fabric_cfg = FabricConfig(workspace=ws, lakehouse=lh_name)
+        lh = FabricLakehouse(spark, fabric_cfg)
+
+    # ── 4. Resolve champion model ─────────────────────────────────────────────
+    champion_model = _resolve_champion(args, spark, lh) if lh else (args.model or config.forecast.forecasters[0])
+    logger.info("Champion model: %s", champion_model)
+
+    # ── 5. Load actuals ───────────────────────────────────────────────────────
+    from pyspark.sql import functions as F
+
+    if lh is not None:
+        actuals_raw = lh.read_table("actuals")
+    else:
+        from src.spark.loader import SparkDataLoader
+        loader = SparkDataLoader(spark, args.data_dir)
+        train_sdf, _, store_sdf = loader.read_rossmann_all()
+        actuals_raw = train_sdf.join(store_sdf, on="Store", how="left")
+
+    actuals_sdf = (
+        actuals_raw
+        .filter(F.col("Open") == 1)
+        .withColumn("series_id", F.col("Store").cast("string"))
+        .withColumn("week", F.date_trunc("week", F.col("Date")))
+        .groupby("series_id", "week")
+        .agg(F.sum("Sales").alias("quantity"))
+        .orderBy("series_id", "week")
+    )
+    logger.info(
+        "Actuals: %d rows, %d series",
+        actuals_sdf.count(),
+        actuals_sdf.select("series_id").distinct().count(),
+    )
+
+    # ── 6. Run distributed forecast ───────────────────────────────────────────
+    from src.spark.pipeline import SparkForecastPipeline
+    pipeline = SparkForecastPipeline(spark, config)
+
+    forecasts_sdf = pipeline.run_forecast(
+        actuals_sdf=actuals_sdf,
+        champion_model=champion_model,
+        horizon=horizon,
+    )
+    forecasts_sdf.cache()
+    logger.info("Forecast rows: %d", forecasts_sdf.count())
+
+    # ── 7. Write forecasts ────────────────────────────────────────────────────
+    forecast_origin = date.today().isoformat()
+
+    if lh is not None:
+        from src.fabric.delta_writer import DeltaWriter
+        writer = DeltaWriter(spark, fabric_cfg)
+        writer.write_forecasts(
+            df=forecasts_sdf,
+            lob=args.lob,
+            forecast_origin=forecast_origin,
+            mode=args.write_mode,
+        )
+        # Optimize for BI queries
+        lh.optimize("forecasts", z_order_by=["series_id", "week"])
+        logger.info("Forecasts written to Lakehouse and optimized.")
+    else:
+        output_path = Path(args.output_dir) / args.lob
+        output_path.mkdir(parents=True, exist_ok=True)
+        filename = f"forecast_{args.lob}_{forecast_origin}.parquet"
+        forecasts_sdf.toPandas().to_parquet(output_path / filename, index=False)
+        logger.info("Forecasts written locally to %s", output_path / filename)
+
+    logger.info("spark_forecast.py complete.")
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/forecasting-platform/src/fabric/__init__.py
+++ b/forecasting-platform/src/fabric/__init__.py
@@ -1,0 +1,13 @@
+"""
+Microsoft Fabric integration layer for the forecasting platform.
+
+Modules
+-------
+config          FabricConfig dataclass — workspace / lakehouse settings.
+lakehouse       Read and write Delta tables in a Fabric Lakehouse.
+delta_writer    Upsert / overwrite helpers for Delta tables.
+"""
+
+from .config import FabricConfig  # noqa: F401
+from .lakehouse import FabricLakehouse  # noqa: F401
+from .delta_writer import DeltaWriter  # noqa: F401

--- a/forecasting-platform/src/fabric/config.py
+++ b/forecasting-platform/src/fabric/config.py
@@ -1,0 +1,119 @@
+"""
+FabricConfig — Microsoft Fabric workspace and Lakehouse settings.
+
+These values can be supplied via:
+  1. Environment variables (``FABRIC_WORKSPACE``, ``FABRIC_LAKEHOUSE``, …).
+  2. Direct constructor arguments.
+  3. The ``fabric_config.yaml`` file (loaded by ``src.config.loader``).
+
+Usage
+-----
+>>> from src.fabric.config import FabricConfig
+>>> cfg = FabricConfig.from_env()
+>>> print(cfg.abfss_base)
+'abfss://my-workspace@onelake.dfs.fabric.microsoft.com/my-lakehouse'
+"""
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class FabricConfig:
+    """
+    Fabric workspace and storage settings.
+
+    Attributes
+    ----------
+    workspace:
+        Fabric workspace name or GUID.
+    lakehouse:
+        Lakehouse name or GUID within the workspace.
+    onelake_host:
+        OneLake DFS endpoint (default: ``onelake.dfs.fabric.microsoft.com``).
+    tables_root:
+        Sub-path under the Lakehouse root where managed Delta tables live
+        (default: ``Tables``).
+    files_root:
+        Sub-path for unmanaged files (default: ``Files``).
+    environment:
+        ``"development"`` | ``"staging"`` | ``"production"``.
+    enable_delta_log_retention:
+        Whether to configure Delta log / data file retention settings.
+    delta_log_retention_days:
+        How many days to keep Delta transaction log entries.
+    delta_data_retention_days:
+        How many days to keep data files eligible for VACUUM.
+    """
+
+    workspace: str = ""
+    lakehouse: str = ""
+    onelake_host: str = "onelake.dfs.fabric.microsoft.com"
+    tables_root: str = "Tables"
+    files_root: str = "Files"
+    environment: str = "development"
+    enable_delta_log_retention: bool = True
+    delta_log_retention_days: int = 30
+    delta_data_retention_days: int = 7
+
+    # ── derived properties ────────────────────────────────────────────────────
+
+    @property
+    def abfss_base(self) -> str:
+        """ABFSS URI for the Lakehouse root."""
+        return (
+            f"abfss://{self.workspace}@{self.onelake_host}/{self.lakehouse}"
+        )
+
+    @property
+    def tables_path(self) -> str:
+        """ABFSS path to the managed Delta tables root."""
+        return f"{self.abfss_base}/{self.tables_root}"
+
+    @property
+    def files_path(self) -> str:
+        """ABFSS path to the unmanaged files root."""
+        return f"{self.abfss_base}/{self.files_root}"
+
+    def table_path(self, table_name: str) -> str:
+        """Full ABFSS path for a specific Delta table."""
+        return f"{self.tables_path}/{table_name}"
+
+    def file_path(self, *parts: str) -> str:
+        """Full ABFSS path for a file under the Files root."""
+        return "/".join([self.files_path] + list(parts))
+
+    # ── factories ─────────────────────────────────────────────────────────────
+
+    @classmethod
+    def from_env(cls) -> "FabricConfig":
+        """
+        Build a FabricConfig from environment variables.
+
+        Environment variables
+        ---------------------
+        FABRIC_WORKSPACE            Workspace name / GUID.
+        FABRIC_LAKEHOUSE            Lakehouse name / GUID.
+        FABRIC_ONELAKE_HOST         Override OneLake host.
+        FABRIC_ENVIRONMENT          development | staging | production.
+        """
+        return cls(
+            workspace=os.environ.get("FABRIC_WORKSPACE", ""),
+            lakehouse=os.environ.get("FABRIC_LAKEHOUSE", ""),
+            onelake_host=os.environ.get(
+                "FABRIC_ONELAKE_HOST", "onelake.dfs.fabric.microsoft.com"
+            ),
+            environment=os.environ.get("FABRIC_ENVIRONMENT", "development"),
+        )
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "FabricConfig":
+        """Build a FabricConfig from a plain dict (e.g. parsed YAML)."""
+        return cls(**{k: v for k, v in d.items() if hasattr(cls, k)})
+
+    def __str__(self) -> str:
+        return (
+            f"FabricConfig(workspace={self.workspace!r}, "
+            f"lakehouse={self.lakehouse!r}, env={self.environment!r})"
+        )

--- a/forecasting-platform/src/fabric/delta_writer.py
+++ b/forecasting-platform/src/fabric/delta_writer.py
@@ -1,0 +1,270 @@
+"""
+DeltaWriter — upsert (MERGE) and overwrite helpers for Delta Lake tables.
+
+Provides a higher-level API on top of ``FabricLakehouse.write_table`` for
+common write patterns used by the forecasting platform:
+
+  * **upsert**    — MERGE INTO for idempotent re-runs.
+  * **overwrite** — full partition overwrite (replaces one forecast cycle).
+  * **append**    — streaming / incremental writes.
+
+Usage
+-----
+>>> from src.fabric.delta_writer import DeltaWriter
+>>> writer = DeltaWriter(spark, config)
+>>> writer.upsert(
+...     df=forecast_sdf,
+...     table_name="forecasts",
+...     merge_keys=["series_id", "week", "lob"],
+... )
+"""
+
+import logging
+from typing import List, Optional
+
+from .config import FabricConfig
+
+logger = logging.getLogger(__name__)
+
+
+class DeltaWriter:
+    """
+    Opinionated Delta table writer for the forecasting platform.
+
+    Parameters
+    ----------
+    spark:
+        Active SparkSession.
+    config:
+        ``FabricConfig`` with Lakehouse path settings.
+    """
+
+    def __init__(self, spark, config: FabricConfig):
+        self.spark = spark
+        self.config = config
+
+    # ── upsert ────────────────────────────────────────────────────────────────
+
+    def upsert(
+        self,
+        df,
+        table_name: str,
+        merge_keys: List[str],
+        update_columns: Optional[List[str]] = None,
+        partition_by: Optional[List[str]] = None,
+    ) -> None:
+        """
+        MERGE (upsert) new data into an existing Delta table.
+
+        If the target table does not yet exist, it is created via an
+        initial ``write`` with ``mode="overwrite"``.
+
+        Parameters
+        ----------
+        df:
+            Source Spark DataFrame.
+        table_name:
+            Target Delta table name (under ``Tables/``).
+        merge_keys:
+            Columns used to match source rows to target rows.
+        update_columns:
+            Columns to update on match.  Defaults to all non-key columns.
+        partition_by:
+            Partition columns for the initial table creation.
+        """
+        try:
+            from delta.tables import DeltaTable  # type: ignore
+        except ImportError as exc:
+            raise ImportError(
+                "delta-spark is required for upsert operations.  "
+                "Install with: pip install delta-spark"
+            ) from exc
+
+        path = self.config.table_path(table_name)
+
+        if not DeltaTable.isDeltaTable(self.spark, path):
+            logger.info(
+                "Target table '%s' not found — creating via initial write.", table_name
+            )
+            writer = df.write.format("delta").mode("overwrite")
+            if partition_by:
+                writer = writer.partitionBy(*partition_by)
+            writer.save(path)
+            return
+
+        target = DeltaTable.forPath(self.spark, path)
+        all_cols = df.columns
+        update_cols = update_columns or [c for c in all_cols if c not in merge_keys]
+
+        merge_condition = " AND ".join(
+            [f"target.{k} = source.{k}" for k in merge_keys]
+        )
+        update_expr = {f"target.{c}": f"source.{c}" for c in update_cols}
+        insert_expr = {c: f"source.{c}" for c in all_cols}
+
+        logger.info(
+            "Upserting into '%s' on keys=%s (%d update cols)",
+            table_name, merge_keys, len(update_cols),
+        )
+
+        (
+            target.alias("target")
+            .merge(df.alias("source"), merge_condition)
+            .whenMatchedUpdate(set=update_expr)
+            .whenNotMatchedInsert(values=insert_expr)
+            .execute()
+        )
+        logger.info("Upsert complete for table '%s'", table_name)
+
+    # ── partition overwrite ───────────────────────────────────────────────────
+
+    def overwrite_partition(
+        self,
+        df,
+        table_name: str,
+        partition_by: List[str],
+    ) -> str:
+        """
+        Replace specific partitions in a Delta table with new data.
+
+        Uses ``replaceWhere`` so only the partitions present in ``df``
+        are overwritten — other partitions are untouched.
+
+        Parameters
+        ----------
+        df:
+            Source Spark DataFrame containing the new partition data.
+        table_name:
+            Target Delta table.
+        partition_by:
+            Partition columns.  The distinct values in ``df`` for these
+            columns define which partitions are replaced.
+
+        Returns
+        -------
+        str — ABFSS path of the target table.
+        """
+        from pyspark.sql import functions as F
+
+        path = self.config.table_path(table_name)
+
+        # Build a replaceWhere predicate from the distinct partition values in df
+        replace_conditions = []
+        for col in partition_by:
+            distinct_vals = [r[0] for r in df.select(col).distinct().collect()]
+            if not distinct_vals:
+                continue
+            # Format as SQL IN clause
+            if isinstance(distinct_vals[0], str):
+                vals_str = ", ".join(f"'{v}'" for v in distinct_vals)
+            else:
+                vals_str = ", ".join(str(v) for v in distinct_vals)
+            replace_conditions.append(f"{col} IN ({vals_str})")
+
+        replace_where = " AND ".join(replace_conditions) if replace_conditions else None
+
+        writer = (
+            df.write
+            .format("delta")
+            .mode("overwrite")
+            .option("mergeSchema", "true")
+            .partitionBy(*partition_by)
+        )
+        if replace_where:
+            writer = writer.option("replaceWhere", replace_where)
+
+        logger.info(
+            "Overwriting partition(s) in '%s' where: %s", table_name, replace_where
+        )
+        writer.save(path)
+        logger.info("Partition overwrite complete for '%s'", table_name)
+        return path
+
+    # ── append ────────────────────────────────────────────────────────────────
+
+    def append(
+        self,
+        df,
+        table_name: str,
+        partition_by: Optional[List[str]] = None,
+        merge_schema: bool = True,
+    ) -> str:
+        """
+        Append rows to a Delta table (creates it if it does not exist).
+
+        Parameters
+        ----------
+        df:
+            Source Spark DataFrame.
+        table_name:
+            Target Delta table.
+        partition_by:
+            Partition columns for initial creation.
+        merge_schema:
+            Allow schema evolution.
+
+        Returns
+        -------
+        str — ABFSS path of the target table.
+        """
+        path = self.config.table_path(table_name)
+        writer = (
+            df.write
+            .format("delta")
+            .mode("append")
+            .option("mergeSchema", str(merge_schema).lower())
+        )
+        if partition_by:
+            writer = writer.partitionBy(*partition_by)
+
+        logger.info("Appending to Delta table '%s'", table_name)
+        writer.save(path)
+        logger.info("Append complete for '%s'", table_name)
+        return path
+
+    # ── write forecast output ─────────────────────────────────────────────────
+
+    def write_forecasts(
+        self,
+        df,
+        lob: str,
+        forecast_origin: str,
+        mode: str = "upsert",
+    ) -> None:
+        """
+        Write forecast results with standard partitioning and merge keys.
+
+        The forecasts table is partitioned by ``(lob, forecast_origin)``
+        and upserted / overwritten on ``(series_id, week)``.
+
+        Parameters
+        ----------
+        df:
+            Forecast DataFrame with at minimum [series_id, week, forecast].
+        lob:
+            Line-of-business identifier (added as a literal column if absent).
+        forecast_origin:
+            ISO-8601 date string for the forecast run (added if absent).
+        mode:
+            ``"upsert"`` | ``"overwrite_partition"`` | ``"append"``.
+        """
+        from pyspark.sql import functions as F
+
+        if "lob" not in df.columns:
+            df = df.withColumn("lob", F.lit(lob))
+        if "forecast_origin" not in df.columns:
+            df = df.withColumn("forecast_origin", F.lit(forecast_origin))
+
+        table_name = "forecasts"
+
+        if mode == "upsert":
+            self.upsert(
+                df,
+                table_name,
+                merge_keys=["series_id", "week", "lob", "forecast_origin"],
+                partition_by=["lob", "forecast_origin"],
+            )
+        elif mode == "overwrite_partition":
+            self.overwrite_partition(df, table_name, partition_by=["lob", "forecast_origin"])
+        else:
+            self.append(df, table_name, partition_by=["lob", "forecast_origin"])

--- a/forecasting-platform/src/fabric/lakehouse.py
+++ b/forecasting-platform/src/fabric/lakehouse.py
@@ -1,0 +1,234 @@
+"""
+FabricLakehouse — read / write Delta tables in a Microsoft Fabric Lakehouse.
+
+This class wraps the Spark + Delta Lake APIs and provides a clean interface
+that is aware of Fabric's OneLake path conventions.
+
+Usage
+-----
+>>> from src.fabric.config import FabricConfig
+>>> from src.fabric.lakehouse import FabricLakehouse
+>>>
+>>> cfg = FabricConfig.from_env()
+>>> lh  = FabricLakehouse(spark, cfg)
+>>>
+>>> actuals_sdf  = lh.read_table("actuals")
+>>> lh.write_table(forecasts_sdf, "forecasts", partition_by=["lob", "forecast_date"])
+"""
+
+import logging
+from typing import List, Optional
+
+from .config import FabricConfig
+
+logger = logging.getLogger(__name__)
+
+
+class FabricLakehouse:
+    """
+    High-level interface for reading and writing Delta tables in a
+    Fabric Lakehouse via ABFSS / OneLake paths.
+
+    Parameters
+    ----------
+    spark:
+        Active SparkSession (Fabric Spark runtime or local Delta session).
+    config:
+        ``FabricConfig`` with workspace and lakehouse identifiers.
+    """
+
+    def __init__(self, spark, config: FabricConfig):
+        self.spark = spark
+        self.config = config
+
+    # ── read ──────────────────────────────────────────────────────────────────
+
+    def read_table(
+        self,
+        table_name: str,
+        version: Optional[int] = None,
+        timestamp: Optional[str] = None,
+    ):
+        """
+        Read a Delta table from the Lakehouse.
+
+        Parameters
+        ----------
+        table_name:
+            Name of the Delta table (sub-path under ``Tables/``).
+        version:
+            Time-travel to a specific Delta version number.
+        timestamp:
+            Time-travel to a specific timestamp string (ISO-8601).
+
+        Returns
+        -------
+        pyspark.sql.DataFrame
+        """
+        path = self.config.table_path(table_name)
+        reader = self.spark.read.format("delta")
+
+        if version is not None:
+            reader = reader.option("versionAsOf", str(version))
+            logger.info("Reading Delta table '%s' at version %d", table_name, version)
+        elif timestamp is not None:
+            reader = reader.option("timestampAsOf", timestamp)
+            logger.info("Reading Delta table '%s' at timestamp %s", table_name, timestamp)
+        else:
+            logger.info("Reading Delta table '%s' (latest)", table_name)
+
+        return reader.load(path)
+
+    def read_file(self, subpath: str, format: str = "parquet", **options):
+        """
+        Read an unmanaged file from the Lakehouse Files root.
+
+        Parameters
+        ----------
+        subpath:
+            Path relative to the ``Files/`` root.
+        format:
+            ``"parquet"`` | ``"csv"`` | ``"json"`` | ``"delta"``.
+        """
+        path = self.config.file_path(subpath)
+        logger.info("Reading file '%s' (format=%s)", path, format)
+        return (
+            self.spark.read
+            .options(**options)
+            .format(format)
+            .load(path)
+        )
+
+    # ── write ─────────────────────────────────────────────────────────────────
+
+    def write_table(
+        self,
+        df,
+        table_name: str,
+        mode: str = "overwrite",
+        partition_by: Optional[List[str]] = None,
+        merge_schema: bool = True,
+    ) -> str:
+        """
+        Write a Spark DataFrame to a Delta table in the Lakehouse.
+
+        Parameters
+        ----------
+        df:
+            Spark DataFrame to write.
+        table_name:
+            Target Delta table name (sub-path under ``Tables/``).
+        mode:
+            ``"overwrite"`` | ``"append"`` | ``"error"`` | ``"ignore"``.
+        partition_by:
+            List of column names to partition the Delta table by.
+        merge_schema:
+            Allow schema evolution on existing Delta tables.
+
+        Returns
+        -------
+        str — the full ABFSS path where the table was written.
+        """
+        path = self.config.table_path(table_name)
+        writer = (
+            df.write
+            .format("delta")
+            .mode(mode)
+            .option("mergeSchema", str(merge_schema).lower())
+        )
+
+        if partition_by:
+            writer = writer.partitionBy(*partition_by)
+
+        if self.config.enable_delta_log_retention:
+            writer = (
+                writer
+                .option("delta.logRetentionDuration",
+                        f"interval {self.config.delta_log_retention_days} days")
+                .option("delta.deletedFileRetentionDuration",
+                        f"interval {self.config.delta_data_retention_days} days")
+            )
+
+        logger.info(
+            "Writing Delta table '%s' (mode=%s, partitions=%s)", table_name, mode, partition_by
+        )
+        writer.save(path)
+        logger.info("Delta table written to %s", path)
+        return path
+
+    def write_file(
+        self,
+        df,
+        subpath: str,
+        format: str = "parquet",
+        mode: str = "overwrite",
+        **options,
+    ) -> str:
+        """Write a DataFrame to the Lakehouse Files area."""
+        path = self.config.file_path(subpath)
+        logger.info("Writing file '%s' (format=%s, mode=%s)", path, format, mode)
+        df.write.mode(mode).options(**options).format(format).save(path)
+        return path
+
+    # ── DDL helpers ───────────────────────────────────────────────────────────
+
+    def table_exists(self, table_name: str) -> bool:
+        """Return True if the Delta table directory exists and is a valid Delta table."""
+        try:
+            from delta.tables import DeltaTable  # type: ignore
+            path = self.config.table_path(table_name)
+            return DeltaTable.isDeltaTable(self.spark, path)
+        except ImportError:
+            # Fall back to checking if the path has _delta_log
+            try:
+                path = self.config.table_path(table_name) + "/_delta_log"
+                self.spark.read.format("delta").load(
+                    self.config.table_path(table_name)
+                ).limit(0)
+                return True
+            except Exception:
+                return False
+
+    def vacuum(self, table_name: str, retention_hours: int = 168) -> None:
+        """
+        Run VACUUM on a Delta table to remove stale data files.
+
+        Parameters
+        ----------
+        table_name:
+            Target table.
+        retention_hours:
+            Minimum file age to delete (default: 7 days = 168 h).
+        """
+        path = self.config.table_path(table_name)
+        logger.info("Running VACUUM on '%s' (retention=%d h)", table_name, retention_hours)
+        self.spark.sql(
+            f"VACUUM delta.`{path}` RETAIN {retention_hours} HOURS"
+        )
+
+    def optimize(self, table_name: str, z_order_by: Optional[List[str]] = None) -> None:
+        """
+        Run OPTIMIZE (and optionally Z-ORDER) on a Delta table.
+
+        Parameters
+        ----------
+        table_name:
+            Target table.
+        z_order_by:
+            Columns to Z-ORDER by for data skipping.
+        """
+        path = self.config.table_path(table_name)
+        z_order_clause = ""
+        if z_order_by:
+            cols = ", ".join(z_order_by)
+            z_order_clause = f" ZORDER BY ({cols})"
+        sql = f"OPTIMIZE delta.`{path}`{z_order_clause}"
+        logger.info("Running OPTIMIZE on '%s'%s", table_name, z_order_clause)
+        self.spark.sql(sql)
+
+    # ── history ───────────────────────────────────────────────────────────────
+
+    def history(self, table_name: str, limit: int = 10):
+        """Return the Delta transaction log history for a table."""
+        path = self.config.table_path(table_name)
+        return self.spark.sql(f"DESCRIBE HISTORY delta.`{path}` LIMIT {limit}")

--- a/forecasting-platform/src/spark/__init__.py
+++ b/forecasting-platform/src/spark/__init__.py
@@ -1,0 +1,19 @@
+"""
+Spark / Microsoft Fabric layer for the forecasting platform.
+
+This sub-package provides distributed execution of the forecasting
+pipeline on Apache Spark (including Microsoft Fabric Spark).
+
+Modules
+-------
+session             SparkSession factory with Fabric auto-detection.
+loader              SparkDataLoader — reads CSV / Parquet / Delta Lake.
+feature_engineering SparkFeatureEngineer — PySpark-native transformations.
+pipeline            SparkForecastPipeline — pandas_udf distributed runner.
+utils               Schema helpers and Polars ↔ Spark conversion utilities.
+"""
+
+from .session import get_or_create_spark  # noqa: F401
+from .loader import SparkDataLoader  # noqa: F401
+from .feature_engineering import SparkFeatureEngineer  # noqa: F401
+from .pipeline import SparkForecastPipeline  # noqa: F401

--- a/forecasting-platform/src/spark/feature_engineering.py
+++ b/forecasting-platform/src/spark/feature_engineering.py
@@ -1,0 +1,215 @@
+"""
+SparkFeatureEngineer — distributed feature engineering using PySpark.
+
+Mirrors the logic in ``src.data.feature_engineering.FeatureEngineer`` but
+operates on Spark DataFrames using native PySpark functions (no UDFs for the
+core transformations — only SQL functions and Window specs for maximum
+performance on large clusters).
+
+Usage
+-----
+>>> from src.spark.feature_engineering import SparkFeatureEngineer
+>>> eng = SparkFeatureEngineer(lag_periods=[1, 7, 14], rolling_windows=[7, 14])
+>>> df_features = eng.fit_transform(df, date_col="Date", target_col="Sales", group_col="Store")
+"""
+
+import logging
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class SparkFeatureEngineer:
+    """
+    Creates features from raw time-series data using PySpark.
+
+    Parameters
+    ----------
+    lag_periods:
+        List of lag periods (in rows) to compute for the target column.
+    rolling_windows:
+        List of window sizes for rolling mean / std.
+    """
+
+    def __init__(
+        self,
+        lag_periods: Optional[List[int]] = None,
+        rolling_windows: Optional[List[int]] = None,
+    ):
+        self.lag_periods = lag_periods or [1, 7, 14, 30]
+        self.rolling_windows = rolling_windows or [7, 14, 30]
+
+    # ── temporal features ─────────────────────────────────────────────────────
+
+    def create_temporal_features(self, df, date_col: str = "Date"):
+        """
+        Extract calendar features from a date column.
+
+        Adds: Year, Month, Day, DayOfWeek, WeekOfYear, Quarter,
+              IsWeekend, IsMonthStart, IsMonthEnd.
+        """
+        from pyspark.sql import functions as F
+
+        df = df.withColumn(date_col, F.to_date(F.col(date_col)))
+        df = (
+            df
+            .withColumn("Year",         F.year(date_col))
+            .withColumn("Month",        F.month(date_col))
+            .withColumn("Day",          F.dayofmonth(date_col))
+            .withColumn("DayOfWeek",    F.dayofweek(date_col))
+            .withColumn("WeekOfYear",   F.weekofyear(date_col))
+            .withColumn("Quarter",      F.quarter(date_col))
+            .withColumn("IsWeekend",    (F.dayofweek(date_col).isin(1, 7)).cast("int"))
+            .withColumn("IsMonthStart", (F.dayofmonth(date_col) == 1).cast("int"))
+            # last day of month: add 1 day, check if month changes
+            .withColumn(
+                "IsMonthEnd",
+                (F.month(F.date_add(date_col, 1)) != F.month(date_col)).cast("int"),
+            )
+        )
+        logger.debug("Created temporal features from column '%s'", date_col)
+        return df
+
+    # ── lag features ──────────────────────────────────────────────────────────
+
+    def create_lag_features(
+        self,
+        df,
+        target_col: str = "Sales",
+        group_col: str = "Store",
+        date_col: str = "Date",
+    ):
+        """
+        Create lag features partitioned by ``group_col``, ordered by ``date_col``.
+        """
+        from pyspark.sql import Window
+        from pyspark.sql import functions as F
+
+        window = Window.partitionBy(group_col).orderBy(date_col)
+
+        for lag in self.lag_periods:
+            col_name = f"{target_col}_lag_{lag}"
+            df = df.withColumn(col_name, F.lag(F.col(target_col), lag).over(window))
+
+        logger.debug(
+            "Created %d lag features for '%s'", len(self.lag_periods), target_col
+        )
+        return df
+
+    # ── rolling features ──────────────────────────────────────────────────────
+
+    def create_rolling_features(
+        self,
+        df,
+        target_col: str = "Sales",
+        group_col: str = "Store",
+        date_col: str = "Date",
+    ):
+        """
+        Create rolling mean / std features (lagged by 1 to avoid leakage).
+        """
+        from pyspark.sql import Window
+        from pyspark.sql import functions as F
+
+        for window_size in self.rolling_windows:
+            # Lag by 1 then compute rolling stats to avoid target leakage.
+            lagged_col = f"__lag1_{target_col}"
+            w_lag = Window.partitionBy(group_col).orderBy(date_col)
+            w_roll = (
+                Window.partitionBy(group_col)
+                .orderBy(date_col)
+                .rowsBetween(-window_size + 1, 0)
+            )
+
+            df = df.withColumn(lagged_col, F.lag(F.col(target_col), 1).over(w_lag))
+            df = df.withColumn(
+                f"{target_col}_roll_mean_{window_size}",
+                F.mean(F.col(lagged_col)).over(w_roll),
+            )
+            df = df.withColumn(
+                f"{target_col}_roll_std_{window_size}",
+                F.stddev(F.col(lagged_col)).over(w_roll),
+            )
+            df = df.drop(lagged_col)
+
+        logger.debug(
+            "Created %d rolling windows for '%s'", len(self.rolling_windows), target_col
+        )
+        return df
+
+    # ── competition features ──────────────────────────────────────────────────
+
+    def create_competition_features(self, df):
+        """
+        Compute months since competition opened (clipped to 0).
+
+        Requires columns: Year, Month, CompetitionOpenSinceYear,
+        CompetitionOpenSinceMonth.
+        """
+        from pyspark.sql import functions as F
+
+        cols = {f.name for f in df.schema.fields}
+        if "CompetitionOpenSinceMonth" not in cols or "Year" not in cols:
+            return df
+
+        df = df.withColumn(
+            "CompetitionOpen",
+            F.greatest(
+                F.lit(0),
+                (
+                    12 * (F.col("Year") - F.col("CompetitionOpenSinceYear"))
+                    + (F.col("Month") - F.col("CompetitionOpenSinceMonth"))
+                ),
+            ),
+        )
+        logger.debug("Created CompetitionOpen feature")
+        return df
+
+    # ── promo features ────────────────────────────────────────────────────────
+
+    def create_promo_features(self, df):
+        """
+        Compute months since Promo2 started (clipped to 0).
+
+        Requires columns: Year, WeekOfYear, Promo2SinceYear, Promo2SinceWeek.
+        """
+        from pyspark.sql import functions as F
+
+        cols = {f.name for f in df.schema.fields}
+        if "Promo2SinceWeek" not in cols or "Year" not in cols:
+            return df
+
+        df = df.withColumn(
+            "Promo2Open",
+            F.greatest(
+                F.lit(0.0),
+                (
+                    12 * (F.col("Year") - F.col("Promo2SinceYear")).cast("double")
+                    + (F.col("WeekOfYear") - F.col("Promo2SinceWeek")).cast("double") / 4.0
+                ),
+            ),
+        )
+        logger.debug("Created Promo2Open feature")
+        return df
+
+    # ── combined ──────────────────────────────────────────────────────────────
+
+    def fit_transform(
+        self,
+        df,
+        date_col: str = "Date",
+        target_col: str = "Sales",
+        group_col: str = "Store",
+    ):
+        """
+        Apply all feature engineering steps in order.
+
+        Returns a Spark DataFrame with all feature columns appended.
+        """
+        df = self.create_temporal_features(df, date_col=date_col)
+        df = self.create_lag_features(df, target_col=target_col, group_col=group_col, date_col=date_col)
+        df = self.create_rolling_features(df, target_col=target_col, group_col=group_col, date_col=date_col)
+        df = self.create_competition_features(df)
+        df = self.create_promo_features(df)
+        logger.info("Feature engineering complete. Schema has %d columns.", len(df.columns))
+        return df

--- a/forecasting-platform/src/spark/loader.py
+++ b/forecasting-platform/src/spark/loader.py
@@ -1,0 +1,148 @@
+"""
+SparkDataLoader — distributed data ingestion for the forecasting platform.
+
+Supports reading from:
+  - Local CSV / Parquet files (dev / unit-test mode)
+  - ABFSS paths on OneLake / ADLS Gen2 (Microsoft Fabric / Azure)
+  - Delta Lake tables (Fabric Lakehouse or standalone Delta)
+
+Usage
+-----
+>>> from src.spark.loader import SparkDataLoader
+>>> loader = SparkDataLoader(spark, base_path="abfss://my-ws@onelake.dfs.fabric.microsoft.com/lh")
+>>> actuals   = loader.read_actuals()
+>>> forecasts = loader.read_delta("forecasts/surface_2024-01-01")
+"""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class SparkDataLoader:
+    """
+    Reads raw and processed data into Spark DataFrames.
+
+    Parameters
+    ----------
+    spark:
+        Active SparkSession.
+    base_path:
+        Root path for all datasets.  Can be a local directory
+        (``/data/…``) or an ABFSS URI
+        (``abfss://<workspace>@onelake.dfs.fabric.microsoft.com/<lakehouse>``).
+    """
+
+    def __init__(self, spark, base_path: str):
+        self.spark = spark
+        self.base_path = base_path.rstrip("/")
+
+    # ── helpers ───────────────────────────────────────────────────────────────
+
+    def _path(self, *parts: str) -> str:
+        return "/".join([self.base_path] + list(parts))
+
+    def _read_csv(self, path: str, **options):
+        return (
+            self.spark.read
+            .options(header=True, inferSchema=True, **options)
+            .csv(path)
+        )
+
+    def _read_parquet(self, path: str):
+        return self.spark.read.parquet(path)
+
+    def _read_delta(self, path: str):
+        return self.spark.read.format("delta").load(path)
+
+    # ── public API ────────────────────────────────────────────────────────────
+
+    def read_actuals(
+        self,
+        table_or_subpath: str = "actuals",
+        format: str = "delta",
+    ):
+        """
+        Read the canonical actuals table.
+
+        Parameters
+        ----------
+        table_or_subpath:
+            Sub-path under ``base_path`` or a fully-qualified Delta table name.
+        format:
+            ``"delta"`` | ``"parquet"`` | ``"csv"``.
+
+        Returns
+        -------
+        pyspark.sql.DataFrame
+        """
+        path = self._path(table_or_subpath)
+        logger.info("Reading actuals from %s (format=%s)", path, format)
+
+        if format == "delta":
+            return self._read_delta(path)
+        elif format == "parquet":
+            return self._read_parquet(path)
+        else:
+            return self._read_csv(path)
+
+    def read_product_master(
+        self,
+        table_or_subpath: str = "product_master",
+        format: str = "delta",
+    ):
+        """Read product/SKU master data."""
+        path = self._path(table_or_subpath)
+        logger.info("Reading product master from %s", path)
+        if format == "delta":
+            return self._read_delta(path)
+        elif format == "parquet":
+            return self._read_parquet(path)
+        return self._read_csv(path)
+
+    def read_delta(self, subpath: str):
+        """Generic Delta table reader relative to ``base_path``."""
+        path = self._path(subpath)
+        logger.info("Reading Delta table: %s", path)
+        return self._read_delta(path)
+
+    def read_parquet(self, subpath: str):
+        """Generic Parquet reader relative to ``base_path``."""
+        path = self._path(subpath)
+        logger.info("Reading Parquet: %s", path)
+        return self._read_parquet(path)
+
+    def read_csv(self, subpath: str, **options):
+        """Generic CSV reader relative to ``base_path``."""
+        path = self._path(subpath)
+        logger.info("Reading CSV: %s", path)
+        return self._read_csv(path, **options)
+
+    # ── Rossmann-specific helpers (dev / Kaggle data) ─────────────────────────
+
+    def read_rossmann_train(self):
+        """Read Rossmann train.csv (local dev)."""
+        return self._read_csv(self._path("train.csv"))
+
+    def read_rossmann_test(self):
+        """Read Rossmann test.csv (local dev)."""
+        return self._read_csv(self._path("test.csv"))
+
+    def read_rossmann_store(self):
+        """Read Rossmann store.csv (local dev)."""
+        return self._read_csv(self._path("store.csv"))
+
+    def read_rossmann_all(self):
+        """
+        Load all three Rossmann datasets.
+
+        Returns
+        -------
+        (train_df, test_df, store_df)
+        """
+        train = self.read_rossmann_train()
+        test = self.read_rossmann_test()
+        store = self.read_rossmann_store()
+        return train, test, store

--- a/forecasting-platform/src/spark/pipeline.py
+++ b/forecasting-platform/src/spark/pipeline.py
@@ -1,0 +1,290 @@
+"""
+SparkForecastPipeline — distributed forecast and backtest via pandas_udf.
+
+Design
+------
+The existing forecasters (``src.forecasting.*``) are Polars/pandas-based
+single-node models.  This pipeline fans them out across the Spark cluster
+using ``applyInPandas`` (GROUPED_MAP pattern):
+
+  1. Partition the actuals DataFrame by ``series_id``.
+  2. Each Spark task picks up one partition (one series) and calls the
+     forecaster's ``fit → predict`` cycle locally.
+  3. Results are collected back into a single Spark DataFrame.
+
+This avoids large model broadcasts and lets Spark schedule tasks purely
+based on data locality.
+
+Usage
+-----
+>>> from src.spark.pipeline import SparkForecastPipeline
+>>> from src.config import load_config
+>>> config   = load_config("configs/platform_config.yaml")
+>>> pipeline = SparkForecastPipeline(spark, config)
+>>> forecasts_sdf = pipeline.run_forecast(actuals_sdf, champion_model="lgbm_direct")
+"""
+
+import logging
+import pickle
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class SparkForecastPipeline:
+    """
+    Distributed forecast / backtest pipeline built on PySpark.
+
+    Parameters
+    ----------
+    spark:
+        Active SparkSession.
+    config:
+        ``PlatformConfig`` instance (loaded from YAML).
+    """
+
+    def __init__(self, spark, config):
+        self.spark = spark
+        self.config = config
+
+    # ── forecast ──────────────────────────────────────────────────────────────
+
+    def run_forecast(
+        self,
+        actuals_sdf,
+        champion_model: str = "naive_seasonal",
+        horizon: Optional[int] = None,
+        num_partitions: Optional[int] = None,
+    ):
+        """
+        Fit a champion model per series and generate forecasts.
+
+        Parameters
+        ----------
+        actuals_sdf:
+            Spark DataFrame with columns
+            [series_id_col, time_col, target_col, …].
+        champion_model:
+            Registered forecaster name (see ``src.forecasting.registry``).
+        horizon:
+            Forecast horizon in weeks.  Defaults to ``config.forecast.horizon_weeks``.
+        num_partitions:
+            Number of Spark partitions (≈ parallelism).  Defaults to
+            number of distinct series (capped at 2 000).
+
+        Returns
+        -------
+        Spark DataFrame: [series_id, week, forecast].
+        """
+        from pyspark.sql import functions as F, types as T
+        from .utils import repartition_by_series
+
+        fc = self.config.forecast
+        horizon = horizon or fc.horizon_weeks
+        id_col = fc.series_id_column
+        time_col = fc.time_column
+        target_col = fc.target_column
+
+        # Serialise config & model name for broadcast
+        config_bytes = self.spark.sparkContext.broadcast(
+            pickle.dumps((self.config, champion_model, horizon, id_col, time_col, target_col))
+        )
+
+        # Output schema: series_id (string), week (date), forecast (double)
+        output_schema = T.StructType([
+            T.StructField(id_col,    T.StringType(),  nullable=False),
+            T.StructField(time_col,  T.DateType(),    nullable=False),
+            T.StructField("forecast", T.DoubleType(), nullable=True),
+        ])
+
+        def _forecast_partition(pdf):
+            """
+            Called once per series partition.  Runs entirely on the executor.
+            """
+            import polars as pl
+            from src.forecasting.registry import registry
+
+            cfg, model_name, h, id_c, time_c, tgt_c = pickle.loads(config_bytes.value)
+
+            if pdf.empty:
+                import pandas as pd
+                return pd.DataFrame(columns=[id_c, time_c, "forecast"])
+
+            series = pl.from_pandas(pdf)
+
+            forecaster = registry.build(model_name)
+            forecaster.fit(series, target_col=tgt_c, time_col=time_c, id_col=id_c)
+            result = forecaster.predict(horizon=h, id_col=id_c, time_col=time_c)
+            return result.to_pandas()
+
+        actuals_sdf = repartition_by_series(actuals_sdf, id_col, num_partitions)
+        forecasts_sdf = actuals_sdf.groupby(id_col).applyInPandas(
+            _forecast_partition, schema=output_schema
+        )
+        logger.info("SparkForecastPipeline.run_forecast launched (model=%s, horizon=%d)", champion_model, horizon)
+        return forecasts_sdf
+
+    # ── backtest ──────────────────────────────────────────────────────────────
+
+    def run_backtest(
+        self,
+        actuals_sdf,
+        model_names: Optional[List[str]] = None,
+        num_partitions: Optional[int] = None,
+    ):
+        """
+        Run walk-forward backtest for multiple models across all series.
+
+        Each (series × model × fold) is evaluated independently on an
+        executor, producing per-series metrics.
+
+        Parameters
+        ----------
+        actuals_sdf:
+            Spark DataFrame with actuals.
+        model_names:
+            List of model names to evaluate.  Defaults to
+            ``config.forecast.forecasters``.
+        num_partitions:
+            Spark parallelism.
+
+        Returns
+        -------
+        Spark DataFrame: [series_id, model, fold, wmape, normalized_bias, …].
+        """
+        from pyspark.sql import functions as F, types as T
+        from .utils import repartition_by_series
+
+        fc = self.config.forecast
+        bt = self.config.backtest
+        id_col = fc.series_id_column
+        time_col = fc.time_column
+        target_col = fc.target_column
+        model_names = model_names or fc.forecasters
+
+        config_bytes = self.spark.sparkContext.broadcast(
+            pickle.dumps((self.config, model_names, id_col, time_col, target_col))
+        )
+
+        output_schema = T.StructType([
+            T.StructField(id_col,            T.StringType(),  nullable=False),
+            T.StructField("model",           T.StringType(),  nullable=False),
+            T.StructField("fold",            T.IntegerType(), nullable=False),
+            T.StructField("wmape",           T.DoubleType(),  nullable=True),
+            T.StructField("normalized_bias", T.DoubleType(),  nullable=True),
+            T.StructField("mae",             T.DoubleType(),  nullable=True),
+        ])
+
+        def _backtest_partition(pdf):
+            """Per-series backtest.  Runs on executor."""
+            import pandas as pd
+            import polars as pl
+            import numpy as np
+            from src.forecasting.registry import registry
+
+            cfg, models, id_c, time_c, tgt_c = pickle.loads(config_bytes.value)
+            bt_cfg = cfg.backtest
+
+            if pdf.empty:
+                return pd.DataFrame(columns=[id_c, "model", "fold", "wmape", "normalized_bias", "mae"])
+
+            series = pl.from_pandas(pdf).sort(time_c)
+            n = len(series)
+            rows = []
+
+            for model_name in models:
+                for fold in range(bt_cfg.n_folds):
+                    val_end   = n - fold * bt_cfg.val_weeks
+                    val_start = val_end - bt_cfg.val_weeks
+                    train_end = val_start - bt_cfg.gap_weeks
+
+                    if train_end < 10 or val_start < 0:
+                        continue
+
+                    train = series[:train_end]
+                    val   = series[val_start:val_end]
+
+                    try:
+                        forecaster = registry.build(model_name)
+                        forecaster.fit(train, target_col=tgt_c, time_col=time_c, id_col=id_c)
+                        preds = forecaster.predict(
+                            horizon=bt_cfg.val_weeks,
+                            id_col=id_c,
+                            time_col=time_c,
+                        )
+
+                        actual_vals = val[tgt_c].to_numpy().astype(float)
+                        pred_vals   = preds["forecast"].to_numpy().astype(float)
+                        min_len     = min(len(actual_vals), len(pred_vals))
+                        actual_vals = actual_vals[:min_len]
+                        pred_vals   = pred_vals[:min_len]
+
+                        denom = np.sum(np.abs(actual_vals))
+                        wmape = float(np.sum(np.abs(actual_vals - pred_vals)) / denom) if denom else None
+                        norm_bias = float(np.sum(actual_vals - pred_vals) / denom) if denom else None
+                        mae = float(np.mean(np.abs(actual_vals - pred_vals)))
+
+                        series_id_val = pdf[id_c].iloc[0] if id_c in pdf.columns else "unknown"
+                        rows.append({
+                            id_c:              series_id_val,
+                            "model":           model_name,
+                            "fold":            fold,
+                            "wmape":           wmape,
+                            "normalized_bias": norm_bias,
+                            "mae":             mae,
+                        })
+                    except Exception as exc:
+                        logger.warning("Backtest failed for series %s model %s fold %d: %s",
+                                       pdf[id_c].iloc[0] if id_c in pdf.columns else "?",
+                                       model_name, fold, exc)
+
+            return pd.DataFrame(rows) if rows else pd.DataFrame(
+                columns=[id_c, "model", "fold", "wmape", "normalized_bias", "mae"]
+            )
+
+        actuals_sdf = repartition_by_series(actuals_sdf, id_col, num_partitions)
+        results_sdf = actuals_sdf.groupby(id_col).applyInPandas(
+            _backtest_partition, schema=output_schema
+        )
+        logger.info(
+            "SparkForecastPipeline.run_backtest launched (models=%s, folds=%d)",
+            model_names, self.config.backtest.n_folds,
+        )
+        return results_sdf
+
+    # ── champion selection ────────────────────────────────────────────────────
+
+    def select_champion(self, backtest_results_sdf, primary_metric: str = "wmape"):
+        """
+        Aggregate backtest results and select the champion model per LOB.
+
+        Parameters
+        ----------
+        backtest_results_sdf:
+            Output of ``run_backtest``.
+        primary_metric:
+            Metric column to minimise for champion selection.
+
+        Returns
+        -------
+        Spark DataFrame: [model, mean_wmape, mean_normalized_bias, mean_mae, rank].
+        """
+        from pyspark.sql import functions as F
+        from pyspark.sql.window import Window
+
+        leaderboard = (
+            backtest_results_sdf
+            .groupby("model")
+            .agg(
+                F.mean("wmape").alias("mean_wmape"),
+                F.mean("normalized_bias").alias("mean_normalized_bias"),
+                F.mean("mae").alias("mean_mae"),
+                F.count("*").alias("n_evals"),
+            )
+            .withColumn(
+                "rank",
+                F.rank().over(Window.orderBy(F.col(f"mean_{primary_metric}").asc_nulls_last())),
+            )
+            .orderBy("rank")
+        )
+        return leaderboard

--- a/forecasting-platform/src/spark/session.py
+++ b/forecasting-platform/src/spark/session.py
@@ -1,0 +1,110 @@
+"""
+SparkSession factory with Microsoft Fabric auto-detection.
+
+Usage
+-----
+>>> from src.spark.session import get_or_create_spark
+>>> spark = get_or_create_spark()          # local (dev/test)
+>>> spark = get_or_create_spark("fabric")  # Fabric / Synapse
+"""
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Fabric environment marker ────────────────────────────────────────────────
+# Microsoft Fabric injects this env-var in every Spark session.
+_FABRIC_ENV_VAR = "MSSPARKUTILS_VERSION"
+_SYNAPSE_ENV_VAR = "SYNAPSE_SPARKPOOL_NAME"
+
+
+def _is_fabric() -> bool:
+    """Return True when running inside a Fabric / Synapse notebook."""
+    return (
+        os.environ.get(_FABRIC_ENV_VAR) is not None
+        or os.environ.get(_SYNAPSE_ENV_VAR) is not None
+    )
+
+
+def _is_notebookutils_available() -> bool:
+    try:
+        import notebookutils  # noqa: F401 — Fabric runtime package
+        return True
+    except ImportError:
+        return False
+
+
+def get_or_create_spark(
+    mode: Optional[str] = None,
+    app_name: str = "ForecastingPlatform",
+    executor_memory: str = "4g",
+    executor_cores: int = 2,
+    shuffle_partitions: int = 200,
+):
+    """
+    Return an active SparkSession, creating one if necessary.
+
+    Parameters
+    ----------
+    mode:
+        ``"local"``  — forces a local[*] session (unit tests / dev).
+        ``"fabric"`` — assumes a running Fabric / Synapse session already
+                       exists and returns ``SparkSession.getActiveSession()``.
+        ``None``     — auto-detect: Fabric if env-vars present, else local.
+    app_name:
+        Application name embedded in the Spark UI.
+    executor_memory:
+        Memory per executor for local mode (ignored in Fabric).
+    executor_cores:
+        Cores per executor for local mode (ignored in Fabric).
+    shuffle_partitions:
+        ``spark.sql.shuffle.partitions`` (tune for cluster size).
+
+    Returns
+    -------
+    pyspark.sql.SparkSession
+    """
+    try:
+        from pyspark.sql import SparkSession
+    except ImportError as exc:
+        raise ImportError(
+            "PySpark is required for the Spark layer.  "
+            "Install it with: pip install pyspark"
+        ) from exc
+
+    resolved_mode = mode or ("fabric" if (_is_fabric() or _is_notebookutils_available()) else "local")
+
+    if resolved_mode == "fabric":
+        # In Fabric, the session is pre-created by the runtime.
+        spark = SparkSession.getActiveSession()
+        if spark is None:
+            raise RuntimeError(
+                "No active SparkSession found in Fabric environment.  "
+                "Ensure you are running inside a Fabric notebook or Spark job."
+            )
+        logger.info("Using existing Fabric SparkSession: %s", spark.sparkContext.appName)
+        return spark
+
+    # ── local mode ────────────────────────────────────────────────────────────
+    spark = (
+        SparkSession.builder
+        .appName(app_name)
+        .master("local[*]")
+        .config("spark.executor.memory", executor_memory)
+        .config("spark.executor.cores", str(executor_cores))
+        .config("spark.sql.shuffle.partitions", str(shuffle_partitions))
+        # Delta Lake support (open-source)
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        # Parquet / date handling
+        .config("spark.sql.legacy.timeParserPolicy", "LEGACY")
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("WARN")
+    logger.info("Created local SparkSession: %s", spark.sparkContext.appName)
+    return spark

--- a/forecasting-platform/src/spark/utils.py
+++ b/forecasting-platform/src/spark/utils.py
@@ -1,0 +1,141 @@
+"""
+Schema helpers and Polars ↔ Spark conversion utilities.
+"""
+
+import logging
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Polars → Spark type mapping ───────────────────────────────────────────────
+
+def polars_to_spark_schema(polars_df):
+    """
+    Convert a Polars DataFrame schema to a PySpark StructType.
+
+    Parameters
+    ----------
+    polars_df:
+        polars.DataFrame whose schema to convert.
+
+    Returns
+    -------
+    pyspark.sql.types.StructType
+    """
+    import polars as pl
+    from pyspark.sql import types as T
+
+    _TYPE_MAP = {
+        pl.Int8:    T.ByteType(),
+        pl.Int16:   T.ShortType(),
+        pl.Int32:   T.IntegerType(),
+        pl.Int64:   T.LongType(),
+        pl.UInt8:   T.ShortType(),
+        pl.UInt16:  T.IntegerType(),
+        pl.UInt32:  T.LongType(),
+        pl.UInt64:  T.LongType(),
+        pl.Float32: T.FloatType(),
+        pl.Float64: T.DoubleType(),
+        pl.Boolean: T.BooleanType(),
+        pl.Utf8:    T.StringType(),
+        pl.String:  T.StringType(),
+        pl.Date:    T.DateType(),
+        pl.Datetime: T.TimestampType(),
+    }
+
+    fields = []
+    for col_name, dtype in zip(polars_df.columns, polars_df.dtypes):
+        spark_type = _TYPE_MAP.get(type(dtype), T.StringType())
+        fields.append(T.StructField(col_name, spark_type, nullable=True))
+
+    return T.StructType(fields)
+
+
+def polars_to_spark(polars_df, spark):
+    """
+    Convert a Polars DataFrame to a PySpark DataFrame.
+
+    Uses an intermediate pandas conversion for correctness across all types.
+    """
+    return spark.createDataFrame(polars_df.to_pandas())
+
+
+def spark_to_polars(spark_df):
+    """
+    Convert a PySpark DataFrame to a Polars DataFrame.
+    """
+    import polars as pl
+    return pl.from_pandas(spark_df.toPandas())
+
+
+# ── Partition utilities ────────────────────────────────────────────────────────
+
+def repartition_by_series(df, series_id_col: str = "series_id", num_partitions: Optional[int] = None):
+    """
+    Repartition a Spark DataFrame so that each series lands on one partition.
+
+    This is important for the ``pandas_udf`` pattern: each task processes
+    exactly one series, avoiding cross-partition shuffles in the UDF.
+
+    Parameters
+    ----------
+    df:
+        Spark DataFrame containing ``series_id_col``.
+    series_id_col:
+        Column that identifies each time series.
+    num_partitions:
+        Explicit partition count.  If None, defaults to the number of
+        distinct series (capped at 2 000 to avoid excessive overhead).
+
+    Returns
+    -------
+    Repartitioned Spark DataFrame.
+    """
+    from pyspark.sql import functions as F
+
+    if num_partitions is None:
+        n_series = df.select(F.countDistinct(series_id_col)).collect()[0][0]
+        num_partitions = min(int(n_series), 2000)
+
+    logger.info(
+        "Repartitioning to %d partitions on '%s'", num_partitions, series_id_col
+    )
+    return df.repartition(num_partitions, series_id_col)
+
+
+# ── ABFSS URI builder ─────────────────────────────────────────────────────────
+
+def abfss_uri(
+    workspace: str,
+    lakehouse: str,
+    subpath: str = "",
+    host: str = "onelake.dfs.fabric.microsoft.com",
+) -> str:
+    """
+    Build an ABFSS URI for a Microsoft Fabric Lakehouse path.
+
+    Parameters
+    ----------
+    workspace:
+        Fabric workspace name (or GUID).
+    lakehouse:
+        Lakehouse name (or GUID).
+    subpath:
+        Optional sub-path within the Lakehouse (e.g. "Tables/forecasts").
+    host:
+        OneLake DFS endpoint.
+
+    Returns
+    -------
+    ``abfss://<workspace>@<host>/<lakehouse>/<subpath>``
+
+    Example
+    -------
+    >>> abfss_uri("myws", "myLH", "Tables/actuals")
+    'abfss://myws@onelake.dfs.fabric.microsoft.com/myLH/Tables/actuals'
+    """
+    base = f"abfss://{workspace}@{host}/{lakehouse}"
+    if subpath:
+        return f"{base}/{subpath.lstrip('/')}"
+    return base


### PR DESCRIPTION
Introduces src/spark/ and src/fabric/ sub-packages that allow the forecasting platform to run at scale on PySpark and Microsoft Fabric:

src/spark/
  session.py              — SparkSession factory with Fabric auto-detection
  loader.py               — SparkDataLoader (CSV / Parquet / Delta / ABFSS)
  feature_engineering.py  — PySpark-native temporal, lag, and rolling features
  pipeline.py             — Distributed forecast & backtest via applyInPandas
  utils.py                — Polars↔Spark conversion, ABFSS URI builder

src/fabric/
  config.py               — FabricConfig dataclass (workspace, lakehouse, paths)
  lakehouse.py            — FabricLakehouse read/write/optimize/vacuum helpers
  delta_writer.py         — DeltaWriter: upsert (MERGE INTO), partition overwrite, append

configs/fabric_config.yaml — Fabric/Spark runtime configuration

notebooks/
  01_data_prep.py         — Ingest raw data + feature engineering → actuals Delta table
  02_backtest.py          — Distributed walk-forward backtest + champion selection
  03_forecast.py          — Production forecast with champion model → forecasts Delta table

scripts/
  spark_backtest.py       — CLI spark-submit entry point for backtest
  spark_forecast.py       — CLI spark-submit entry point for production forecast

requirements.txt updated with pyspark>=3.4.0 and delta-spark>=2.4.0.

https://claude.ai/code/session_01U8RCtLVxpzc8YR6xe4rgKu