### PR TITLE
Phase 2 item 8: REST API serving layer — Phase 2 complete

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -365,6 +365,20 @@ All metrics defined in `src/metrics/definitions.py`.
 | `scripts/run_sku_mapping.py` | `python run_sku_mapping.py --config configs/sku_mapping_config.yaml` | SKU discovery, writes mapping CSV |
 | `scripts/spark_forecast.py` | `spark-submit spark_forecast.py` | Distributed forecast on Spark |
 | `scripts/spark_backtest.py` | `spark-submit spark_backtest.py` | Distributed backtest on Spark |
+| `scripts/spark_deploy.py`   | `spark-submit spark_deploy.py --lob rossmann` | Unified deploy: pre-flight → backtest → forecast → audit |
+| `scripts/serve.py`          | `python serve.py --port 8000`  | REST API server (uvicorn) |
+
+### REST API Endpoints (`src/api/`)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Liveness probe — returns `{"status": "ok"}` |
+| GET | `/forecast/{lob}` | Latest forecasts for a LOB (query: `series_id`, `horizon`) |
+| GET | `/forecast/{lob}/{series_id}` | Latest forecast for a single series |
+| GET | `/metrics/leaderboard/{lob}` | Model leaderboard from metric store |
+| GET | `/metrics/drift/{lob}` | Drift alerts (accuracy, bias, volume) |
+
+OpenAPI docs auto-generated at `/docs`. Response schemas in `src/api/schemas.py`.
 
 ---
 
@@ -410,7 +424,7 @@ pytest tests/ -v
 - [x] Enhanced proportion estimation (Bayesian)
 - [x] Production Fabric deployment pipeline
 - [x] Monitoring & drift detection
-- [ ] REST API / serving layer
+- [x] REST API / serving layer
 
 ---
 
@@ -426,6 +440,7 @@ pytest tests/ -v
 | 2026-03-12 | 0.6.0 | Phase 2 — Bayesian proportion estimation: `BayesianProportionEstimator` replaces equal-split fallback for 1-to-Many, Many-to-1, and Many-to-Many mappings using Dirichlet-Bayes formula. Integrated into `CandidateFusion` and `build_phase2_pipeline()`. 11 new tests. |
 | 2026-03-12 | 0.7.0 | Phase 2 — Production Fabric deployment pipeline: `DeploymentOrchestrator` chains backtest→champion→forecast with pre-flight validation (data freshness, series count), post-run checks (forecast row count), and audit logging to `deploy_log` Delta table. New `spark_deploy.py` unified CLI entry point. 12 new tests. |
 | 2026-03-12 | 0.8.0 | Phase 2 — Monitoring & drift detection: `ForecastDriftDetector` detects accuracy drift (WMAPE ratio), bias drift (normalised bias threshold), and volume anomalies (z-score) with configurable WARNING/CRITICAL severity levels. `summary()` returns Polars DataFrame. 12 new tests. |
+| 2026-03-12 | 0.9.0 | Phase 2 — REST API serving layer: FastAPI app with `/health`, `/forecast/{lob}`, `/forecast/{lob}/{series_id}`, `/metrics/leaderboard/{lob}`, `/metrics/drift/{lob}` endpoints. Pydantic response schemas, auto-generated OpenAPI docs at `/docs`. `scripts/serve.py` uvicorn entry point. 10 new tests. Phase 2 complete. |
 
 ---
 

