### PR TITLE
Fix five Spark/Fabric layer issues before Phase 2

### DIFF
--- a/forecasting-platform/configs/fabric_config.yaml
+++ b/forecasting-platform/configs/fabric_config.yaml
@@ -78,3 +78,22 @@ data:
   actuals_path:        "raw/actuals"
   product_master_path: "raw/product_master"
   format: "parquet"    # delta | parquet | csv
+
+# ── Series builder ────────────────────────────────────────────────────────────
+# Controls how raw source columns are mapped to the canonical series schema
+# expected by the forecasting pipeline:
+#   series_id  — unique key per time series
+#   week       — truncated weekly date
+#   quantity   — forecast target
+#
+# source_id_cols:   one or more columns concatenated (with '_') to form series_id
+# date_col:         date column in the raw actuals table
+# target_col:       numeric column summed to produce quantity
+# filter_expr:      optional Spark SQL WHERE expression applied before aggregation
+#                   (e.g. exclude closed stores, cancelled orders, etc.)
+series_builder:
+  source_id_cols: ["Store"]            # for Rossmann; use ["product_unit", "country"] for Surface
+  date_col:       "Date"
+  target_col:     "Sales"
+  filter_expr:    "Open = 1"           # exclude closed-store days
+  frequency:      "week"               # Spark date_trunc argument: "week" | "month"

--- a/forecasting-platform/notebooks/01_data_prep.py
+++ b/forecasting-platform/notebooks/01_data_prep.py
@@ -16,6 +16,7 @@
 # %%
 import os
 import sys
+import yaml
 
 # ── Add platform src to path ─────────────────────────────────────────────────
 # In Fabric, mount the repo via the Lakehouse Git integration or upload the
@@ -25,10 +26,14 @@ if PLATFORM_ROOT not in sys.path:
     sys.path.insert(0, PLATFORM_ROOT)
 
 # ── Fabric / Lakehouse identifiers ───────────────────────────────────────────
-WORKSPACE  = os.environ.get("FABRIC_WORKSPACE", "my-workspace")
-LAKEHOUSE  = os.environ.get("FABRIC_LAKEHOUSE", "my-lakehouse")
-LOB        = os.environ.get("FORECAST_LOB", "rossmann")
-ENVIRONMENT = os.environ.get("FABRIC_ENVIRONMENT", "development")
+WORKSPACE       = os.environ.get("FABRIC_WORKSPACE", "my-workspace")
+LAKEHOUSE       = os.environ.get("FABRIC_LAKEHOUSE", "my-lakehouse")
+LOB             = os.environ.get("FORECAST_LOB", "rossmann")
+ENVIRONMENT     = os.environ.get("FABRIC_ENVIRONMENT", "development")
+FABRIC_CFG_PATH = os.environ.get("FABRIC_CONFIG", "configs/fabric_config.yaml")
+
+with open(FABRIC_CFG_PATH) as _f:
+    fabric_yaml = yaml.safe_load(_f)
 
 print(f"Workspace : {WORKSPACE}")
 print(f"Lakehouse : {LAKEHOUSE}")
@@ -52,12 +57,10 @@ print(f"Spark version: {spark.version}")
 from src.spark.loader import SparkDataLoader
 from src.spark.utils import abfss_uri
 
-# Build the ABFSS base path for the Lakehouse
 base_path = abfss_uri(WORKSPACE, LAKEHOUSE)
 loader = SparkDataLoader(spark, base_path=base_path)
 
-# For local / dev mode, read from Files/raw/
-# For Rossmann Kaggle data specifically:
+# Rossmann Kaggle data
 train_sdf, test_sdf, store_sdf = loader.read_rossmann_all()
 
 print(f"Train rows : {train_sdf.count():,}")
@@ -74,20 +77,26 @@ actuals_sdf.printSchema()
 
 # %% [markdown]
 # ## 4 — Distributed feature engineering
+#
+# Column names are read from fabric_config.yaml → series_builder, so this
+# cell works without changes for any LOB.
 
 # %%
 from src.spark.feature_engineering import SparkFeatureEngineer
 
+sb_cfg = fabric_yaml["series_builder"]
+feat_cfg = fabric_yaml.get("features", {})
+
 eng = SparkFeatureEngineer(
-    lag_periods=[1, 7, 14, 30],
-    rolling_windows=[7, 14, 30],
+    lag_periods=feat_cfg.get("lag_periods", [1, 7, 14, 30]),
+    rolling_windows=feat_cfg.get("rolling_windows", [7, 14, 30]),
 )
 
 actuals_features_sdf = eng.fit_transform(
     actuals_sdf,
-    date_col="Date",
-    target_col="Sales",
-    group_col="Store",
+    date_col=sb_cfg["date_col"],
+    target_col=sb_cfg["target_col"],
+    group_col=sb_cfg["source_id_cols"][0],   # primary grouping key for rolling/lag
 )
 
 print(f"Feature columns ({len(actuals_features_sdf.columns)}): {actuals_features_sdf.columns}")
@@ -99,6 +108,10 @@ actuals_features_sdf.show(5, truncate=False)
 # %%
 from pyspark.sql import functions as F
 
