### PR TITLE
Fix ML data integrity: enriched features, tuned hyperparams, regressor validation

### DIFF
--- a/forecasting-platform/configs/platform_config.yaml
+++ b/forecasting-platform/configs/platform_config.yaml
@@ -69,12 +69,26 @@ forecast:
   # When enabled, external feature columns are joined to the training data
   # and passed to ML models (LightGBM, XGBoost).  Statistical models
   # (ARIMA, ETS) ignore external features.
+  #
+  # IMPORTANT: each feature must be classified as "known_ahead" or
+  # "contemporaneous" via the feature_types mapping.
+  #   - known_ahead:      plannable features whose future values are known
+  #                        (holiday calendars, planned promotions). Safe to
+  #                        forward-fill at prediction time.
+  #   - contemporaneous:   features derived from actual observations (e.g.
+  #                        actual promo ratio, foot traffic).  These REQUIRE
+  #                        explicit future values or they are dropped at
+  #                        prediction time to prevent data leakage.
   external_regressors:
     enabled: false                         # set to true when feature data is available
     feature_columns: []                    # e.g. [promotion_flag, holiday_flag, price_index]
     future_features_path: null             # path to Parquet with future feature values for prediction
+    feature_types: {}                      # e.g. {holiday_flag: known_ahead, promo_ratio: contemporaneous}
 
 # ── Backtesting ───────────────────────────────────────────────────────────────
+# NOTE: For datasets with < 3 years of history, consider reducing n_folds
+# and val_weeks to preserve enough training data after lag consumption.
+# Recommended for short histories: n_folds: 2, val_weeks: 8
 backtest:
   n_folds: 3
   val_weeks: 13                          # 3 months per fold

--- a/forecasting-platform/src/config/schema.py
+++ b/forecasting-platform/src/config/schema.py
@@ -17,6 +17,12 @@ class ExternalRegressorConfig:
     enabled: bool = False
     feature_columns: List[str] = field(default_factory=list)
     future_features_path: Optional[str] = None
+    # Maps column name → "known_ahead" | "contemporaneous".
+    # "known_ahead" features (holidays, planned promos) can be forward-filled.
+    # "contemporaneous" features (actual promo ratio, foot traffic) MUST have
+    # explicit future values or they are dropped at prediction time.
+    # Columns not listed default to "known_ahead" for backward compatibility.
+    feature_types: Dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/forecasting-platform/src/data/regressors.py
+++ b/forecasting-platform/src/data/regressors.py
@@ -128,6 +128,7 @@ def validate_regressors(
     time_column: str = "week",
     id_column: Optional[str] = None,
     horizon_weeks: int = 0,
+    feature_types: Optional[dict] = None,
 ) -> List[str]:
     """
     Validate external regressor data against actuals.
@@ -137,6 +138,9 @@ def validate_regressors(
     2. Time column alignment (same grain as actuals).
     3. No nulls in feature columns during training period.
     4. If horizon_weeks > 0, future feature values must be present.
+    5. Series ID alignment (if series-level features).
+    6. Temporal causality — contemporaneous features without future values
+       cannot be used for forecasting.
 
     Parameters
     ----------
@@ -152,12 +156,16 @@ def validate_regressors(
         Optional series ID column (for series-level features).
     horizon_weeks:
         If > 0, validates that future feature values exist for this many weeks.
+    feature_types:
+        Optional dict mapping column name to ``"known_ahead"`` or
+        ``"contemporaneous"``.  Unlisted columns default to ``"known_ahead"``.
 
     Returns
     -------
     List of warning/error messages. Empty list means all checks passed.
     """
     issues: List[str] = []
+    feature_types = feature_types or {}
 
     # Check 1: Feature columns exist
     missing_cols = [c for c in feature_columns if c not in external_features.columns]
@@ -212,5 +220,25 @@ def validate_regressors(
                 f"{len(missing_ids)} series in actuals have no external features. "
                 f"These series will get null feature values (filled with 0)."
             )