--- a/forecasting-platform/scripts/serve.py
+++ b/forecasting-platform/scripts/serve.py
@@ -1,0 +1,76 @@
+"""
+serve.py — Start the forecasting platform REST API server.
+
+Usage
+-----
+python scripts/serve.py
+python scripts/serve.py --port 8080 --data-dir data/ --metrics-dir data/metrics/
+python scripts/serve.py --host 0.0.0.0 --port 8000 --reload   # dev mode
+
+Environment variable overrides
+-------------------------------
+API_DATA_DIR      Path to data directory.
+API_METRICS_DIR   Path to metrics store.
+API_VERSION       Version string embedded in /health.
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent.parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s — %(message)s",
+)
+logger = logging.getLogger("serve")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Forecasting Platform REST API server")
+    p.add_argument("--host",        default="0.0.0.0",  help="Bind host")
+    p.add_argument("--port",        type=int, default=8000, help="Bind port")
+    p.add_argument("--data-dir",    default=os.environ.get("API_DATA_DIR", "data/"),
+                   help="Root data directory for forecasts")
+    p.add_argument("--metrics-dir", default=os.environ.get("API_METRICS_DIR", "data/metrics/"),
+                   help="Metrics store directory")
+    p.add_argument("--reload",      action="store_true", help="Enable hot-reload (dev mode)")
+    p.add_argument("--workers",     type=int, default=1,
+                   help="Number of Uvicorn worker processes (production)")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Patch environment so create_app picks up the right directories
+    os.environ["API_DATA_DIR"]    = args.data_dir
+    os.environ["API_METRICS_DIR"] = args.metrics_dir
+
+    from src.api.app import create_app
+    import uvicorn
+
+    app = create_app(data_dir=args.data_dir, metrics_dir=args.metrics_dir)
+
+    logger.info("Starting Forecasting Platform API on %s:%d", args.host, args.port)
+    logger.info("  data_dir    = %s", args.data_dir)
+    logger.info("  metrics_dir = %s", args.metrics_dir)
+    logger.info("  Swagger UI  = http://%s:%d/docs", args.host, args.port)
+
+    uvicorn.run(
+        app,
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        workers=args.workers if not args.reload else 1,
+        log_level="info",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/forecasting-platform/src/api/__init__.py
+++ b/forecasting-platform/src/api/__init__.py
@@ -1,0 +1,19 @@
+"""
+REST API / serving layer for the forecasting platform.
+
+Modules
+-------
+schemas     Pydantic response models for all API endpoints.
+app         FastAPI application with routes.
+"""
+
+from .app import create_app  # noqa: F401
+from .schemas import (  # noqa: F401
+    ForecastPoint,
+    ForecastResponse,
+    LeaderboardEntry,
+    LeaderboardResponse,
+    DriftAlertItem,
+    DriftResponse,
+    HealthResponse,
+)

--- a/forecasting-platform/src/api/app.py
+++ b/forecasting-platform/src/api/app.py
@@ -1,0 +1,265 @@
+"""
+Forecasting Platform REST API
+(Design document §13 / Phase 2)
+
+Exposes forecast results, model leaderboards, and drift alerts over HTTP.
+Built with FastAPI — auto-generates OpenAPI (Swagger) docs at /docs.
+
+Endpoints
+---------
+GET  /health                         Liveness probe.
+GET  /forecast/{lob}                 Latest forecasts for a LOB.
+GET  /forecast/{lob}/{series_id}     Latest forecast for a specific series.
+GET  /metrics/leaderboard/{lob}      Model leaderboard from metric store.
+GET  /metrics/drift/{lob}            Drift alerts for a LOB.
+
+Usage
+-----
+>>> from src.api.app import create_app
+>>> app = create_app(data_dir="data/", metrics_dir="data/metrics/")
+
+Or via scripts/serve.py:
+    python scripts/serve.py --port 8000 --data-dir data/
+
+Environment variables
+---------------------
+API_DATA_DIR      Path to local data directory (default: data/).
+API_METRICS_DIR   Path to metrics store (default: data/metrics/).
+API_VERSION       Version string embedded in /health (default: "1.0.0").
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Query
+
+from .schemas import (
+    DriftAlertItem,
+    DriftResponse,
+    ForecastPoint,
+    ForecastResponse,
+    HealthResponse,
+    LeaderboardEntry,
+    LeaderboardResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+_API_VERSION = os.environ.get("API_VERSION", "1.0.0")
+
+
+def create_app(
+    data_dir: str = "data/",
+    metrics_dir: str = "data/metrics/",
+    title: str = "Forecasting Platform API",
+) -> FastAPI:
+    """
+    Factory function — returns a configured FastAPI application.
+
+    Parameters
+    ----------
+    data_dir:
+        Root directory for forecast Parquet files.
+        Structure: ``{data_dir}/forecasts/{lob}/forecast_*.parquet``.
+    metrics_dir:
+        Root directory for the MetricStore Parquet partitions.
+    title:
+        Application title (appears in /docs).
+    """
+    app = FastAPI(
+        title=title,
+        description=(
+            "REST API for the forecasting platform. "
+            "Serves forecast results, model leaderboards, and drift alerts."
+        ),
+        version=_API_VERSION,
+        docs_url="/docs",
+        redoc_url="/redoc",
+    )
+
+    # ── Shared state (attached to app for testability) ─────────────────────
+    app.state.data_dir    = Path(data_dir)
+    app.state.metrics_dir = Path(metrics_dir)
+
+    # ── Routes ─────────────────────────────────────────────────────────────
+
+    @app.get("/health", response_model=HealthResponse, tags=["system"])
+    def health():
+        """Liveness probe — returns 200 OK when the service is running."""
+        return HealthResponse(status="ok", version=_API_VERSION)
+
+    @app.get("/forecast/{lob}", response_model=ForecastResponse, tags=["forecasts"])
+    def get_forecast(
+        lob: str,
+        series_id: Optional[str] = Query(None, description="Filter to a single series"),
+        horizon: Optional[int] = Query(None, description="Limit output to first N weeks"),
+    ):
+        """
+        Return the latest forecast Parquet file for a LOB.
+
+        Reads the most recently written ``forecast_*.parquet`` under
+        ``{data_dir}/forecasts/{lob}/``.
+        """
+        forecast_dir = app.state.data_dir / "forecasts" / lob
+        if not forecast_dir.exists():
+            raise HTTPException(
+                status_code=404,
+                detail=f"No forecast data found for LOB '{lob}'. "
+                       f"Expected directory: {forecast_dir}",
+            )
+
+        parquet_files = sorted(forecast_dir.glob("forecast_*.parquet"))
+        if not parquet_files:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No forecast Parquet files in {forecast_dir}.",
+            )
+
+        import polars as pl
+        df = pl.read_parquet(parquet_files[-1])   # most recent
+
+        if series_id:
+            df = df.filter(pl.col("series_id") == series_id)
+            if df.is_empty():
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"series_id '{series_id}' not found in LOB '{lob}'.",
+                )
+
+        if horizon:
+            df = df.sort("week").head(horizon * df["series_id"].n_unique())
+
+        points = [
+            ForecastPoint(
+                series_id=row["series_id"],
+                week=row["week"],
+                forecast=float(row["forecast"]),
+                model=row.get("model"),
+                lob=lob,
+            )
+            for row in df.iter_rows(named=True)
+        ]
+
+        return ForecastResponse(
+            lob=lob,
+            series_count=df["series_id"].n_unique(),
+            forecast_origin=parquet_files[-1].stem.replace(f"forecast_{lob}_", ""),
+            points=points,
+        )
+
+    @app.get(
+        "/forecast/{lob}/{series_id}",
+        response_model=ForecastResponse,
+        tags=["forecasts"],
+    )
+    def get_forecast_series(lob: str, series_id: str):
+        """Return the latest forecast for a single series within a LOB."""
+        return get_forecast(lob=lob, series_id=series_id, horizon=None)
+
+    @app.get(
+        "/metrics/leaderboard/{lob}",
+        response_model=LeaderboardResponse,
+        tags=["metrics"],
+    )
+    def get_leaderboard(
+        lob: str,
+        run_type: str = Query("backtest", description="'backtest' or 'live'"),
+    ):
+        """
+        Return the model leaderboard for a LOB from the metric store.
+
+        Models are ranked by WMAPE (ascending).
+        """
+        from ..metrics.store import MetricStore
+
+        store = MetricStore(str(app.state.metrics_dir))
+        try:
+            df = store.leaderboard(lob=lob, run_type=run_type)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to read leaderboard: {exc}",
+            )
+
+        if df.is_empty():
+            raise HTTPException(
+                status_code=404,
+                detail=f"No leaderboard data found for LOB '{lob}' (run_type={run_type}).",
+            )
+
+        entries = [
+            LeaderboardEntry(
+                model=row["model_id"],
+                wmape=float(row["wmape"]),
+                normalized_bias=float(row.get("normalized_bias", 0.0) or 0.0),
+                rank=int(row.get("rank", i + 1)),
+                n_series=int(row.get("n_series", 0) or 0),
+            )
+            for i, row in enumerate(df.iter_rows(named=True))
+        ]
+
+        return LeaderboardResponse(lob=lob, run_type=run_type, entries=entries)
+
+    @app.get(
+        "/metrics/drift/{lob}",
+        response_model=DriftResponse,
+        tags=["metrics"],
+    )
+    def get_drift(
+        lob: str,
+        run_type: str = Query("backtest", description="'backtest' or 'live'"),
+        baseline_weeks: int = Query(26, ge=4),
+        recent_weeks:   int = Query(8,  ge=2),
+    ):
+        """
+        Return drift alerts for all series in a LOB.
+
+        Reads the metric store, runs ``ForecastDriftDetector``, and returns
+        any accuracy / bias / volume alerts.
+        """
+        from ..metrics.store import MetricStore
+        from ..metrics.drift import DriftConfig, ForecastDriftDetector
+
+        store = MetricStore(str(app.state.metrics_dir))
+        try:
+            df = store.read(lob=lob, run_type=run_type)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to read metric store: {exc}",
+            )
+
+        if df is None or df.is_empty():
+            raise HTTPException(
+                status_code=404,
+                detail=f"No metric data found for LOB '{lob}' (run_type={run_type}).",
+            )
+
+        cfg = DriftConfig(baseline_weeks=baseline_weeks, recent_weeks=recent_weeks)
+        detector = ForecastDriftDetector(cfg)
+        alerts = detector.detect(df)
+
+        alert_items = [
+            DriftAlertItem(
+                series_id=a.series_id,
+                metric=a.metric,
+                severity=a.severity.value,
+                current_value=a.current_value,
+                baseline_value=a.baseline_value,
+                message=a.message,
+            )
+            for a in alerts
+        ]
+
+        return DriftResponse(
+            lob=lob,
+            n_critical=sum(1 for a in alerts if a.severity.value == "critical"),
+            n_warning=sum(1 for a in alerts if a.severity.value == "warning"),
+            alerts=alert_items,
+        )
+
+    return app

