### PR TITLE
Add P1-P3 test coverage: 7 new test files, fix 10 failing API tests

### DIFF
--- a/forecasting-platform/requirements.txt
+++ b/forecasting-platform/requirements.txt
@@ -26,6 +26,7 @@ seaborn>=0.11.0
 
 # ── Testing ──────────────────────────────────────────────────────────────────
 pytest>=7.0.0
+httpx>=0.23.0
 
 # ── Spark / Microsoft Fabric layer ──────────────────────────────────────────
 # PySpark (use the version that matches your Fabric Spark runtime)

--- a/forecasting-platform/tests/test_data_loader.py
+++ b/forecasting-platform/tests/test_data_loader.py
@@ -1,0 +1,91 @@
+"""
+Tests for DataLoader — src/data/loader.py.
+
+Covers:
+  - load_train / load_test / load_store
+  - load_all returns 3-tuple
+  - merge_with_store
+  - missing file raises FileNotFoundError
+  - date column parsing
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+
+def _write_csv(path: Path, content: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class TestDataLoader(unittest.TestCase):
+
+    def _make_loader(self, tmpdir: str):
+        from src.data.loader import DataLoader
+        return DataLoader(tmpdir)
+
+    def test_load_train(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_csv(
+                Path(tmpdir) / "train.csv",
+                "Date,Store,Sales\n2024-01-01,1,100\n2024-01-02,2,200\n",
+            )
+            loader = self._make_loader(tmpdir)
+            df = loader.load_train()
+            self.assertEqual(len(df), 2)
+            self.assertTrue(pd.api.types.is_datetime64_any_dtype(df["Date"]))
+
+    def test_load_test(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_csv(
+                Path(tmpdir) / "test.csv",
+                "Date,Store,Id\n2024-02-01,1,1\n2024-02-02,2,2\n",
+            )
+            loader = self._make_loader(tmpdir)
+            df = loader.load_test()
+            self.assertEqual(len(df), 2)
+            self.assertTrue(pd.api.types.is_datetime64_any_dtype(df["Date"]))
+
+    def test_load_store(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_csv(
+                Path(tmpdir) / "store.csv",
+                "Store,StoreType,Assortment\n1,a,a\n2,b,b\n",
+            )
+            loader = self._make_loader(tmpdir)
+            df = loader.load_store()
+            self.assertEqual(len(df), 2)
+            self.assertIn("StoreType", df.columns)
+
+    def test_load_all(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_csv(Path(tmpdir) / "train.csv", "Date,Store,Sales\n2024-01-01,1,100\n")
+            _write_csv(Path(tmpdir) / "test.csv", "Date,Store,Id\n2024-02-01,1,1\n")
+            _write_csv(Path(tmpdir) / "store.csv", "Store,StoreType\n1,a\n")
+            loader = self._make_loader(tmpdir)
+            train, test, store = loader.load_all()
+            self.assertIsInstance(train, pd.DataFrame)
+            self.assertIsInstance(test, pd.DataFrame)
+            self.assertIsInstance(store, pd.DataFrame)
+
+    def test_merge_with_store(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            loader = self._make_loader(tmpdir)
+            sales = pd.DataFrame({"Store": [1, 2], "Sales": [100, 200]})
+            store = pd.DataFrame({"Store": [1, 2], "StoreType": ["a", "b"]})
+            merged = loader.merge_with_store(sales, store)
+            self.assertIn("StoreType", merged.columns)
+            self.assertEqual(len(merged), 2)
+
+    def test_missing_file_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            loader = self._make_loader(tmpdir)
+            with self.assertRaises(FileNotFoundError):
+                loader.load_train()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forecasting-platform/tests/test_data_preprocessor.py
+++ b/forecasting-platform/tests/test_data_preprocessor.py
@@ -1,0 +1,133 @@
+"""
+Tests for DataPreprocessor — src/data/preprocessor.py.
+
+Covers:
+  - clean removes closed stores and zero sales
+  - clean fills missing values
+  - clean preserves original DataFrame
+  - remove_closed=False keeps closed stores
+  - encode_categoricals with explicit and auto columns
+  - encode_categoricals preserves original
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+
+class TestDataPreprocessor(unittest.TestCase):
+
+    def _get_preprocessor(self, **kwargs):
+        from src.data.preprocessor import DataPreprocessor
+        return DataPreprocessor(**kwargs)
+
+    def _sample_df(self):
+        return pd.DataFrame({
+            "Store": [1, 2, 3, 4],
+            "Open": [1, 1, 0, 1],
+            "Sales": [100, 200, 150, 0],
+            "CompetitionDistance": [500.0, np.nan, 300.0, np.nan],
+            "Promo2SinceWeek": [10, np.nan, 5, np.nan],
+            "Promo2SinceYear": [2020, np.nan, 2019, np.nan],
+            "PromoInterval": ["Jan,Apr", np.nan, "Feb", np.nan],
+            "CompetitionOpenSinceMonth": [3, np.nan, 6, np.nan],
+            "CompetitionOpenSinceYear": [2018, np.nan, 2017, np.nan],
+        })
+
+    def test_clean_removes_closed(self):
+        pp = self._get_preprocessor()
+        df = self._sample_df()
+        result = pp.clean(df)
+        # Store 3 is closed (Open=0), Store 4 has Sales=0 → removed
+        self.assertTrue((result["Open"] == 1).all())
+
+    def test_clean_removes_zero_sales(self):
+        pp = self._get_preprocessor()
+        df = self._sample_df()
+        result = pp.clean(df)
+        self.assertTrue((result["Sales"] > 0).all())
+
+    def test_clean_fills_competition_distance(self):
+        pp = self._get_preprocessor()
+        df = self._sample_df()
+        result = pp.clean(df)
+        self.assertFalse(result["CompetitionDistance"].isna().any())
+
+    def test_clean_fills_promo_columns(self):
+        pp = self._get_preprocessor()
+        df = self._sample_df()
+        result = pp.clean(df)
+        for col in ["Promo2SinceWeek", "Promo2SinceYear"]:
+            self.assertFalse(result[col].isna().any())
+
+    def test_clean_fills_competition_timing(self):
+        pp = self._get_preprocessor()
+        df = self._sample_df()
+        result = pp.clean(df)
+        for col in ["CompetitionOpenSinceMonth", "CompetitionOpenSinceYear"]:
+            self.assertFalse(result[col].isna().any())
+
+    def test_clean_preserves_original(self):
+        pp = self._get_preprocessor()
+        df = self._sample_df()
+        original_len = len(df)
+        _ = pp.clean(df)
+        self.assertEqual(len(df), original_len)  # original not mutated
+
+    def test_remove_closed_false(self):
+        pp = self._get_preprocessor(remove_closed=False)
+        df = self._sample_df()
+        result = pp.clean(df)
+        # Closed stores kept, but zero sales still removed
+        # Store 3 (Open=0, Sales=150) should be kept
+        stores_in_result = result["Store"].tolist()
+        self.assertIn(3, stores_in_result)
+
+    def test_clean_without_open_column(self):
+        pp = self._get_preprocessor()
+        df = pd.DataFrame({"Store": [1, 2], "Sales": [100, 200]})
+        result = pp.clean(df)
+        self.assertEqual(len(result), 2)
+
+    def test_clean_resets_index(self):
+        pp = self._get_preprocessor()
+        df = self._sample_df()
+        result = pp.clean(df)
+        self.assertEqual(list(result.index), list(range(len(result))))
+
+    def test_encode_categoricals_explicit(self):
+        pp = self._get_preprocessor()
+        df = pd.DataFrame({
+            "Store": [1, 2, 3],
+            "Type": ["a", "b", "a"],
+            "Region": ["north", "south", "north"],
+        })
+        result = pp.encode_categoricals(df, columns=["Type"])
+        # "Type" should be encoded to integer codes
+        self.assertTrue(pd.api.types.is_integer_dtype(result["Type"]))
+        # "Region" should remain unchanged (not specified for encoding)
+        self.assertFalse(pd.api.types.is_integer_dtype(result["Region"]))
+
+    def test_encode_categoricals_auto(self):
+        pp = self._get_preprocessor()
+        df = pd.DataFrame({
+            "Store": [1, 2],
+            "Type": ["a", "b"],
+            "Region": ["north", "south"],
+        })
+        result = pp.encode_categoricals(df)
+        # Both "Type" and "Region" are object → should be encoded
+        self.assertTrue(pd.api.types.is_integer_dtype(result["Type"]))
+        self.assertTrue(pd.api.types.is_integer_dtype(result["Region"]))
+
+    def test_encode_preserves_original(self):
+        pp = self._get_preprocessor()
+        df = pd.DataFrame({"Type": ["a", "b", "c"]})
+        original_dtype = df["Type"].dtype
+        _ = pp.encode_categoricals(df, columns=["Type"])
+        self.assertEqual(df["Type"].dtype, original_dtype)  # original unmodified
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forecasting-platform/tests/test_evaluator.py
+++ b/forecasting-platform/tests/test_evaluator.py
@@ -1,0 +1,104 @@
+"""
+Tests for ModelEvaluator — src/evaluation/evaluator.py.
+
+Covers:
+  - evaluate returns all default metrics
+  - evaluate with specific metric subset
+  - unknown metrics are silently ignored
+  - compare_models returns DataFrame sorted by rmspe
+  - metric values are reasonable (perfect predictions → ~0 error)
+"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+
+class _MockModel:
+    """Minimal model satisfying BaseForecaster interface for evaluation."""
+
+    def __init__(self, name: str, predictions: np.ndarray):
+        self.name = name
+        self._predictions = predictions
+
+    def predict(self, X):
+        return self._predictions
+
+
+class TestModelEvaluator(unittest.TestCase):
+
+    def _get_evaluator(self):
+        from src.evaluation.evaluator import ModelEvaluator
+        return ModelEvaluator()
+
+    def test_evaluate_all_metrics(self):
+        ev = self._get_evaluator()
+        y_true = np.array([100.0, 200.0, 150.0, 300.0])
+        y_pred = np.array([110.0, 190.0, 160.0, 280.0])
+        model = _MockModel("test", y_pred)
+        X = pd.DataFrame({"f1": [1, 2, 3, 4]})
+        y = pd.Series(y_true)
+
+        result = ev.evaluate(model, X, y)
+        self.assertIn("rmspe", result)
+        self.assertIn("rmse", result)
+        self.assertIn("mae", result)
+        self.assertIn("mape", result)
+        for v in result.values():
+            self.assertIsInstance(v, float)
+            self.assertGreater(v, 0)
+
+    def test_evaluate_specific_metrics(self):
+        ev = self._get_evaluator()
+        y_true = np.array([100.0, 200.0])
+        model = _MockModel("test", np.array([110.0, 190.0]))
+        X = pd.DataFrame({"f1": [1, 2]})
+        y = pd.Series(y_true)
+
+        result = ev.evaluate(model, X, y, metrics=["mae", "rmse"])
+        self.assertEqual(set(result.keys()), {"mae", "rmse"})
+
+    def test_unknown_metric_ignored(self):
+        ev = self._get_evaluator()
+        y_true = np.array([100.0, 200.0])
+        model = _MockModel("test", np.array([100.0, 200.0]))
+        X = pd.DataFrame({"f1": [1, 2]})
+        y = pd.Series(y_true)
+
+        result = ev.evaluate(model, X, y, metrics=["mae", "nonexistent"])
+        self.assertIn("mae", result)
+        self.assertNotIn("nonexistent", result)
+
+    def test_compare_models(self):
+        ev = self._get_evaluator()
+        y_true = np.array([100.0, 200.0, 300.0])
+        X = pd.DataFrame({"f1": [1, 2, 3]})
+        y = pd.Series(y_true)
+
+        good = _MockModel("good", np.array([100.0, 200.0, 300.0]))
+        bad = _MockModel("bad", np.array([200.0, 100.0, 400.0]))
+
+        result = ev.compare_models([good, bad], X, y)
+        self.assertIsInstance(result, pd.DataFrame)
+        self.assertEqual(result.index.name, "model")
+        self.assertIn("good", result.index)
+        self.assertIn("bad", result.index)
+        # "good" should be first (lowest rmspe)
+        self.assertEqual(result.index[0], "good")
+
+    def test_perfect_predictions_low_error(self):
+        ev = self._get_evaluator()
+        y_true = np.array([100.0, 200.0, 300.0])
+        model = _MockModel("perfect", y_true.copy())
+        X = pd.DataFrame({"f1": [1, 2, 3]})
+        y = pd.Series(y_true)
+
+        result = ev.evaluate(model, X, y)
+        for metric, val in result.items():
+            self.assertAlmostEqual(val, 0.0, places=5,
+                                   msg=f"{metric} should be ~0 for perfect predictions")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forecasting-platform/tests/test_hierarchy_aggregator.py
+++ b/forecasting-platform/tests/test_hierarchy_aggregator.py
@@ -1,0 +1,254 @@
+"""
+Tests for HierarchyAggregator — src/hierarchy/aggregator.py.
+
+Covers:
+  - aggregate_to with sum and mean
+  - disaggregate_to with equal split and explicit proportions
+  - round-trip aggregate → disaggregate preserves totals
+  - compute_historical_proportions sums to 1.0 per parent
+  - n_recent_weeks filtering
+  - invalid agg raises ValueError
+"""
+
+import unittest
+from datetime import date, timedelta
+
+import polars as pl
+import pytest
+
+
+def _make_geo_tree():
+    """
+    Three-level geography hierarchy:
+        global → region → country
+    """
+    from src.hierarchy.tree import HierarchyTree
+    from src.config.schema import HierarchyConfig
+
+    cfg = HierarchyConfig(
+        name="geography",
+        levels=["global", "region", "country"],
+        id_column="country",
+        fixed=False,
+        reconciliation_level="region",
+    )
+    data = pl.DataFrame({
+        "global": ["world"] * 4,
+        "region": ["NA", "NA", "EMEA", "EMEA"],
+        "country": ["USA", "CAN", "GBR", "DEU"],
+    })
+    return HierarchyTree(cfg, data)
+
+
+def _make_leaf_data(weeks: int = 8):
+    """Build country-level weekly data."""
+    values = {"USA": 100.0, "CAN": 50.0, "GBR": 80.0, "DEU": 60.0}
+    rows = []
+    for w in range(weeks):
+        for country, val in values.items():
+            rows.append({
+                "country": country,
+                "week": date(2024, 1, 1) + timedelta(weeks=w),
+                "quantity": val + w * 2,
+            })
+    return pl.DataFrame(rows).with_columns(pl.col("quantity").cast(pl.Float64))
+
+
+class TestAggregateSum(unittest.TestCase):
+
+    def test_aggregate_to_region_sum(self):
+        from src.hierarchy.aggregator import HierarchyAggregator
+        tree = _make_geo_tree()
+        agg = HierarchyAggregator(tree)
+        df = _make_leaf_data(weeks=4)
+
+        result = agg.aggregate_to(df, "region", ["quantity"])
+        self.assertIn("region", result.columns)
+        self.assertIn("quantity", result.columns)
+        # 2 regions x 4 weeks = 8 rows
+        self.assertEqual(result.shape[0], 8)
+
+        # Check NA sum for week 0: USA(100) + CAN(50) = 150
+        na_w0 = result.filter(
+            (pl.col("region") == "NA")
+            & (pl.col("week") == date(2024, 1, 1))
+        )
+        self.assertAlmostEqual(na_w0["quantity"][0], 150.0)
+
+    def test_aggregate_to_global_sum(self):
+        from src.hierarchy.aggregator import HierarchyAggregator
+        tree = _make_geo_tree()
+        agg = HierarchyAggregator(tree)
+        df = _make_leaf_data(weeks=2)
+
+        result = agg.aggregate_to(df, "global", ["quantity"])
+        self.assertEqual(result.shape[0], 2)  # 1 global x 2 weeks
+        # week 0: 100+50+80+60 = 290
+        w0 = result.filter(pl.col("week") == date(2024, 1, 1))
+        self.assertAlmostEqual(w0["quantity"][0], 290.0)
+
+
+class TestAggregateMean(unittest.TestCase):
+
+    def test_aggregate_mean(self):
+        from src.hierarchy.aggregator import HierarchyAggregator
+        tree = _make_geo_tree()
+        agg = HierarchyAggregator(tree)
+        df = _make_leaf_data(weeks=2)
+
+        result = agg.aggregate_to(df, "region", ["quantity"], agg="mean")
+        na_w0 = result.filter(
+            (pl.col("region") == "NA")
+            & (pl.col("week") == date(2024, 1, 1))
+        )
+        # mean of USA(100) + CAN(50) = 75
+        self.assertAlmostEqual(na_w0["quantity"][0], 75.0)
+
+
+class TestAggregateInvalidAgg(unittest.TestCase):
+
+    def test_invalid_agg_raises(self):
+        from src.hierarchy.aggregator import HierarchyAggregator
+        tree = _make_geo_tree()
+        agg = HierarchyAggregator(tree)
+        df = _make_leaf_data(weeks=2)
+        with self.assertRaises(ValueError):
+            agg.aggregate_to(df, "region", ["quantity"], agg="median")
+
+
+class TestDisaggregate(unittest.TestCase):
+
+    def test_equal_split(self):
+        from src.hierarchy.aggregator import HierarchyAggregator
+        tree = _make_geo_tree()
+        agg = HierarchyAggregator(tree)
+
+        region_data = pl.DataFrame({
+            "region": ["NA", "EMEA"],
+            "week": [date(2024, 1, 1)] * 2,
+            "quantity": [200.0, 100.0],
+        })
+        result = agg.disaggregate_to(
+            region_data, "region", "country", ["quantity"]
+        )
+        self.assertIn("country", result.columns)
+        # NA → USA, CAN equally: 100 each
+        usa = result.filter(pl.col("country") == "USA")
+        self.assertAlmostEqual(usa["quantity"][0], 100.0)
+
+    def test_with_proportions(self):
+        from src.hierarchy.aggregator import HierarchyAggregator
+        tree = _make_geo_tree()
+        agg = HierarchyAggregator(tree)
+
+        region_data = pl.DataFrame({
+            "region": ["NA"],
+            "week": [date(2024, 1, 1)],
+            "quantity": [300.0],
+        })
+        props = pl.DataFrame({
+            "region": ["NA", "NA"],
+            "country": ["USA", "CAN"],
+            "proportion": [0.7, 0.3],
+        })
+        result = agg.disaggregate_to(
+            region_data, "region", "country", ["quantity"],
+            proportions=props,
+        )
+        usa = result.filter(pl.col("country") == "USA")
+        can = result.filter(pl.col("country") == "CAN")
+        self.assertAlmostEqual(usa["quantity"][0], 210.0)
+        self.assertAlmostEqual(can["quantity"][0], 90.0)
+
+    def test_disaggregate_preserves_total(self):
+        from src.hierarchy.aggregator import HierarchyAggregator
+        tree = _make_geo_tree()
+        agg = HierarchyAggregator(tree)
+
+        region_data = pl.DataFrame({
+            "region": ["NA", "EMEA"],
+            "week": [date(2024, 1, 1)] * 2,
+            "quantity": [200.0, 100.0],
+        })
+        result = agg.disaggregate_to(
+            region_data, "region", "country", ["quantity"]
+        )
+        total = result["quantity"].sum()
+        self.assertAlmostEqual(total, 300.0)
+
+
+class TestRoundTrip(unittest.TestCase):
+
+    def test_aggregate_then_disaggregate(self):
+        from src.hierarchy.aggregator import HierarchyAggregator
+        tree = _make_geo_tree()
+        agg_obj = HierarchyAggregator(tree)
+        leaf_data = _make_leaf_data(weeks=2)
+
+        # Aggregate to region
+        region_agg = agg_obj.aggregate_to(leaf_data, "region", ["quantity"])
+        # Disaggregate back with equal split
+        back = agg_obj.disaggregate_to(
+            region_agg, "region", "country", ["quantity"]
+        )
+        # Total should be preserved
+        original_total = leaf_data["quantity"].sum()
+        round_trip_total = back["quantity"].sum()
+        self.assertAlmostEqual(round_trip_total, original_total, places=2)
+
+
+class TestComputeHistoricalProportions(unittest.TestCase):
+
+    def test_proportions_sum_to_one(self):
+        from src.hierarchy.aggregator import HierarchyAggregator
+        tree = _make_geo_tree()
+        agg = HierarchyAggregator(tree)
+        df = _make_leaf_data(weeks=8)
+
+        props = agg.compute_historical_proportions(
+            df, "region", "country", "quantity"
+        )
+        self.assertIn("proportion", props.columns)
+        # Proportions per region sum to 1.0
+        for region in ["NA", "EMEA"]:
+            region_props = props.filter(pl.col("region") == region)
+            total = region_props["proportion"].sum()
+            self.assertAlmostEqual(total, 1.0, places=5)
+
+    def test_proportions_reflect_data(self):
+        from src.hierarchy.aggregator import HierarchyAggregator
+        tree = _make_geo_tree()
+        agg = HierarchyAggregator(tree)
+        df = _make_leaf_data(weeks=1)  # USA=100, CAN=50
+
+        props = agg.compute_historical_proportions(
+            df, "region", "country", "quantity"
+        )
+        na = props.filter(pl.col("region") == "NA")
+        usa_prop = na.filter(pl.col("country") == "USA")["proportion"][0]
+        # USA / (USA+CAN) = 100/150 ≈ 0.667
+        self.assertAlmostEqual(usa_prop, 100.0 / 150.0, places=3)
+
+    def test_n_recent_weeks_filter(self):
+        from src.hierarchy.aggregator import HierarchyAggregator
+        tree = _make_geo_tree()
+        agg = HierarchyAggregator(tree)
+        # Make data with dates as Datetime to support duration arithmetic
+        df = _make_leaf_data(weeks=8)
+        df = df.with_columns(pl.col("week").cast(pl.Datetime))
+
+        props = agg.compute_historical_proportions(
+            df, "region", "country", "quantity",
+            time_column="week",
+            n_recent_weeks=4,
+        )
+        # Should still produce proportions
+        self.assertGreater(props.shape[0], 0)
+        for region in ["NA", "EMEA"]:
+            region_props = props.filter(pl.col("region") == region)
+            total = region_props["proportion"].sum()
+            self.assertAlmostEqual(total, 1.0, places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forecasting-platform/tests/test_ml_forecasters.py
+++ b/forecasting-platform/tests/test_ml_forecasters.py
@@ -1,0 +1,203 @@
+"""
+Tests for ML-based forecasters (LightGBM, XGBoost) — src/forecasting/ml.py.
+
+Covers:
+  - fit / predict shape and columns
+  - predict_quantiles ordering
+  - manual fallback when mlforecast unavailable
+  - get_params, set_future_features
+  - error paths (predict before fit)
+"""
+
+import random
+import unittest
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import polars as pl
+
+
+def _make_weekly_series(n_series: int = 2, n_weeks: int = 104, seed: int = 42):
+    """Build a synthetic weekly panel DataFrame with Sunday dates (W freq)."""
+    random.seed(seed)
+    rows = []
+    for s in range(1, n_series + 1):
+        sid = f"S{s}"
+        base = 100.0 + s * 20
+        for w in range(n_weeks):
+            rows.append({
+                "series_id": sid,
+                "week": date(2023, 1, 1) + timedelta(weeks=w),  # Sunday
+                "quantity": base + random.gauss(0, 10),
+            })
+    return pl.DataFrame(rows).with_columns(pl.col("quantity").cast(pl.Float64))
+
+
+# --------------------------------------------------------------------------- #
+#  LightGBM
+# --------------------------------------------------------------------------- #
+
+class TestLGBMDirectForecaster(unittest.TestCase):
+
+    def _get_forecaster(self):
+        from src.forecasting.ml import LGBMDirectForecaster
+        return LGBMDirectForecaster()
+
+    def test_fit_predict_shape(self):
+        f = self._get_forecaster()
+        df = _make_weekly_series()
+        f.fit(df)
+        out = f.predict(horizon=8)
+        self.assertIn("series_id", out.columns)
+        self.assertIn("week", out.columns)
+        self.assertIn("forecast", out.columns)
+        self.assertEqual(out.shape[0], 2 * 8)
+        self.assertFalse(out["forecast"].is_null().any())
+
+    def test_predict_quantiles(self):
+        f = self._get_forecaster()
+        df = _make_weekly_series()
+        f.fit(df)
+        out = f.predict_quantiles(horizon=4, quantiles=[0.1, 0.5, 0.9])
+        self.assertIn("forecast_p10", out.columns)
+        self.assertIn("forecast_p50", out.columns)
+        self.assertIn("forecast_p90", out.columns)
+        # p10 <= p50 <= p90 (row-wise)
+        for row in out.iter_rows(named=True):
+            self.assertLessEqual(row["forecast_p10"], row["forecast_p90"])
+
+    def test_get_params(self):
+        f = self._get_forecaster()
+        p = f.get_params()
+        self.assertEqual(p["model"], "LightGBM")
+        self.assertIn("lags", p)
+
+    def test_set_future_features(self):
+        """set_future_features stores future features without error."""
+        f = self._get_forecaster()
+        df = _make_weekly_series()
+        f.fit(df)
+        # build future features for horizon=4
+        future_rows = []
+        max_date = df["week"].max()
+        for s in ["S1", "S2"]:
+            for h in range(1, 5):
+                future_rows.append({
+                    "series_id": s,
+                    "week": max_date + timedelta(weeks=h),
+                    "promo": 0.0,
+                })
+        future_df = pl.DataFrame(future_rows)
+        f.set_future_features(future_df)
+        # Verify it was stored (converted to pandas)
+        self.assertTrue(hasattr(f, "_future_features"))
+        self.assertEqual(len(f._future_features), 8)
+
+
+# --------------------------------------------------------------------------- #
+#  XGBoost
+# --------------------------------------------------------------------------- #
+
+class TestXGBoostDirectForecaster(unittest.TestCase):
+
+    def _get_forecaster(self):
+        from src.forecasting.ml import XGBoostDirectForecaster
+        return XGBoostDirectForecaster()
+
+    def test_fit_predict_shape(self):
+        f = self._get_forecaster()
+        df = _make_weekly_series()
+        f.fit(df)
+        out = f.predict(horizon=8)
+        self.assertIn("forecast", out.columns)
+        self.assertEqual(out.shape[0], 2 * 8)
+
+    def test_predict_quantiles(self):
+        f = self._get_forecaster()
+        df = _make_weekly_series()
+        f.fit(df)
+        out = f.predict_quantiles(horizon=4, quantiles=[0.1, 0.5, 0.9])
+        self.assertIn("forecast_p10", out.columns)
+        self.assertIn("forecast_p50", out.columns)
+        self.assertIn("forecast_p90", out.columns)
+
+    def test_get_params(self):
+        f = self._get_forecaster()
+        p = f.get_params()
+        self.assertEqual(p["model"], "XGBoost")
+
+
+# --------------------------------------------------------------------------- #
+#  Manual fallback (mlforecast unavailable)
+# --------------------------------------------------------------------------- #
+
+class TestManualFallback(unittest.TestCase):
+
+    def test_manual_fallback_predict(self):
+        """When _HAS_MLFORECAST is False, fit/predict should still work."""
+        import src.forecasting.ml as ml_mod
+        original = ml_mod._HAS_MLFORECAST
+        try:
+            ml_mod._HAS_MLFORECAST = False
+            from src.forecasting.ml import LGBMDirectForecaster
+            f = LGBMDirectForecaster()
+            df = _make_weekly_series()
+            f.fit(df)
+            out = f.predict(horizon=4)
+            self.assertIn("forecast", out.columns)
+            self.assertEqual(out.shape[0], 2 * 4)
+        finally:
+            ml_mod._HAS_MLFORECAST = original
+
+    def test_predict_before_fit_raises(self):
+        import src.forecasting.ml as ml_mod
+        original = ml_mod._HAS_MLFORECAST
+        try:
+            ml_mod._HAS_MLFORECAST = False
+            from src.forecasting.ml import LGBMDirectForecaster
+            f = LGBMDirectForecaster()
+            with self.assertRaises(RuntimeError):
+                f.predict(horizon=4)
+        finally:
+            ml_mod._HAS_MLFORECAST = original
+
+    def test_manual_fallback_quantiles_residual(self):
+        """Quantile prediction falls back to residual-based when mlforecast off."""
+        import src.forecasting.ml as ml_mod
+        original = ml_mod._HAS_MLFORECAST
+        try:
+            ml_mod._HAS_MLFORECAST = False
+            from src.forecasting.ml import LGBMDirectForecaster
+            f = LGBMDirectForecaster()
+            df = _make_weekly_series()
+            f.fit(df)
+            out = f.predict_quantiles(horizon=4, quantiles=[0.1, 0.5, 0.9])
+            self.assertIn("forecast_p10", out.columns)
+            self.assertIn("forecast_p50", out.columns)
+            self.assertIn("forecast_p90", out.columns)
+        finally:
+            ml_mod._HAS_MLFORECAST = original
+
+    def test_manual_empty_series(self):
+        """Empty input should produce empty output with correct schema."""
+        import src.forecasting.ml as ml_mod
+        original = ml_mod._HAS_MLFORECAST
+        try:
+            ml_mod._HAS_MLFORECAST = False
+            from src.forecasting.ml import LGBMDirectForecaster
+            f = LGBMDirectForecaster()
+            empty = pl.DataFrame({
+                "series_id": pl.Series([], dtype=pl.Utf8),
+                "week": pl.Series([], dtype=pl.Date),
+                "quantity": pl.Series([], dtype=pl.Float64),
+            })
+            f.fit(empty)
+            out = f.predict(horizon=4)
+            self.assertEqual(out.shape[0], 0)
+            self.assertIn("forecast", out.columns)
+        finally:
+            ml_mod._HAS_MLFORECAST = original
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forecasting-platform/tests/test_override_store.py
+++ b/forecasting-platform/tests/test_override_store.py
@@ -1,0 +1,159 @@
+"""
+Tests for OverrideStore — src/overrides/store.py.
+
+Covers:
+  - add / retrieve / delete overrides (DuckDB path)
+  - override_id format
+  - SKU filtering (old_sku, new_sku, both)
+  - approval logic (auto-approved vs pending)
+  - empty store returns empty DataFrame
+  - close() without error
+"""
+
+import re
+import tempfile
+import unittest
+
+import polars as pl
+
+
+class TestOverrideStoreDuckDB(unittest.TestCase):
+    """Tests using DuckDB backend (default when duckdb is installed)."""
+
+    def _make_store(self, tmpdir: str):
+        from src.overrides.store import OverrideStore
+        return OverrideStore(db_path=f"{tmpdir}/overrides.duckdb")
+
+    def test_add_and_retrieve(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            oid = store.add_override("OLD-A", "NEW-A", 0.6)
+            df = store.get_all()
+            self.assertEqual(df.shape[0], 1)
+            self.assertEqual(df["old_sku"][0], "OLD-A")
+            self.assertEqual(df["new_sku"][0], "NEW-A")
+            self.assertAlmostEqual(df["proportion"][0], 0.6)
+            store.close()
+
+    def test_override_id_format(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            oid = store.add_override("X", "Y", 0.5)
+            self.assertRegex(oid, r"^OVR-[A-F0-9]{8}$")
+            store.close()
+
+    def test_filter_by_old_sku(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            store.add_override("A", "X", 0.3)
+            store.add_override("B", "Y", 0.4)
+            df = store.get_overrides(old_sku="A")
+            self.assertEqual(df.shape[0], 1)
+            self.assertEqual(df["old_sku"][0], "A")
+            store.close()
+
+    def test_filter_by_new_sku(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            store.add_override("A", "X", 0.3)
+            store.add_override("B", "Y", 0.4)
+            df = store.get_overrides(new_sku="Y")
+            self.assertEqual(df.shape[0], 1)
+            self.assertEqual(df["new_sku"][0], "Y")
+            store.close()
+
+    def test_filter_by_both_skus(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            store.add_override("A", "X", 0.3)
+            store.add_override("A", "Y", 0.4)
+            store.add_override("B", "X", 0.5)
+            df = store.get_overrides(old_sku="A", new_sku="X")
+            self.assertEqual(df.shape[0], 1)
+            store.close()
+
+    def test_delete_override(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            oid = store.add_override("A", "X", 0.3)
+            ok = store.delete_override(oid)
+            self.assertTrue(ok)
+            df = store.get_all()
+            self.assertEqual(df.shape[0], 0)
+            store.close()
+
+    def test_approval_auto_approved(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            store.add_override("A", "X", 0.8, approval_threshold=0.0)
+            df = store.get_all()
+            self.assertEqual(df["status"][0], "approved")
+            store.close()
+
+    def test_approval_pending(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            store.add_override("A", "X", 0.8, approval_threshold=0.5)
+            df = store.get_all()
+            self.assertEqual(df["status"][0], "pending_approval")
+            store.close()
+
+    def test_approval_below_threshold(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            store.add_override("A", "X", 0.3, approval_threshold=0.5)
+            df = store.get_all()
+            self.assertEqual(df["status"][0], "approved")
+            store.close()
+
+    def test_get_all_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            df = store.get_all()
+            self.assertEqual(df.shape[0], 0)
+            store.close()
+
+    def test_close_no_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            store.close()  # should not raise
+
+    def test_multiple_overrides(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            store.add_override("A", "X", 0.3)
+            store.add_override("B", "Y", 0.4)
+            store.add_override("C", "Z", 0.5)
+            df = store.get_all()
+            self.assertEqual(df.shape[0], 3)
+            store.close()
+
+    def test_scenario_and_ramp_shape(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            store.add_override(
+                "A", "X", 0.5,
+                scenario="scenario_a",
+                ramp_shape="sigmoid",
+            )
+            df = store.get_all()
+            self.assertEqual(df["scenario"][0], "scenario_a")
+            self.assertEqual(df["ramp_shape"][0], "sigmoid")
+            store.close()
+
+    def test_created_by_and_notes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = self._make_store(tmpdir)
+            store.add_override(
+                "A", "X", 0.5,
+                created_by="alice",
+                notes="test override",
+            )
+            df = store.get_all()
+            self.assertEqual(df["created_by"][0], "alice")
+            self.assertEqual(df["notes"][0], "test override")
+            store.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forecasting-platform/tests/test_statistical_forecasters.py
+++ b/forecasting-platform/tests/test_statistical_forecasters.py
@@ -1,0 +1,136 @@
+"""
+Tests for statistical forecasters (AutoARIMA, AutoETS) — src/forecasting/statistical.py.
+
+Covers:
+  - fit / predict shape and column names
+  - predict_quantiles output structure and ordering
+  - predict before fit raises RuntimeError
+  - get_params returns correct metadata
+  - custom season_length
+  - output date type enforcement
+"""
+
+import random
+import unittest
+from datetime import date, timedelta
+
+import polars as pl
+
+
+def _make_weekly_series(n_series: int = 2, n_weeks: int = 104, seed: int = 42):
+    random.seed(seed)
+    rows = []
+    for s in range(1, n_series + 1):
+        sid = f"S{s}"
+        base = 100.0 + s * 20
+        for w in range(n_weeks):
+            rows.append({
+                "series_id": sid,
+                "week": date(2023, 1, 1) + timedelta(weeks=w),  # Sunday
+                "quantity": base + random.gauss(0, 10),
+            })
+    return pl.DataFrame(rows).with_columns(pl.col("quantity").cast(pl.Float64))
+
+
+class TestAutoARIMAForecaster(unittest.TestCase):
+
+    def _get_forecaster(self):
+        from src.forecasting.statistical import AutoARIMAForecaster
+        return AutoARIMAForecaster()
+
+    def test_fit_predict_shape(self):
+        f = self._get_forecaster()
+        df = _make_weekly_series()
+        f.fit(df)
+        out = f.predict(horizon=8)
+        self.assertIn("series_id", out.columns)
+        self.assertIn("week", out.columns)
+        self.assertIn("forecast", out.columns)
+        self.assertEqual(out.shape[0], 2 * 8)
+        self.assertFalse(out["forecast"].is_null().any())
+
+    def test_predict_quantiles(self):
+        f = self._get_forecaster()
+        df = _make_weekly_series()
+        f.fit(df)
+        out = f.predict_quantiles(horizon=4, quantiles=[0.1, 0.5, 0.9])
+        self.assertIn("forecast_p10", out.columns)
+        self.assertIn("forecast_p50", out.columns)
+        self.assertIn("forecast_p90", out.columns)
+        # p10 <= p90 row-wise
+        for row in out.iter_rows(named=True):
+            self.assertLessEqual(row["forecast_p10"], row["forecast_p90"])
+
+    def test_predict_before_fit_raises(self):
+        f = self._get_forecaster()
+        with self.assertRaises(RuntimeError):
+            f.predict(horizon=4)
+
+    def test_predict_quantiles_before_fit_raises(self):
+        f = self._get_forecaster()
+        with self.assertRaises(RuntimeError):
+            f.predict_quantiles(horizon=4, quantiles=[0.1, 0.5, 0.9])
+
+    def test_get_params(self):
+        f = self._get_forecaster()
+        p = f.get_params()
+        self.assertEqual(p["model"], "AutoARIMA")
+        self.assertEqual(p["season_length"], 52)
+
+    def test_date_column_type(self):
+        f = self._get_forecaster()
+        df = _make_weekly_series()
+        f.fit(df)
+        out = f.predict(horizon=4)
+        self.assertEqual(out["week"].dtype, pl.Date)
+
+
+class TestAutoETSForecaster(unittest.TestCase):
+
+    def _get_forecaster(self):
+        from src.forecasting.statistical import AutoETSForecaster
+        return AutoETSForecaster()
+
+    def test_fit_predict_shape(self):
+        f = self._get_forecaster()
+        df = _make_weekly_series()
+        f.fit(df)
+        out = f.predict(horizon=8)
+        self.assertIn("forecast", out.columns)
+        self.assertEqual(out.shape[0], 2 * 8)
+
+    def test_predict_quantiles(self):
+        f = self._get_forecaster()
+        df = _make_weekly_series()
+        f.fit(df)
+        out = f.predict_quantiles(horizon=4, quantiles=[0.1, 0.5, 0.9])
+        self.assertIn("forecast_p10", out.columns)
+        self.assertIn("forecast_p50", out.columns)
+        self.assertIn("forecast_p90", out.columns)
+
+    def test_predict_before_fit_raises(self):
+        f = self._get_forecaster()
+        with self.assertRaises(RuntimeError):
+            f.predict(horizon=4)
+
+    def test_get_params(self):
+        f = self._get_forecaster()
+        p = f.get_params()
+        self.assertEqual(p["model"], "AutoETS")
+        self.assertEqual(p["season_length"], 52)
+
+    def test_custom_season_length(self):
+        from src.forecasting.statistical import AutoETSForecaster
+        f = AutoETSForecaster(season_length=12)
+        self.assertEqual(f.get_params()["season_length"], 12)
+
+    def test_date_column_type(self):
+        f = self._get_forecaster()
+        df = _make_weekly_series()
+        f.fit(df)
+        out = f.predict(horizon=4)
+        self.assertEqual(out["week"].dtype, pl.Date)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Coverage improvements for critical business logic:
- ML forecasters (ml.py): 22% → 90% — fit/predict, quantiles, manual fallback
- Statistical forecasters (statistical.py): 28% → 95% — ARIMA/ETS fit/predict/quantiles
- Override store (store.py): 0% → 70% — CRUD, approval logic, filtering
- Hierarchy aggregator (aggregator.py): 34% → 90% — aggregate/disaggregate/proportions
- Evaluator (evaluator.py): 38% → 100% — metric evaluation, model comparison
- Data loader (loader.py): 0% → tested — CSV loading, merging, error paths
- Data preprocessor (preprocessor.py): 0% → tested — cleaning, encoding, fill missing

Also adds httpx to requirements.txt to fix 10 failing FastAPI TestClient tests.

Overall: 422 tests → 503 tests, 0 failures, coverage 64% → 74%.

https://claude.ai/code/session_01Bm6Bo1n4BegPCkg8kY1HA2