+
+    # Check 6: Temporal causality — contemporaneous features need future values
+    if horizon_weeks > 0 and time_column in actuals.columns:
+        actuals_max = actuals[time_column].max()
+        features_max = external_features[time_column].max()
+        for col in feature_columns:
+            ftype = feature_types.get(col, "known_ahead")
+            if ftype == "contemporaneous":
+                if (
+                    actuals_max is not None
+                    and features_max is not None
+                    and features_max <= actuals_max
+                ):
+                    issues.append(
+                        f"Feature '{col}' is marked as contemporaneous but has "
+                        f"no future values beyond the training period "
+                        f"(features end: {features_max}, actuals end: {actuals_max}). "
+                        f"This feature will be dropped at prediction time. "
+                        f"Either provide future values or remove it from the model."
+                    )
 
     return issues

--- a/forecasting-platform/src/forecasting/base.py
+++ b/forecasting-platform/src/forecasting/base.py
@@ -59,12 +59,22 @@ class BaseForecaster(ABC):
         time_col: str = "week",
         id_col: str = "series_id",
         target_col: str = "quantity",
+        strategy: str = "zero",
     ) -> pl.DataFrame:
         """
-        Fill missing weeks with zeros for each series.
+        Fill missing weeks for each series to ensure contiguous weekly dates.
 
         Utility method available to any forecaster that needs contiguous
         weekly dates (e.g. mlforecast, statsforecast).
+
+        Parameters
+        ----------
+        strategy:
+            ``"zero"`` — fill gaps with 0.0 (original behaviour, good for
+            statistical models where zero demand is meaningful).
+            ``"forward_fill"`` — propagate last known value forward, then
+            back-fill any leading nulls with the first known value.  Better
+            for tree-based models where artificial zeros contaminate splits.
         """
         if df.is_empty():
             return df
@@ -82,10 +92,27 @@ class BaseForecaster(ABC):
         grid = series_ids.join(all_weeks_df, how="cross")
 
         filled = grid.join(df, on=[id_col, time_col], how="left")
+
         if target_col in filled.columns:
-            filled = filled.with_columns(
-                pl.col(target_col).fill_null(0.0)
-            )
+            if strategy == "forward_fill":
+                # Forward-fill per series, then back-fill leading nulls
+                filled = filled.sort([id_col, time_col])
+                filled = filled.with_columns(
+                    pl.col(target_col)
+                    .forward_fill()
+                    .over(id_col)
+                    .alias(target_col)
+                )
+                filled = filled.with_columns(
+                    pl.col(target_col)
+                    .backward_fill()
+                    .over(id_col)
+                    .alias(target_col)
+                )
+            else:
+                filled = filled.with_columns(
+                    pl.col(target_col).fill_null(0.0)
+                )
 
         return filled.sort([id_col, time_col])
 

--- a/forecasting-platform/src/forecasting/feature_manager.py
+++ b/forecasting-platform/src/forecasting/feature_manager.py
@@ -4,13 +4,18 @@ External feature lifecycle management for mlforecast-based models.
 Handles:
   1. Detection of external feature columns during fit.
   2. Merging features into the training DataFrame.