--- a/forecasting-platform/src/api/schemas.py
+++ b/forecasting-platform/src/api/schemas.py
@@ -1,0 +1,63 @@
+"""
+Pydantic response models for the forecasting platform REST API.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class HealthResponse(BaseModel):
+    status: str = Field(description="'ok' when the service is healthy")
+    version: str = Field(description="API version string")
+
+
+class ForecastPoint(BaseModel):
+    """A single (series, week, forecast) data point."""
+    series_id: str
+    week: date
+    forecast: float
+    model: Optional[str] = None
+    lob: Optional[str] = None
+
+
+class ForecastResponse(BaseModel):
+    lob: str
+    series_count: int
+    forecast_origin: Optional[str] = None
+    points: List[ForecastPoint]
+
+
+class LeaderboardEntry(BaseModel):
+    """One model's aggregated performance metrics."""
+    model: str
+    wmape: float
+    normalized_bias: float
+    rank: int
+    n_series: int
+
+
+class LeaderboardResponse(BaseModel):
+    lob: str
+    run_type: str
+    entries: List[LeaderboardEntry]
+
+
+class DriftAlertItem(BaseModel):
+    """One drift alert for a series/metric pair."""
+    series_id: str
+    metric: str
+    severity: str     # "warning" | "critical"
+    current_value: float
+    baseline_value: float
+    message: str
+
+
+class DriftResponse(BaseModel):
+    lob: str
+    n_critical: int
+    n_warning: int
+    alerts: List[DriftAlertItem]