+date_col   = sb_cfg["date_col"]
+target_col = sb_cfg["target_col"]
+id_col     = sb_cfg["source_id_cols"][0]
+
 # Missing values summary
 null_counts = actuals_features_sdf.select(
     [F.count(F.when(F.col(c).isNull(), c)).alias(c) for c in actuals_features_sdf.columns]
@@ -106,11 +119,11 @@ null_counts = actuals_features_sdf.select(
 print("Null counts per column:")
 null_counts.show(truncate=False)
 
-# Date range
+# Date range and series count
 actuals_features_sdf.select(
-    F.min("Date").alias("min_date"),
-    F.max("Date").alias("max_date"),
-    F.countDistinct("Store").alias("n_stores"),
+    F.min(date_col).alias("min_date"),
+    F.max(date_col).alias("max_date"),
+    F.countDistinct(id_col).alias("n_series"),
 ).show()
 
 # %% [markdown]
@@ -131,7 +144,7 @@ lh.write_table(
     actuals_features_sdf,
     table_name="actuals",
     mode="overwrite",
-    partition_by=["Store"],
+    partition_by=[id_col],
     merge_schema=True,
 )
 
@@ -141,5 +154,5 @@ print(f"Actuals Delta table written to: {fabric_cfg.table_path('actuals')}")
 # ## 7 — (Optional) Optimize the Delta table
 
 # %%
-lh.optimize("actuals", z_order_by=["Date"])
+lh.optimize("actuals", z_order_by=[date_col])
 print("OPTIMIZE complete.")

--- a/forecasting-platform/notebooks/02_backtest.py
+++ b/forecasting-platform/notebooks/02_backtest.py
@@ -14,16 +14,21 @@
 # %%
 import os
 import sys
+import yaml
 
 PLATFORM_ROOT = "/lakehouse/default/Files/forecasting-platform"
 if PLATFORM_ROOT not in sys.path:
     sys.path.insert(0, PLATFORM_ROOT)
 
-WORKSPACE   = os.environ.get("FABRIC_WORKSPACE", "my-workspace")
-LAKEHOUSE   = os.environ.get("FABRIC_LAKEHOUSE", "my-lakehouse")
-LOB         = os.environ.get("FORECAST_LOB", "rossmann")
-CONFIG_PATH = os.environ.get("FORECAST_CONFIG", "configs/platform_config.yaml")
-ENVIRONMENT = os.environ.get("FABRIC_ENVIRONMENT", "development")
+WORKSPACE       = os.environ.get("FABRIC_WORKSPACE", "my-workspace")
+LAKEHOUSE       = os.environ.get("FABRIC_LAKEHOUSE", "my-lakehouse")
+LOB             = os.environ.get("FORECAST_LOB", "rossmann")
+CONFIG_PATH     = os.environ.get("FORECAST_CONFIG", "configs/platform_config.yaml")
+ENVIRONMENT     = os.environ.get("FABRIC_ENVIRONMENT", "development")
+FABRIC_CFG_PATH = os.environ.get("FABRIC_CONFIG", "configs/fabric_config.yaml")
+
+with open(FABRIC_CFG_PATH) as _f:
+    fabric_yaml = yaml.safe_load(_f)
 
 print(f"Workspace  : {WORKSPACE}")
 print(f"LOB        : {LOB}")
@@ -66,29 +71,17 @@ print(f"Actuals loaded: {actuals_sdf.count():,} rows")
 actuals_sdf.printSchema()
 
 # %% [markdown]
-# ## 4 — Prepare series-level data
+# ## 4 — Build canonical series panel
 #
-# The SparkForecastPipeline expects:
-#   - A ``series_id`` column (Store + product key).
-#   - A ``week`` column (weekly period date).
-#   - A ``quantity`` column (target).
+# Column mapping is read from fabric_config.yaml → series_builder.
+# No LOB-specific column names appear in this cell.
 
 # %%
-from pyspark.sql import functions as F
+from src.spark.series_builder import SparkSeriesBuilder
 
-# For Rossmann: series_id = Store, week = truncated Date, quantity = Sales
-actuals_series_sdf = (
-    actuals_sdf
-    .filter(F.col("Open") == 1)             # exclude closed days
-    .withColumn("series_id", F.col("Store").cast("string"))
-    .withColumn("week", F.date_trunc("week", F.col("Date")))
-    .groupby("series_id", "week")
-    .agg(F.sum("Sales").alias("quantity"))
-    .orderBy("series_id", "week")
-)
+builder = SparkSeriesBuilder.from_config(fabric_yaml["series_builder"])
+actuals_series_sdf = builder.build(actuals_sdf)
 
-print(f"Series rows: {actuals_series_sdf.count():,}")
-print(f"Series count: {actuals_series_sdf.select('series_id').distinct().count():,}")
 actuals_series_sdf.show(5)
 
 # %% [markdown]
@@ -111,32 +104,31 @@ backtest_results_sdf.show(20)
 # ## 6 — Select champion model
 
 # %%
+from pyspark.sql import functions as F
+
 leaderboard_sdf = pipeline.select_champion(
     backtest_results_sdf,
     primary_metric=config.backtest.primary_metric,
 )
 leaderboard_sdf.show(truncate=False)
 
-champion_model = leaderboard_sdf.filter(F.col("rank") == 1).select("model").collect()[0][0]
+champion_model = leaderboard_sdf.filter(F.col("rank") == 1).select("model").first()[0]
 print(f"\nChampion model: {champion_model}")
 
 # %% [markdown]
 # ## 7 — Write results to Lakehouse
 
 # %%
+from datetime import date
 from src.fabric.delta_writer import DeltaWriter
-from pyspark.sql import functions as F as _F
 
 writer = DeltaWriter(spark, fabric_cfg)
-
-# Backtest results
-from datetime import date
 run_date = date.today().isoformat()
 
 backtest_results_sdf_out = (
     backtest_results_sdf
-    .withColumn("lob", _F.lit(LOB))
-    .withColumn("run_date", _F.lit(run_date))
+    .withColumn("lob", F.lit(LOB))
+    .withColumn("run_date", F.lit(run_date))
 )
 writer.append(
     backtest_results_sdf_out,
@@ -145,12 +137,11 @@ writer.append(
 )
 print("Backtest results written.")
 
-# Leaderboard
 leaderboard_out = (
     leaderboard_sdf
-    .withColumn("lob", _F.lit(LOB))
-    .withColumn("run_date", _F.lit(run_date))
-    .withColumn("champion_model", _F.lit(champion_model))
+    .withColumn("lob", F.lit(LOB))
+    .withColumn("run_date", F.lit(run_date))
+    .withColumn("champion_model", F.lit(champion_model))
 )
 writer.upsert(
     leaderboard_out,

--- a/forecasting-platform/notebooks/03_forecast.py
+++ b/forecasting-platform/notebooks/03_forecast.py
@@ -15,19 +15,24 @@
 # %%
 import os
 import sys
+import yaml
 from datetime import date
 
 PLATFORM_ROOT = "/lakehouse/default/Files/forecasting-platform"
 if PLATFORM_ROOT not in sys.path:
     sys.path.insert(0, PLATFORM_ROOT)
 
-WORKSPACE       = os.environ.get("FABRIC_WORKSPACE", "my-workspace")
-LAKEHOUSE       = os.environ.get("FABRIC_LAKEHOUSE", "my-lakehouse")
-LOB             = os.environ.get("FORECAST_LOB", "rossmann")
-CONFIG_PATH     = os.environ.get("FORECAST_CONFIG", "configs/platform_config.yaml")
-ENVIRONMENT     = os.environ.get("FABRIC_ENVIRONMENT", "development")
+WORKSPACE         = os.environ.get("FABRIC_WORKSPACE", "my-workspace")
+LAKEHOUSE         = os.environ.get("FABRIC_LAKEHOUSE", "my-lakehouse")
+LOB               = os.environ.get("FORECAST_LOB", "rossmann")
+CONFIG_PATH       = os.environ.get("FORECAST_CONFIG", "configs/platform_config.yaml")
+ENVIRONMENT       = os.environ.get("FABRIC_ENVIRONMENT", "development")
+FABRIC_CFG_PATH   = os.environ.get("FABRIC_CONFIG", "configs/fabric_config.yaml")
 # Override champion model (empty = read from leaderboard table)
 CHAMPION_OVERRIDE = os.environ.get("CHAMPION_MODEL", "")
+
+with open(FABRIC_CFG_PATH) as _f:
+    fabric_yaml = yaml.safe_load(_f)
 
 FORECAST_ORIGIN = date.today().isoformat()
 
@@ -88,20 +93,17 @@ else:
     print(f"Champion model from leaderboard: {champion_model}")
 
 # %% [markdown]
-# ## 5 — Load actuals
+# ## 5 — Load actuals and build canonical series panel
+#
+# Column mapping is read from fabric_config.yaml → series_builder.
 
 # %%
+from src.spark.series_builder import SparkSeriesBuilder
+
 actuals_raw_sdf = lh.read_table("actuals")
 
-actuals_series_sdf = (
-    actuals_raw_sdf
-    .filter(F.col("Open") == 1)
-    .withColumn("series_id", F.col("Store").cast("string"))
-    .withColumn("week", F.date_trunc("week", F.col("Date")))
-    .groupby("series_id", "week")
-    .agg(F.sum("Sales").alias("quantity"))
-    .orderBy("series_id", "week")
-)
+builder = SparkSeriesBuilder.from_config(fabric_yaml["series_builder"])
+actuals_series_sdf = builder.build(actuals_raw_sdf)
 
 print(f"Actuals rows   : {actuals_series_sdf.count():,}")
 print(f"Series count   : {actuals_series_sdf.select('series_id').distinct().count():,}")

--- a/forecasting-platform/scripts/spark_backtest.py
+++ b/forecasting-platform/scripts/spark_backtest.py
@@ -59,6 +59,8 @@ def parse_args():
                    help="Model names to backtest (default: from config)")
     p.add_argument("--write-lakehouse", action="store_true",
                    help="Write results to Fabric Lakehouse (requires --workspace/--lakehouse)")
+    p.add_argument("--fabric-config", default="configs/fabric_config.yaml",
+                   help="Path to fabric_config.yaml (drives series_builder mapping)")
     p.add_argument("--output-dir", default="data/backtest_results/",
                    help="Local output directory for backtest results (non-Fabric mode)")
     return p.parse_args()
@@ -72,16 +74,20 @@ def main():
     spark = get_or_create_spark(app_name=f"BacktestPipeline-{args.lob}")
     logger.info("SparkSession ready (version=%s)", spark.version)
 
-    # ── 2. Platform config ────────────────────────────────────────────────────
+    # ── 2. Platform config + fabric config ───────────────────────────────────
+    import yaml
     from src.config.loader import load_config
+    from src.spark.series_builder import SparkSeriesBuilder
+
     config = load_config(args.config)
     config.lob = args.lob
     model_names = args.models or config.forecast.forecasters
     logger.info("Models: %s | Folds: %d", model_names, config.backtest.n_folds)
 
-    # ── 3. Load actuals ───────────────────────────────────────────────────────
-    from pyspark.sql import functions as F
+    with open(args.fabric_config) as _f:
+        fabric_yaml = yaml.safe_load(_f)
 
+    # ── 3. Load actuals ───────────────────────────────────────────────────────
     if args.write_lakehouse and (args.workspace or args.lakehouse):
         import os
         ws = args.workspace or os.environ.get("FABRIC_WORKSPACE", "")
@@ -97,22 +103,14 @@ def main():
         train_sdf, _, store_sdf = loader.read_rossmann_all()
         actuals_raw = train_sdf.join(store_sdf, on="Store", how="left")
 
-    # Build series-level weekly aggregation
-    actuals_sdf = (
-        actuals_raw
-        .filter(F.col("Open") == 1)
-        .withColumn("series_id", F.col("Store").cast("string"))
-        .withColumn("week", F.date_trunc("week", F.col("Date")))
-        .groupby("series_id", "week")
-        .agg(F.sum("Sales").alias("quantity"))
-        .orderBy("series_id", "week")
+    # Build canonical series panel via config — no hard-coded column names
+    builder = SparkSeriesBuilder.from_config(fabric_yaml["series_builder"])
+    actuals_sdf = builder.build(actuals_raw)
+    logger.info(
+        "Series rows: %d | Series: %d",
+        actuals_sdf.count(),
+        actuals_sdf.select("series_id").distinct().count(),
     )
-    logger.info("Series rows: %d | Series: %d",
-                actuals_sdf.count(),
-                actuals_sdf.select("series_id").distinct().count())
-
-    # ── 4. Feature engineering ────────────────────────────────────────────────
-    # (Series pipeline uses the polars-based models — no Spark features needed here)
 
     # ── 5. Run backtest ───────────────────────────────────────────────────────
     from src.spark.pipeline import SparkForecastPipeline

--- a/forecasting-platform/scripts/spark_forecast.py
+++ b/forecasting-platform/scripts/spark_forecast.py
@@ -64,34 +64,41 @@ def parse_args():
     p.add_argument("--write-mode", default="upsert",
                    choices=["upsert", "overwrite_partition", "append"],
                    help="Write strategy for the forecasts Delta table")
+    p.add_argument("--fabric-config", default="configs/fabric_config.yaml",
+                   help="Path to fabric_config.yaml (drives series_builder mapping)")
     p.add_argument("--output-dir", default="data/forecasts/",
                    help="Local output directory (non-Fabric mode)")
     return p.parse_args()
 
 
 def _resolve_champion(args, spark, lh):
-    """Read champion model from leaderboard or use CLI override."""
+    """
+    Return the champion model name as a Python string.
+
+    Aggregation and ranking stay on Spark executors; only the single
+    winning model name (one string) is collected to the driver via
+    ``.first()``.  Raises clearly if no backtest results exist yet.
+    """
     from pyspark.sql import functions as F
 
     if args.model:
         logger.info("Using CLI-supplied champion model: %s", args.model)
         return args.model
 
-    leaderboard_sdf = lh.read_table("leaderboard")
-    champion = (
-        leaderboard_sdf
+    row = (
+        lh.read_table("leaderboard")
         .filter(F.col("lob") == args.lob)
         .orderBy(F.col("run_date").desc(), F.col("rank").asc())
         .select("champion_model")
         .limit(1)
-        .collect()
+        .first()
     )
-    if not champion:
+    if row is None:
         raise RuntimeError(
             f"No champion model found for lob='{args.lob}' in leaderboard table.  "
             "Run spark_backtest.py first, or supply --model."
         )
-    return champion[0][0]
+    return row[0]
 
 
 def main():
@@ -102,12 +109,18 @@ def main():
     spark = get_or_create_spark(app_name=f"ForecastPipeline-{args.lob}")
     logger.info("SparkSession ready (version=%s)", spark.version)
 
-    # ── 2. Platform config ────────────────────────────────────────────────────
+    # ── 2. Platform config + fabric config ───────────────────────────────────
+    import yaml
     from src.config.loader import load_config
+    from src.spark.series_builder import SparkSeriesBuilder
+
     config = load_config(args.config)
     config.lob = args.lob
     horizon = args.horizon or config.forecast.horizon_weeks
     logger.info("Horizon: %d weeks", horizon)
+
+    with open(args.fabric_config) as _f:
+        fabric_yaml = yaml.safe_load(_f)
 
     # ── 3. Fabric / Lakehouse client (optional) ───────────────────────────────
     import os
@@ -135,15 +148,9 @@ def main():
         train_sdf, _, store_sdf = loader.read_rossmann_all()
         actuals_raw = train_sdf.join(store_sdf, on="Store", how="left")
 
-    actuals_sdf = (
-        actuals_raw
-        .filter(F.col("Open") == 1)
-        .withColumn("series_id", F.col("Store").cast("string"))
-        .withColumn("week", F.date_trunc("week", F.col("Date")))
-        .groupby("series_id", "week")
-        .agg(F.sum("Sales").alias("quantity"))
-        .orderBy("series_id", "week")
-    )
+    # Build canonical series panel via config — no hard-coded column names
+    builder = SparkSeriesBuilder.from_config(fabric_yaml["series_builder"])
+    actuals_sdf = builder.build(actuals_raw)
     logger.info(
         "Actuals: %d rows, %d series",
         actuals_sdf.count(),

--- a/forecasting-platform/src/fabric/lakehouse.py
+++ b/forecasting-platform/src/fabric/lakehouse.py
@@ -48,9 +48,17 @@ class FabricLakehouse:
         table_name: str,
         version: Optional[int] = None,
         timestamp: Optional[str] = None,
+        date_col: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        partition_filter: Optional[str] = None,
     ):
         """
-        Read a Delta table from the Lakehouse.
+        Read a Delta table from the Lakehouse with optional partition pruning.
+
+        Partition filters are pushed down to the Delta scan — only the
+        matching files are read, which dramatically reduces I/O for large
+        tables with years of history.
 
         Parameters
         ----------
@@ -60,11 +68,37 @@ class FabricLakehouse:
             Time-travel to a specific Delta version number.
         timestamp:
             Time-travel to a specific timestamp string (ISO-8601).
+        date_col:
+            Name of the date/timestamp partition column.  Required when
+            ``start_date`` or ``end_date`` is supplied.
+        start_date:
+            Inclusive lower bound (ISO-8601 string, e.g. ``"2022-01-01"``).
+            Generates a ``date_col >= 'start_date'`` predicate.
+        end_date:
+            Exclusive upper bound (ISO-8601 string, e.g. ``"2024-01-01"``).
+            Generates a ``date_col < 'end_date'`` predicate.
+        partition_filter:
+            Arbitrary Spark SQL WHERE predicate for additional partition
+            pruning (e.g. ``"lob = 'surface' AND region = 'EMEA'"``).
+            Applied in addition to any date bounds above.
 
         Returns
         -------
         pyspark.sql.DataFrame
+
+        Examples
+        --------
+        Read only the last two years of actuals:
+
+        >>> lh.read_table("actuals", date_col="Date",
+        ...               start_date="2022-01-01", end_date="2024-01-01")
+
+        Read a specific LOB partition:
+
+        >>> lh.read_table("forecasts", partition_filter="lob = 'surface'")
         """
+        from pyspark.sql import functions as F
+
         path = self.config.table_path(table_name)
         reader = self.spark.read.format("delta")
 
@@ -77,7 +111,30 @@ class FabricLakehouse:
         else:
             logger.info("Reading Delta table '%s' (latest)", table_name)
 
-        return reader.load(path)
+        df = reader.load(path)
+
+        # ── apply partition / date filters ────────────────────────────────────
+        filters_applied = []
+
+        if date_col and start_date:
+            df = df.filter(F.col(date_col) >= start_date)
+            filters_applied.append(f"{date_col} >= {start_date!r}")
+
+        if date_col and end_date:
+            df = df.filter(F.col(date_col) < end_date)
+            filters_applied.append(f"{date_col} < {end_date!r}")
+
+        if partition_filter:
+            df = df.filter(partition_filter)
+            filters_applied.append(partition_filter)
+
+        if filters_applied:
+            logger.info(
+                "Partition filters applied to '%s': %s",
+                table_name, " AND ".join(filters_applied),
+            )
+
+        return df
 
     def read_file(self, subpath: str, format: str = "parquet", **options):
         """

--- a/forecasting-platform/src/spark/__init__.py
+++ b/forecasting-platform/src/spark/__init__.py
@@ -10,6 +10,7 @@ session             SparkSession factory with Fabric auto-detection.
 loader              SparkDataLoader — reads CSV / Parquet / Delta Lake.
 feature_engineering SparkFeatureEngineer — PySpark-native transformations.
 pipeline            SparkForecastPipeline — pandas_udf distributed runner.
+series_builder      SparkSeriesBuilder — configurable raw → canonical series mapping.
 utils               Schema helpers and Polars ↔ Spark conversion utilities.
 """
 
@@ -17,3 +18,4 @@ from .session import get_or_create_spark  # noqa: F401
 from .loader import SparkDataLoader  # noqa: F401
 from .feature_engineering import SparkFeatureEngineer  # noqa: F401
 from .pipeline import SparkForecastPipeline  # noqa: F401
+from .series_builder import SparkSeriesBuilder, SeriesBuilderConfig  # noqa: F401

--- a/forecasting-platform/src/spark/pipeline.py
+++ b/forecasting-platform/src/spark/pipeline.py
@@ -12,8 +12,12 @@ using ``applyInPandas`` (GROUPED_MAP pattern):
      forecaster's ``fit → predict`` cycle locally.
   3. Results are collected back into a single Spark DataFrame.
 
-This avoids large model broadcasts and lets Spark schedule tasks purely
-based on data locality.
+Pickle safety
+-------------
+Only plain Python scalars (strings, ints) are broadcast to executors —
+never the full PlatformConfig object.  This prevents serialization failures
+caused by live resources (DuckDB connections, file handles) that may be
+attached to config objects on the driver.
 
 Usage
 -----
@@ -25,10 +29,31 @@ Usage
 """
 
 import logging
-import pickle
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_forecast_params(config, champion_model: str, horizon: int) -> dict:
+    """
+    Pull only the primitive values needed by executor tasks from a PlatformConfig.
+
+    Returns a plain dict that is guaranteed to pickle cleanly — no live
+    connections, file handles, or complex objects.
+    """
+    fc = config.forecast
+    bt = config.backtest
+    return {
+        "model_name":  champion_model,
+        "horizon":     horizon,
+        "id_col":      fc.series_id_column,
+        "time_col":    fc.time_column,
+        "target_col":  fc.target_column,
+        # backtest params (also needed for run_backtest path)
+        "n_folds":     bt.n_folds,
+        "val_weeks":   bt.val_weeks,
+        "gap_weeks":   bt.gap_weeks,
+    }
 
 
 class SparkForecastPipeline:
@@ -76,52 +101,50 @@ class SparkForecastPipeline:
         -------
         Spark DataFrame: [series_id, week, forecast].
         """
-        from pyspark.sql import functions as F, types as T
+        from pyspark.sql import types as T
         from .utils import repartition_by_series
 
-        fc = self.config.forecast
-        horizon = horizon or fc.horizon_weeks
-        id_col = fc.series_id_column
-        time_col = fc.time_column
-        target_col = fc.target_column
+        horizon = horizon or self.config.forecast.horizon_weeks
+        params = _extract_forecast_params(self.config, champion_model, horizon)
 
-        # Serialise config & model name for broadcast
-        config_bytes = self.spark.sparkContext.broadcast(
-            pickle.dumps((self.config, champion_model, horizon, id_col, time_col, target_col))
-        )
+        # Broadcast only the plain-scalar dict — safe to pickle on any executor.
+        params_bc = self.spark.sparkContext.broadcast(params)
 
-        # Output schema: series_id (string), week (date), forecast (double)
+        id_col   = params["id_col"]
+        time_col = params["time_col"]
+
         output_schema = T.StructType([
-            T.StructField(id_col,    T.StringType(),  nullable=False),
-            T.StructField(time_col,  T.DateType(),    nullable=False),
+            T.StructField(id_col,     T.StringType(), nullable=False),
+            T.StructField(time_col,   T.DateType(),   nullable=False),
             T.StructField("forecast", T.DoubleType(), nullable=True),
         ])
 
         def _forecast_partition(pdf):
-            """
-            Called once per series partition.  Runs entirely on the executor.
-            """
+            """Called once per series partition.  Runs entirely on the executor."""
+            import pandas as pd
             import polars as pl
             from src.forecasting.registry import registry
 
-            cfg, model_name, h, id_c, time_c, tgt_c = pickle.loads(config_bytes.value)
-
+            p = params_bc.value
             if pdf.empty:
-                import pandas as pd
-                return pd.DataFrame(columns=[id_c, time_c, "forecast"])
+                return pd.DataFrame(columns=[p["id_col"], p["time_col"], "forecast"])
 
             series = pl.from_pandas(pdf)
-
-            forecaster = registry.build(model_name)
-            forecaster.fit(series, target_col=tgt_c, time_col=time_c, id_col=id_c)
-            result = forecaster.predict(horizon=h, id_col=id_c, time_col=time_c)
+            forecaster = registry.build(p["model_name"])
+            forecaster.fit(series, target_col=p["target_col"],
+                           time_col=p["time_col"], id_col=p["id_col"])
+            result = forecaster.predict(horizon=p["horizon"],
+                                        id_col=p["id_col"], time_col=p["time_col"])
             return result.to_pandas()
 
         actuals_sdf = repartition_by_series(actuals_sdf, id_col, num_partitions)
         forecasts_sdf = actuals_sdf.groupby(id_col).applyInPandas(
             _forecast_partition, schema=output_schema
         )
-        logger.info("SparkForecastPipeline.run_forecast launched (model=%s, horizon=%d)", champion_model, horizon)
+        logger.info(
+            "SparkForecastPipeline.run_forecast launched (model=%s, horizon=%d)",
+            champion_model, horizon,
+        )
         return forecasts_sdf
 
     # ── backtest ──────────────────────────────────────────────────────────────
@@ -150,21 +173,27 @@ class SparkForecastPipeline:
 
         Returns
         -------
-        Spark DataFrame: [series_id, model, fold, wmape, normalized_bias, …].
+        Spark DataFrame: [series_id, model, fold, wmape, normalized_bias, mae].
         """
-        from pyspark.sql import functions as F, types as T
+        from pyspark.sql import types as T
         from .utils import repartition_by_series
 
-        fc = self.config.forecast
-        bt = self.config.backtest
-        id_col = fc.series_id_column
-        time_col = fc.time_column
-        target_col = fc.target_column
-        model_names = model_names or fc.forecasters
+        model_names = model_names or self.config.forecast.forecasters
 
-        config_bytes = self.spark.sparkContext.broadcast(
-            pickle.dumps((self.config, model_names, id_col, time_col, target_col))
-        )
+        # Plain-scalar params dict — no config object on the wire.
+        params = {
+            "model_names": list(model_names),
+            "id_col":      self.config.forecast.series_id_column,
+            "time_col":    self.config.forecast.time_column,
+            "target_col":  self.config.forecast.target_column,
+            "n_folds":     self.config.backtest.n_folds,
+            "val_weeks":   self.config.backtest.val_weeks,
+            "gap_weeks":   self.config.backtest.gap_weeks,
+        }
+        params_bc = self.spark.sparkContext.broadcast(params)
+
+        id_col   = params["id_col"]
+        time_col = params["time_col"]
 
         output_schema = T.StructType([
             T.StructField(id_col,            T.StringType(),  nullable=False),
@@ -176,27 +205,29 @@ class SparkForecastPipeline:
         ])
 
         def _backtest_partition(pdf):
-            """Per-series backtest.  Runs on executor."""
+            """Per-series backtest.  Runs entirely on the executor."""
+            import numpy as np
             import pandas as pd
             import polars as pl
-            import numpy as np
             from src.forecasting.registry import registry
 
-            cfg, models, id_c, time_c, tgt_c = pickle.loads(config_bytes.value)
-            bt_cfg = cfg.backtest
+            p = params_bc.value
+            id_c, time_c, tgt_c = p["id_col"], p["time_col"], p["target_col"]
 
             if pdf.empty:
-                return pd.DataFrame(columns=[id_c, "model", "fold", "wmape", "normalized_bias", "mae"])
+                return pd.DataFrame(
+                    columns=[id_c, "model", "fold", "wmape", "normalized_bias", "mae"]
+                )
 
             series = pl.from_pandas(pdf).sort(time_c)
             n = len(series)
             rows = []
 
-            for model_name in models:
-                for fold in range(bt_cfg.n_folds):
-                    val_end   = n - fold * bt_cfg.val_weeks
-                    val_start = val_end - bt_cfg.val_weeks
-                    train_end = val_start - bt_cfg.gap_weeks
+            for model_name in p["model_names"]:
+                for fold in range(p["n_folds"]):
+                    val_end   = n - fold * p["val_weeks"]
+                    val_start = val_end - p["val_weeks"]
+                    train_end = val_start - p["gap_weeks"]
 
                     if train_end < 10 or val_start < 0:
                         continue
@@ -206,11 +237,10 @@ class SparkForecastPipeline:
 
                     try:
                         forecaster = registry.build(model_name)
-                        forecaster.fit(train, target_col=tgt_c, time_col=time_c, id_col=id_c)
+                        forecaster.fit(train, target_col=tgt_c,
+                                       time_col=time_c, id_col=id_c)
                         preds = forecaster.predict(
-                            horizon=bt_cfg.val_weeks,
-                            id_col=id_c,
-                            time_col=time_c,
+                            horizon=p["val_weeks"], id_col=id_c, time_col=time_c
                         )
 
                         actual_vals = val[tgt_c].to_numpy().astype(float)
@@ -219,10 +249,10 @@ class SparkForecastPipeline:
                         actual_vals = actual_vals[:min_len]
                         pred_vals   = pred_vals[:min_len]
 
-                        denom = np.sum(np.abs(actual_vals))
-                        wmape = float(np.sum(np.abs(actual_vals - pred_vals)) / denom) if denom else None
+                        denom     = np.sum(np.abs(actual_vals))
+                        wmape     = float(np.sum(np.abs(actual_vals - pred_vals)) / denom) if denom else None
                         norm_bias = float(np.sum(actual_vals - pred_vals) / denom) if denom else None
-                        mae = float(np.mean(np.abs(actual_vals - pred_vals)))
+                        mae       = float(np.mean(np.abs(actual_vals - pred_vals)))
 
                         series_id_val = pdf[id_c].iloc[0] if id_c in pdf.columns else "unknown"
                         rows.append({
@@ -234,12 +264,18 @@ class SparkForecastPipeline:
                             "mae":             mae,
                         })
                     except Exception as exc:
-                        logger.warning("Backtest failed for series %s model %s fold %d: %s",
-                                       pdf[id_c].iloc[0] if id_c in pdf.columns else "?",
-                                       model_name, fold, exc)
+                        series_id_val = pdf[id_c].iloc[0] if id_c in pdf.columns else "?"
+                        logger.warning(
+                            "Backtest failed — series=%s model=%s fold=%d: %s",
+                            series_id_val, model_name, fold, exc,
+                        )
 
-            return pd.DataFrame(rows) if rows else pd.DataFrame(
-                columns=[id_c, "model", "fold", "wmape", "normalized_bias", "mae"]
+            return (
+                pd.DataFrame(rows)
+                if rows
+                else pd.DataFrame(
+                    columns=[id_c, "model", "fold", "wmape", "normalized_bias", "mae"]
+                )
             )
 
         actuals_sdf = repartition_by_series(actuals_sdf, id_col, num_partitions)
@@ -256,21 +292,28 @@ class SparkForecastPipeline:
 
     def select_champion(self, backtest_results_sdf, primary_metric: str = "wmape"):
         """
-        Aggregate backtest results and select the champion model per LOB.
+        Aggregate backtest results and select the champion model.
+
+        Fully distributed — all aggregation and ranking runs on Spark
+        executors.  No ``collect()`` call here.
 
         Parameters
         ----------
         backtest_results_sdf:
             Output of ``run_backtest``.
         primary_metric:
-            Metric column to minimise for champion selection.
+            Metric column to minimise for champion selection
+            (``"wmape"`` | ``"mae"`` | ``"normalized_bias"``).
 
         Returns
         -------
-        Spark DataFrame: [model, mean_wmape, mean_normalized_bias, mean_mae, rank].
+        Spark DataFrame: [model, mean_wmape, mean_normalized_bias, mean_mae,
+                          n_evals, rank].
         """
         from pyspark.sql import functions as F
         from pyspark.sql.window import Window
+
+        metric_col = f"mean_{primary_metric}"
 
         leaderboard = (
             backtest_results_sdf
@@ -283,7 +326,7 @@ class SparkForecastPipeline:
             )
             .withColumn(
                 "rank",
-                F.rank().over(Window.orderBy(F.col(f"mean_{primary_metric}").asc_nulls_last())),
+                F.rank().over(Window.orderBy(F.col(metric_col).asc_nulls_last())),
             )
             .orderBy("rank")
         )

--- a/forecasting-platform/src/spark/series_builder.py
+++ b/forecasting-platform/src/spark/series_builder.py
@@ -1,0 +1,144 @@
+"""
+SparkSeriesBuilder — configurable mapping from raw actuals to the canonical
+series schema expected by SparkForecastPipeline.
+
+The canonical schema has three columns:
+  series_id  (string)  — unique identifier per time series
+  week       (date)    — period start date, truncated to the configured frequency
+  quantity   (double)  — forecast target, summed over the period
+
+All LOB-specific column names are driven by ``fabric_config.yaml``
+(the ``series_builder`` section), so notebooks and scripts contain zero
+hard-coded source column references.
+
+Usage
+-----
+>>> import yaml
+>>> raw = yaml.safe_load(open("configs/fabric_config.yaml"))
+>>> builder = SparkSeriesBuilder.from_config(raw["series_builder"])
+>>> series_sdf = builder.build(actuals_sdf)
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SeriesBuilderConfig:
+    """
+    Mapping from raw actuals columns to the canonical series schema.
+
+    Attributes
+    ----------
+    source_id_cols:
+        One or more columns whose values are concatenated (with ``_``) to
+        form the ``series_id`` string.
+        Examples:
+          - Rossmann: ``["Store"]``
+          - Surface:  ``["product_unit", "country", "channel"]``
+    date_col:
+        Name of the date column in the raw actuals table.
+    target_col:
+        Numeric column that is summed to produce ``quantity``.
+    filter_expr:
+        Optional Spark SQL WHERE predicate applied before aggregation.
+        Example: ``"Open = 1"`` (Rossmann) or ``"status = 'shipped'"``.
+    frequency:
+        ``date_trunc`` argument for the time period.
+        ``"week"`` → Monday-aligned ISO weeks.
+        ``"month"`` → first day of month.
+    """
+    source_id_cols: List[str] = field(default_factory=lambda: ["Store"])
+    date_col: str = "Date"
+    target_col: str = "Sales"
+    filter_expr: Optional[str] = None
+    frequency: str = "week"
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "SeriesBuilderConfig":
+        return cls(
+            source_id_cols=d.get("source_id_cols", ["Store"]),
+            date_col=d.get("date_col", "Date"),
+            target_col=d.get("target_col", "Sales"),
+            filter_expr=d.get("filter_expr") or None,
+            frequency=d.get("frequency", "week"),
+        )
+
+
+class SparkSeriesBuilder:
+    """
+    Transforms a raw actuals Spark DataFrame into the canonical
+    [series_id, week, quantity] panel format.
+
+    Parameters
+    ----------
+    config:
+        ``SeriesBuilderConfig`` describing the column mapping.
+    """
+
+    def __init__(self, config: SeriesBuilderConfig):
+        self.config = config
+
+    @classmethod
+    def from_config(cls, cfg_dict: dict) -> "SparkSeriesBuilder":
+        """Build from the ``series_builder`` dict in fabric_config.yaml."""
+        return cls(SeriesBuilderConfig.from_dict(cfg_dict))
+
+    def build(self, df):
+        """
+        Apply filter, build ``series_id``, truncate to period, and aggregate.
+
+        Parameters
+        ----------
+        df:
+            Raw actuals Spark DataFrame.
+
+        Returns
+        -------
+        Spark DataFrame with columns [series_id, <frequency>, quantity],
+        where the time column name matches ``platform_config.forecast.time_column``
+        (default: ``"week"``).
+        """
+        from pyspark.sql import functions as F
+
+        cfg = self.config
+
+        # ── 1. Optional row filter ─────────────────────────────────────────
+        if cfg.filter_expr:
+            df = df.filter(cfg.filter_expr)
+            logger.debug("Applied filter: %s", cfg.filter_expr)
+
+        # ── 2. Build series_id from one or more source columns ─────────────
+        if len(cfg.source_id_cols) == 1:
+            df = df.withColumn("series_id", F.col(cfg.source_id_cols[0]).cast("string"))
+        else:
+            # Concatenate multiple columns with "_" separator
+            concat_expr = F.concat_ws(
+                "_", *[F.col(c).cast("string") for c in cfg.source_id_cols]
+            )
+            df = df.withColumn("series_id", concat_expr)
+
+        logger.debug("series_id built from: %s", cfg.source_id_cols)
+
+        # ── 3. Truncate date to configured frequency ───────────────────────
+        time_col = cfg.frequency  # "week" or "month" → becomes the output column name
+        df = df.withColumn(time_col, F.date_trunc(cfg.frequency, F.col(cfg.date_col)))
+
+        # ── 4. Aggregate target to period grain ────────────────────────────
+        series_sdf = (
+            df
+            .groupby("series_id", time_col)
+            .agg(F.sum(F.col(cfg.target_col)).alias("quantity"))
+            .orderBy("series_id", time_col)
+        )
+
+        n_series = series_sdf.select("series_id").distinct().count()
+        n_rows   = series_sdf.count()
+        logger.info(
+            "SparkSeriesBuilder.build: %d series, %d rows (filter=%r, id_cols=%s)",
+            n_series, n_rows, cfg.filter_expr, cfg.source_id_cols,
+        )
+        return series_sdf


### PR DESCRIPTION
1. Notebook syntax bug (02_backtest.py) Invalid `from pyspark.sql import functions as F as _F` replaced with a clean import; all _F references updated to use the already-imported F.

2. Pickle safety in applyInPandas broadcast pipeline.py no longer broadcasts the full PlatformConfig object. Only plain Python scalars (strings + ints) are serialised into the broadcast dict, eliminating failures caused by live DuckDB connections or file handles that may be attached to the config on the driver.

3. Configurable series ID construction (SparkSeriesBuilder) Hard-coded Rossmann column references (Store → series_id, Date → week, Sales → quantity, Open = 1 filter) have been removed from all three notebooks and both CLI scripts.  A new SparkSeriesBuilder class reads the mapping from fabric_config.yaml → series_builder, making the pipeline LOB-agnostic with a one-line config change.

4. Partition pruning on Delta reads (FabricLakehouse.read_table) read_table() now accepts date_col, start_date, end_date, and partition_filter parameters.  Filters are pushed into the Delta scan so only matching files are read, avoiding full-table scans on large multi-year tables.

5. Champion selection collect() safety (spark_forecast.py) .collect()[0][0] replaced with .first() + explicit None guard so a missing leaderboard row raises a clear RuntimeError instead of an IndexError with no context.

https://claude.ai/code/session_01U8RCtLVxpzc8YR6xe4rgKu