-  3. Generating future feature values for prediction (forward-fill fallback).
+  3. Generating future feature values for prediction (forward-fill fallback
+     for known-ahead features only; contemporaneous features require explicit
+     future values or are dropped).
   4. Accepting user-provided future features via ``set_future_features``.
 """
 
+import logging
 from typing import Any, Dict, List, Optional
 
 import polars as pl
+
+logger = logging.getLogger(__name__)
 
 try:
     import pandas as pd
@@ -27,10 +32,12 @@ class MLForecastFeatureManager:
     so that ``_DirectMLBase`` doesn't need inline feature plumbing.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, feature_types: Optional[Dict[str, str]] = None) -> None:
         self._feature_cols: List[str] = []
         self._train_pdf: Optional[Any] = None  # pandas DataFrame
         self._future_features: Optional[Any] = None  # pandas DataFrame
+        # Maps column name → "known_ahead" | "contemporaneous"
+        self._feature_types: Dict[str, str] = feature_types or {}
 
     @property
     def feature_cols(self) -> List[str]:
@@ -89,13 +96,44 @@ class MLForecastFeatureManager:
         )
         return pdf_with_features
 
+    def _get_feature_type(self, col: str) -> str:
+        """Return the temporal type for a feature column."""
+        return self._feature_types.get(col, "known_ahead")
+
+    def _eligible_predict_cols(self) -> List[str]:
+        """
+        Return feature columns eligible for prediction.
+
+        Contemporaneous features (e.g. actual promo ratio) are dropped
+        unless explicit future values were provided via set_future_features.
+        """
+        if self._future_features is not None:
+            # User provided explicit future values — all features are usable
+            return list(self._feature_cols)
+
+        eligible = []
+        for col in self._feature_cols:
+            if self._get_feature_type(col) == "contemporaneous":
+                logger.warning(
+                    "Dropping contemporaneous feature '%s' at prediction time: "
+                    "no future values provided. Use set_future_features() or "
+                    "mark as 'known_ahead' in config if this feature is "
+                    "plannable.",
+                    col,
+                )
+            else:
+                eligible.append(col)
+        return eligible
+
     def prepare_predict(self, horizon: int) -> Optional["pd.DataFrame"]:
         """
         Build future feature DataFrame for mlforecast predict.
 
         Returns None if no external features are present.
         Uses user-provided future features if available, otherwise
-        forward-fills the last known values per series.
+        forward-fills the last known values per series for known-ahead
+        features only. Contemporaneous features without explicit future
+        values are dropped with a warning.
         """
         if not self._feature_cols:
             return None
@@ -104,7 +142,12 @@ class MLForecastFeatureManager:
         if self._future_features is not None:
             return self._future_features
 
-        # Forward-fill fallback
+        # Determine which features can be forward-filled
+        eligible_cols = self._eligible_predict_cols()
+        if not eligible_cols:
+            return None
+
+        # Forward-fill fallback (known-ahead features only)
         if self._train_pdf is None:
             return None
 
@@ -119,7 +162,7 @@ class MLForecastFeatureManager:
                     "unique_id": uid,
                     "ds": last_ds + pd.Timedelta(weeks=h),
                 }
-                for col in self._feature_cols:
+                for col in eligible_cols:
                     row[col] = (
                         float(last_row.get(col, 0))
                         if col in uid_data.columns

--- a/forecasting-platform/src/forecasting/ml.py
+++ b/forecasting-platform/src/forecasting/ml.py
@@ -34,13 +34,18 @@ class _DirectMLBase(BaseForecaster):
     manually in Polars.
     """
 
+    # Default lags: dense coverage at short horizons, key seasonal multiples
+    DEFAULT_LAGS = [1, 2, 3, 4, 5, 6, 7, 8, 12, 13, 16, 20, 24, 26, 36, 40, 48, 52]
+
     def __init__(
         self,
         lags: Optional[List[int]] = None,
         lag_transforms: Optional[Dict] = None,
         num_threads: int = 1,
+        **kwargs,
     ):
-        self.lags = lags or [1, 2, 4, 8, 13, 26, 52]
+        self.lags = lags or self.DEFAULT_LAGS
+        self.lag_transforms = lag_transforms or self._default_lag_transforms()
         self.num_threads = num_threads
         self._id_col: str = "series_id"
         self._time_col: str = "week"
@@ -62,6 +67,26 @@ class _DirectMLBase(BaseForecaster):
         # Quantile regression state (lazily populated by predict_quantiles)
         self._quantile_mlfs: Dict[float, Any] = {}     # q -> fitted MLForecast
 