--- a/forecasting-platform/tests/test_platform.py
+++ b/forecasting-platform/tests/test_platform.py
@@ -1374,3 +1374,140 @@ class TestForecastDriftDetector:
         warn_indices = [i for i, s in enumerate(severities) if s == "warning"]
         if crit_indices and warn_indices:
             assert max(crit_indices) < min(warn_indices)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# REST API tests (Phase 2 item 8)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestRestApi:
+    """
+    Tests for the FastAPI serving layer using the TestClient (no network I/O).
+    """
+
+    def _make_app(self, tmpdir: str):
+        """Create a test app pointing at a temp directory."""
+        from src.api.app import create_app
+        return create_app(data_dir=tmpdir, metrics_dir=os.path.join(tmpdir, "metrics"))
+
+    def _write_forecast_parquet(self, tmpdir: str, lob: str):
+        """Write a minimal forecast Parquet to the expected location."""
+        import polars as pl
+        from datetime import date, timedelta
+
+        forecast_dir = Path(tmpdir) / "forecasts" / lob
+        forecast_dir.mkdir(parents=True, exist_ok=True)
+
+        rows = []
+        for i in range(4):
+            rows.append({
+                "series_id": "S1",
+                "week": date(2026, 1, 1) + timedelta(weeks=i),
+                "forecast": 100.0 + i * 5,
+                "model": "naive_seasonal",
+            })
+        df = pl.DataFrame(rows)
+        df.write_parquet(str(forecast_dir / f"forecast_{lob}_2026-01-01.parquet"))
+
+    def test_health_endpoint_returns_ok(self):
+        """GET /health should return status='ok' and a version string."""
+        from fastapi.testclient import TestClient
+        app = self._make_app("/tmp/test_api_health")
+        client = TestClient(app)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert "version" in data
+
+    def test_forecast_endpoint_returns_200(self):
+        """GET /forecast/{lob} should return forecast points when data exists."""
+        from fastapi.testclient import TestClient
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_forecast_parquet(tmpdir, "rossmann")
+            app = self._make_app(tmpdir)
+            client = TestClient(app)
+            resp = client.get("/forecast/rossmann")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["lob"] == "rossmann"
+        assert data["series_count"] == 1
+        assert len(data["points"]) == 4
+
+    def test_forecast_endpoint_404_when_no_data(self):
+        """GET /forecast/{lob} should return 404 when no forecast data exists."""
+        from fastapi.testclient import TestClient
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(tmpdir)
+            client = TestClient(app)
+            resp = client.get("/forecast/unknown_lob")
+        assert resp.status_code == 404
+
+    def test_forecast_series_filter(self):
+        """GET /forecast/{lob}?series_id=S1 should filter to that series."""
+        from fastapi.testclient import TestClient
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_forecast_parquet(tmpdir, "rossmann")
+            app = self._make_app(tmpdir)
+            client = TestClient(app)
+            resp = client.get("/forecast/rossmann?series_id=S1")
+        assert resp.status_code == 200
+        assert all(p["series_id"] == "S1" for p in resp.json()["points"])
+
+    def test_forecast_series_404_for_unknown_series(self):
+        """series_id that doesn't exist should return 404."""
+        from fastapi.testclient import TestClient
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_forecast_parquet(tmpdir, "rossmann")
+            app = self._make_app(tmpdir)
+            client = TestClient(app)
+            resp = client.get("/forecast/rossmann?series_id=NONEXISTENT")
+        assert resp.status_code == 404
+
+    def test_forecast_horizon_filter(self):
+        """horizon query param should limit the number of returned weeks."""
+        from fastapi.testclient import TestClient
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_forecast_parquet(tmpdir, "rossmann")
+            app = self._make_app(tmpdir)
+            client = TestClient(app)
+            resp = client.get("/forecast/rossmann?horizon=2")
+        assert resp.status_code == 200
+        assert len(resp.json()["points"]) == 2
+
+    def test_forecast_series_path_param(self):
+        """GET /forecast/{lob}/{series_id} path param should work."""
+        from fastapi.testclient import TestClient
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_forecast_parquet(tmpdir, "rossmann")
+            app = self._make_app(tmpdir)
+            client = TestClient(app)
+            resp = client.get("/forecast/rossmann/S1")
+        assert resp.status_code == 200
+        assert resp.json()["series_count"] == 1
+
+    def test_leaderboard_404_when_no_metrics(self):
+        """GET /metrics/leaderboard/{lob} should return 404 when no data."""
+        from fastapi.testclient import TestClient
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(tmpdir)
+            client = TestClient(app)
+            resp = client.get("/metrics/leaderboard/rossmann")
+        assert resp.status_code == 404
+
+    def test_drift_404_when_no_metrics(self):
+        """GET /metrics/drift/{lob} should return 404 when no data."""
+        from fastapi.testclient import TestClient
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(tmpdir)
+            client = TestClient(app)
+            resp = client.get("/metrics/drift/rossmann")
+        assert resp.status_code == 404
+
+    def test_openapi_docs_available(self):
+        """The /docs endpoint should return 200 (Swagger UI)."""
+        from fastapi.testclient import TestClient
+        app = self._make_app("/tmp/test_api_docs")
+        client = TestClient(app)
+        resp = client.get("/docs")
+        assert resp.status_code == 200

