### PR TITLE
Remove dead code and fix missing imports discovered during codebase a…

### DIFF
--- a/forecasting-platform/scripts/run_sku_mapping.py
+++ b/forecasting-platform/scripts/run_sku_mapping.py
@@ -26,6 +26,8 @@ import logging
 import sys
 from pathlib import Path
 
+import polars as pl
+
 # Allow running from the repo root without installing the package
 sys.path.insert(0, str(Path(__file__).parent.parent))
 

--- a/forecasting-platform/scripts/spark_backtest.py
+++ b/forecasting-platform/scripts/spark_backtest.py
@@ -103,6 +103,8 @@ def main():
         train_sdf, _, store_sdf = loader.read_rossmann_all()
         actuals_raw = train_sdf.join(store_sdf, on="Store", how="left")
 
+    from pyspark.sql import functions as F
+
     # Build canonical series panel via config — no hard-coded column names
     builder = SparkSeriesBuilder.from_config(fabric_yaml["series_builder"])
     actuals_sdf = builder.build(actuals_raw)

--- a/forecasting-platform/src/backtesting/engine.py
+++ b/forecasting-platform/src/backtesting/engine.py
@@ -265,7 +265,7 @@ class BacktestEngine:
                 metric_names=self.config.metrics,
             )
 
-            for _, row in enumerate(s.iter_rows(named=True)):
+            for row in s.iter_rows(named=True):
                 record = {
                     "run_id": run_id,
                     "run_type": "backtest",

--- a/forecasting-platform/src/data/regressors.py
+++ b/forecasting-platform/src/data/regressors.py
@@ -6,7 +6,7 @@ features, and validating that external regressors align with actuals data.
 """
 
 import logging
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import List, Optional
 
@@ -107,7 +107,6 @@ def generate_holiday_calendar(
             else:
                 # Handle polars date type
                 try:
-                    from datetime import timedelta
                     py_date = week_start + timedelta(days=day_offset)
                     if py_date in country_holidays:
                         count += 1
@@ -195,7 +194,6 @@ def validate_regressors(
                 )
 
         if horizon_weeks > 0 and actuals_max is not None and features_max is not None:
-            from datetime import timedelta
             required_end = actuals_max + timedelta(weeks=horizon_weeks)
             if features_max < required_end:
                 issues.append(

--- a/forecasting-platform/src/forecasting/base.py
+++ b/forecasting-platform/src/forecasting/base.py
@@ -7,7 +7,6 @@ The interface is designed to work with Polars DataFrames in a multi-series
 """
 
 from abc import ABC, abstractmethod
-from datetime import timedelta
 from typing import Any, Dict, List
 
 import polars as pl


### PR DESCRIPTION
…udit

Dead code removed:
- Unused `timedelta` import in src/forecasting/base.py
- Unnecessary `enumerate` wrapper in src/backtesting/engine.py:268
- Redundant nested `from datetime import timedelta` in src/data/regressors.py (hoisted to module-level import)

Missing import bugs fixed:
- Added `import polars as pl` in scripts/run_sku_mapping.py (pl.len() used but never imported)
- Added `from pyspark.sql import functions as F` in scripts/spark_backtest.py (F.col/F.lit used but never imported)

Test suite: 484 passed, 10 pre-existing FastAPI failures (no regressions).

https://claude.ai/code/session_01WWwWiBpjFwFjfhCo6cVPLr