+    @staticmethod
+    def _default_lag_transforms():
+        """Default rolling window transforms applied to lag features."""
+        try:
+            from mlforecast.lag_transforms import RollingMean, RollingStd
+            return {
+                1: [
+                    RollingMean(window_size=4),
+                    RollingMean(window_size=8),
+                    RollingMean(window_size=13),
+                    RollingMean(window_size=26),
+                    RollingMean(window_size=52),
+                    RollingStd(window_size=4),
+                    RollingStd(window_size=13),
+                    RollingStd(window_size=52),
+                ],
+            }
+        except ImportError:
+            return {}
+
     def _get_learner(self):
         raise NotImplementedError
 
@@ -76,8 +101,10 @@ class _DirectMLBase(BaseForecaster):
         time_col: str = "week",
         id_col: str = "series_id",
     ) -> pl.DataFrame:
-        """Fill weekly gaps — mlforecast requires contiguous dates."""
-        return self.fill_weekly_gaps(df, time_col, id_col, target_col)
+        """Fill weekly gaps with forward-fill — avoids zero-contamination for tree models."""
+        return self.fill_weekly_gaps(
+            df, time_col, id_col, target_col, strategy="forward_fill"
+        )
 
     def fit(
         self,
@@ -109,6 +136,21 @@ class _DirectMLBase(BaseForecaster):
 
     # ── mlforecast path ───────────────────────────────────────────────────
 
+    @staticmethod
+    def _week_of_year(dates):
+        """Extract ISO week-of-year as an integer feature for mlforecast."""
+        return dates.isocalendar().week.astype(int)
+
+    @staticmethod
+    def _month(dates):
+        """Extract month as an integer feature."""
+        return dates.month
+
+    @staticmethod
+    def _quarter(dates):
+        """Extract quarter as an integer feature."""
+        return dates.quarter
+
     def _fit_mlforecast(self, df, target_col, time_col, id_col):
         train_pdf = self._feature_mgr.prepare_fit(df, id_col, time_col, target_col)
 
@@ -116,7 +158,8 @@ class _DirectMLBase(BaseForecaster):
             models=[self._get_learner()],
             freq="W",
             lags=self.lags,
-            date_features=["week", "month", "quarter"],
+            lag_transforms=self.lag_transforms,
+            date_features=[self._month, self._quarter, self._week_of_year],
             num_threads=self.num_threads,
         )
 
@@ -216,7 +259,8 @@ class _DirectMLBase(BaseForecaster):
                 models=[q_learner],
                 freq="W",
                 lags=self.lags,
-                date_features=["week", "month", "quarter"],
+                lag_transforms=self.lag_transforms,
+                date_features=[self._month, self._quarter, self._week_of_year],
                 num_threads=self.num_threads,
             )
             mlf_q.fit(self._feature_mgr.train_pdf, validate_data=False)
@@ -315,31 +359,34 @@ class LGBMDirectForecaster(_DirectMLBase):
 
     name = "lgbm_direct"
 
-    def __init__(self, **kwargs):
+    # Tuned defaults: more trees + lower lr + regularization to prevent overfitting
+    DEFAULT_PARAMS = dict(
+        n_estimators=500,
+        learning_rate=0.03,
+        num_leaves=31,
+        min_child_samples=20,
+        subsample=0.8,
+        colsample_bytree=0.8,
+        reg_alpha=0.1,
+        reg_lambda=0.1,
+        verbose=-1,
+    )
+
+    def __init__(self, lgbm_params: Optional[Dict[str, Any]] = None, **kwargs):
         super().__init__(**kwargs)
+        self._lgbm_params = {**self.DEFAULT_PARAMS, **(lgbm_params or {})}
 
     def _get_learner(self):
         import lightgbm as lgb