--- a/forecasting-platform/tests/test_sku_mapping.py
+++ b/forecasting-platform/tests/test_sku_mapping.py
@@ -684,11 +684,11 @@ class TestPhase2Pipeline:
         df = pipeline.run(pm)
         assert isinstance(df, pl.DataFrame)
 
-    def test_phase2_pipeline_has_three_methods(self):
+    def test_phase2_pipeline_has_four_methods(self):
         pipeline = build_phase2_pipeline()
-        assert len(pipeline.methods) == 3
+        assert len(pipeline.methods) == 4
         names = {m.name for m in pipeline.methods}
-        assert names == {"attribute", "naming", "curve"}
+        assert names == {"attribute", "naming", "curve", "temporal"}
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
FastAPI application exposing forecast results, model leaderboards, and drift alerts over HTTP with auto-generated OpenAPI docs.

- New: src/api/app.py — FastAPI app with 5 endpoints
  - GET /health — liveness probe
  - GET /forecast/{lob} — latest forecasts (filter by series_id, horizon)
  - GET /forecast/{lob}/{series_id} — single-series forecast
  - GET /metrics/leaderboard/{lob} — model leaderboard
  - GET /metrics/drift/{lob} — accuracy/bias/volume drift alerts
- New: src/api/schemas.py — Pydantic response models
- New: src/api/__init__.py
- New: scripts/serve.py — uvicorn entry point
- Fixed: test_phase2_pipeline_has_three_methods → four methods
- 10 new API tests, all passing (166 total)
- SPEC.md updated to v0.9.0 — Phase 2 roadmap fully complete

https://claude.ai/code/session_01U8RCtLVxpzc8YR6xe4rgKu