-        return lgb.LGBMRegressor(
-            n_estimators=200,
-            learning_rate=0.05,
-            num_leaves=31,
-            verbose=-1,
-        )
+        return lgb.LGBMRegressor(**self._lgbm_params)
 
     def _get_quantile_learner(self, alpha: float):
         import lightgbm as lgb
-        return lgb.LGBMRegressor(
-            n_estimators=200,
-            learning_rate=0.05,
-            num_leaves=31,
-            verbose=-1,
-            objective="quantile",
-            alpha=alpha,
-        )
+        params = {**self._lgbm_params, "objective": "quantile", "alpha": alpha}
+        return lgb.LGBMRegressor(**params)
 
     def get_params(self) -> Dict[str, Any]:
-        return {"model": "LightGBM", "lags": self.lags}
+        return {"model": "LightGBM", "lags": self.lags, **self._lgbm_params}
 
 
 @registry.register("xgboost_direct")
@@ -348,38 +395,38 @@ class XGBoostDirectForecaster(_DirectMLBase):
 
     name = "xgboost_direct"
 
-    def __init__(self, **kwargs):
+    # Tuned defaults: more trees + lower lr + regularization to prevent overfitting
+    DEFAULT_PARAMS = dict(
+        n_estimators=500,
+        learning_rate=0.03,
+        max_depth=6,
+        min_child_weight=20,
+        subsample=0.8,
+        colsample_bytree=0.8,
+        reg_alpha=0.1,
+        reg_lambda=0.1,
+        verbosity=0,
+    )
+
+    def __init__(self, xgb_params: Optional[Dict[str, Any]] = None, **kwargs):
         super().__init__(**kwargs)
+        self._xgb_params = {**self.DEFAULT_PARAMS, **(xgb_params or {})}
 
     def _get_learner(self):
         import xgboost as xgb
-        return xgb.XGBRegressor(
-            n_estimators=200,
-            learning_rate=0.05,
-            max_depth=6,
-            verbosity=0,
-        )
+        return xgb.XGBRegressor(**self._xgb_params)
 
     def _get_quantile_learner(self, alpha: float):
         import xgboost as xgb
         try:
-            # XGBoost ≥ 1.6 supports reg:quantileerror
-            return xgb.XGBRegressor(
-                n_estimators=200,
-                learning_rate=0.05,
-                max_depth=6,
-                verbosity=0,
-                objective="reg:quantileerror",
-                quantile_alpha=alpha,
-            )
+            params = {
+                **self._xgb_params,
+                "objective": "reg:quantileerror",
+                "quantile_alpha": alpha,
+            }
+            return xgb.XGBRegressor(**params)
         except TypeError:
-            # Older XGBoost: fall back to pseudo-Huber (approximate)
-            return xgb.XGBRegressor(
-                n_estimators=200,
-                learning_rate=0.05,
-                max_depth=6,
-                verbosity=0,
-            )
+            return xgb.XGBRegressor(**self._xgb_params)
 
     def get_params(self) -> Dict[str, Any]:
-        return {"model": "XGBoost", "lags": self.lags}
+        return {"model": "XGBoost", "lags": self.lags, **self._xgb_params}

--- a/forecasting-platform/tests/test_data_integrity.py
+++ b/forecasting-platform/tests/test_data_integrity.py
@@ -1,0 +1,294 @@
+"""
+Data integrity tests — verifying that ML pipelines don't leak, contaminate,
+or misuse features.
+
+Covers:
+  - fill_weekly_gaps forward-fill vs zero-fill behaviour
+  - Temporal causality validation for external regressors
+  - Contemporaneous feature dropping at prediction time
+  - ML beats naive on data with clear seasonal signal (regression guard)
+"""
+
+import math
+import random
+import unittest
+from datetime import date, timedelta
+from typing import List
+
+import polars as pl
+
+
+# --------------------------------------------------------------------------- #
+#  Helpers
+# --------------------------------------------------------------------------- #
+
+def _make_seasonal_series(
+    n_series: int = 3,
+    n_weeks: int = 156,  # 3 years
+    seed: int = 7,
+) -> pl.DataFrame:
+    """
+    Synthetic data with clear weekly seasonality + trend.
+
+    This is designed so that a competent ML model with lag/rolling features
+    should beat seasonal naive.
+    """
+    random.seed(seed)
+    rows: List[dict] = []
+    for s in range(1, n_series + 1):
+        base = 500.0 + s * 100
+        for w in range(n_weeks):
+            week_date = date(2020, 1, 5) + timedelta(weeks=w)  # Sunday
+            # Seasonality: higher in weeks 45-52 (holiday) and 10-15 (spring)
+            woy = week_date.isocalendar()[1]
+            seasonal = 80 * math.sin(2 * math.pi * woy / 52)
+            # Trend: slow growth
+            trend = 0.5 * w
+            noise = random.gauss(0, 15)
+            rows.append({
+                "series_id": f"S{s}",
+                "week": week_date,
+                "quantity": max(base + seasonal + trend + noise, 0.0),
+            })
+    return pl.DataFrame(rows).with_columns(pl.col("quantity").cast(pl.Float64))
+
+
+def _make_gapped_series() -> pl.DataFrame:
+    """Series with intentional gaps (missing weeks)."""
+    rows = []
+    for w in range(52):
+        week_date = date(2022, 1, 2) + timedelta(weeks=w)
+        # Skip weeks 10, 11, 12 to create a gap
+        if w in (10, 11, 12):
+            continue
+        rows.append({
+            "series_id": "G1",
+            "week": week_date,
+            "quantity": 100.0 + 5 * w,
+        })
+    return pl.DataFrame(rows).with_columns(pl.col("quantity").cast(pl.Float64))
+
+
+# --------------------------------------------------------------------------- #
+#  fill_weekly_gaps tests
+# --------------------------------------------------------------------------- #
+
+class TestFillWeeklyGaps(unittest.TestCase):
+
+    def test_forward_fill_produces_nonzero_for_gaps(self):
+        """Forward-fill strategy should propagate the last known value, not zero."""
+        from src.forecasting.base import BaseForecaster
+
+        gapped = _make_gapped_series()
+        filled = BaseForecaster.fill_weekly_gaps(
+            gapped, strategy="forward_fill"
+        )
+        # Weeks 10-12 should now be filled
+        self.assertEqual(filled.shape[0], 52)
+        gap_weeks = filled.filter(
+            pl.col("week").is_between(
+                date(2022, 3, 13), date(2022, 3, 27),  # weeks 10-12
+            )
+        )
+        # Values should be forward-filled from week 9 (not zero)
+        for val in gap_weeks["quantity"].to_list():
+            self.assertGreater(val, 0.0, "Forward-fill should not produce zeros for gaps")
+
+    def test_zero_fill_produces_zeros_for_gaps(self):
+        """Zero-fill (default) should fill gaps with 0."""
+        from src.forecasting.base import BaseForecaster
+
+        gapped = _make_gapped_series()
+        filled = BaseForecaster.fill_weekly_gaps(gapped, strategy="zero")
+        gap_weeks = filled.filter(
+            pl.col("week").is_between(
+                date(2022, 3, 13), date(2022, 3, 27),
+            )
+        )
+        for val in gap_weeks["quantity"].to_list():
+            self.assertAlmostEqual(val, 0.0)
+
+    def test_forward_fill_preserves_real_values(self):
+        """Forward-fill should not alter existing non-null values."""
+        from src.forecasting.base import BaseForecaster
+
+        gapped = _make_gapped_series()
+        original_values = gapped["quantity"].to_list()
+
+        filled = BaseForecaster.fill_weekly_gaps(
+            gapped, strategy="forward_fill"
+        )
+        # Join back to original to check values weren't altered
+        merged = gapped.join(
+            filled, on=["series_id", "week"], how="inner", suffix="_filled"
+        )
+        for orig, fil in zip(
+            merged["quantity"].to_list(),
+            merged["quantity_filled"].to_list(),
+        ):
+            self.assertAlmostEqual(orig, fil, places=6)
+
+
+# --------------------------------------------------------------------------- #
+#  Regressor validation tests
+# --------------------------------------------------------------------------- #
+
+class TestRegressorTemporalCausality(unittest.TestCase):
+
+    def test_contemporaneous_feature_flagged(self):
+        """validate_regressors should warn about contemporaneous features without future values."""
+        from src.data.regressors import validate_regressors
+
+        actuals = pl.DataFrame({
+            "week": [date(2023, 1, 1) + timedelta(weeks=w) for w in range(52)],
+            "quantity": [100.0] * 52,
+        })
+        # External features only cover training period (no future)
+        features = pl.DataFrame({
+            "week": [date(2023, 1, 1) + timedelta(weeks=w) for w in range(52)],
+            "promo_ratio": [0.5] * 52,
+        })
+        issues = validate_regressors(
+            external_features=features,
+            actuals=actuals,
+            feature_columns=["promo_ratio"],
+            horizon_weeks=13,
+            feature_types={"promo_ratio": "contemporaneous"},
+        )
+        contemporaneous_issues = [i for i in issues if "contemporaneous" in i]
+        self.assertTrue(
+            len(contemporaneous_issues) > 0,
+            "Should flag contemporaneous feature without future values",
+        )
+
+    def test_known_ahead_not_flagged(self):
+        """known_ahead features should not trigger temporal causality warning."""
+        from src.data.regressors import validate_regressors
+
+        actuals = pl.DataFrame({
+            "week": [date(2023, 1, 1) + timedelta(weeks=w) for w in range(52)],
+            "quantity": [100.0] * 52,
+        })
+        # Features cover beyond actuals
+        features = pl.DataFrame({
+            "week": [date(2023, 1, 1) + timedelta(weeks=w) for w in range(65)],
+            "holiday_flag": [0] * 65,
+        })
+        issues = validate_regressors(
+            external_features=features,
+            actuals=actuals,
+            feature_columns=["holiday_flag"],
+            horizon_weeks=13,
+            feature_types={"holiday_flag": "known_ahead"},
+        )
+        contemporaneous_issues = [i for i in issues if "contemporaneous" in i]
+        self.assertEqual(len(contemporaneous_issues), 0)
+
+
+# --------------------------------------------------------------------------- #
+#  Feature manager tests
+# --------------------------------------------------------------------------- #
+
+class TestFeatureManagerTemporalValidation(unittest.TestCase):
+
+    def test_contemporaneous_feature_dropped_without_future(self):
+        """Contemporaneous features should be dropped when no future values provided."""
+        from src.forecasting.feature_manager import MLForecastFeatureManager
+
+        mgr = MLForecastFeatureManager(
+            feature_types={"promo_ratio": "contemporaneous"}
+        )
+        # Simulate detected features
+        mgr._feature_cols = ["promo_ratio"]
+
+        eligible = mgr._eligible_predict_cols()
+        self.assertEqual(eligible, [], "Contemporaneous features should be dropped")
+
+    def test_known_ahead_feature_kept_without_future(self):
+        """known_ahead features should be eligible for forward-fill fallback."""
+        from src.forecasting.feature_manager import MLForecastFeatureManager
+
+        mgr = MLForecastFeatureManager(
+            feature_types={"holiday_flag": "known_ahead"}
+        )
+        mgr._feature_cols = ["holiday_flag"]
+
+        eligible = mgr._eligible_predict_cols()
+        self.assertEqual(eligible, ["holiday_flag"])
+
+    def test_all_features_eligible_with_explicit_future(self):
+        """All features are eligible when explicit future values are provided."""
+        import pandas as pd
+        from src.forecasting.feature_manager import MLForecastFeatureManager
+
+        mgr = MLForecastFeatureManager(
+            feature_types={"promo_ratio": "contemporaneous"}
+        )
+        mgr._feature_cols = ["promo_ratio"]
+        # Simulate user-provided future features
+        mgr._future_features = pd.DataFrame({
+            "unique_id": ["S1"] * 4,
+            "ds": pd.date_range("2024-01-01", periods=4, freq="W"),
+            "promo_ratio": [0.3, 0.0, 0.5, 0.0],
+        })
+
+        eligible = mgr._eligible_predict_cols()
+        self.assertEqual(eligible, ["promo_ratio"])
+
+
+# --------------------------------------------------------------------------- #
+#  ML regression guard
+# --------------------------------------------------------------------------- #
+
+class TestMLBeatsNaive(unittest.TestCase):
+
+    def test_ml_beats_naive_on_clear_seasonal_data(self):
+        """
+        On synthetic data with clear trend + seasonality, ML (with enriched
+        features) should achieve lower WMAPE than seasonal naive.
+
+        This is a regression guard — if this fails, the ML pipeline is broken.
+        """
+        from src.forecasting.ml import LGBMDirectForecaster
+        from src.forecasting.naive import SeasonalNaiveForecaster
+
+        data = _make_seasonal_series(n_series=3, n_weeks=156)
+
+        # Train/test split: last 13 weeks as holdout
+        max_week = data["week"].max()
+        cutoff = max_week - timedelta(weeks=13)
+        train = data.filter(pl.col("week") <= cutoff)
+        test = data.filter(pl.col("week") > cutoff)
+
+        horizon = test.select("week").unique().shape[0]
+
+        # Naive
+        naive = SeasonalNaiveForecaster()
+        naive.fit(train, target_col="quantity", time_col="week", id_col="series_id")
+        naive_preds = naive.predict(horizon=horizon, id_col="series_id", time_col="week")
+
+        # LightGBM
+        lgbm = LGBMDirectForecaster(num_threads=1)
+        lgbm.fit(train, target_col="quantity", time_col="week", id_col="series_id")
+        lgbm_preds = lgbm.predict(horizon=horizon, id_col="series_id", time_col="week")
+
+        def compute_wmape(preds, actuals):
+            merged = preds.join(actuals, on=["series_id", "week"], how="inner")
+            if merged.is_empty():
+                return 1.0
+            abs_error = (merged["forecast"] - merged["quantity"]).abs().sum()
+            total = merged["quantity"].abs().sum()
+            return float(abs_error / total) if total > 0 else 1.0
+
+        naive_wmape = compute_wmape(naive_preds, test)
+        lgbm_wmape = compute_wmape(lgbm_preds, test)
+
+        self.assertLess(
+            lgbm_wmape, naive_wmape,
+            f"LightGBM ({lgbm_wmape:.4f}) should beat naive ({naive_wmape:.4f}) "
+            f"on clear seasonal data",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Gap #1 - ML models losing to naive:
- Expand lags from 7 to 18 with denser coverage at key seasonal periods
- Add rolling mean/std transforms (windows 4/8/13/26/52) via mlforecast
- Replace zero-fill with forward-fill for tree models to prevent contamination
- Add week_of_year date feature for proper seasonality capture
- Tune LightGBM/XGBoost: 500 trees, lr=0.03, regularization, subsampling

Gap #2 - External regressors making forecasts worse:
- Add feature_types config distinguishing known_ahead vs contemporaneous
- Drop contemporaneous features without future values instead of forward-filling
- Add temporal causality check to validate_regressors
- Document feature classification in platform_config.yaml

Tests: 9 new data integrity tests (fill strategy, temporal validation,
ML-beats-naive regression guard). All 412 existing tests still pass.

https://claude.ai/code/session_01JqTtU1YHupPJ2QDeTzUEx5