### PR TITLE
Add multi-frequency support (D/W/M/Q) across the platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ forecasting-platform/
 │   ├── sku_mapping/        # New/discontinued SKU mapping
 │   ├── spark/              # PySpark distributed execution
 │   └── analytics/          # BI export, comparators, explainability, governance, FVA
-├── tests/                  # 760+ tests (pytest)
+├── tests/                  # 790+ tests (pytest)
 ├── configs/                # YAML configuration files
 ├── scripts/                # Entry points (run_backtest, run_forecast, serve, spark_*)
 └── notebooks/              # Jupyter notebooks for exploration
@@ -95,13 +95,28 @@ YAML-driven config system with dataclass schema validation:
 
 Key config dataclasses: `ForecastConfig`, `BacktestConfig`, `DataQualityConfig` (contains `ValidationConfig`, `CleansingConfig`), `ConstraintConfig`, `ExternalRegressorConfig` (contains `RegressorScreenConfig`)
 
+### Multi-frequency support
+
+The platform supports daily (`"D"`), weekly (`"W"`), monthly (`"M"`), and quarterly (`"Q"`) data frequencies. The `FREQUENCY_PROFILES` dict in `src/config/schema.py` is the single source of truth, mapping each frequency to: `season_length`, `default_lags`, `min_series_length`, `default_val_periods`, `default_horizon`, `statsforecast_freq`, and `timedelta_kwargs`.
+
+Set `frequency` in the YAML config:
+```yaml
+forecast:
+  frequency: "M"          # "D" | "W" | "M" | "Q"
+  horizon_periods: 12     # alias for horizon_weeks (backward-compat)
+backtest:
+  val_periods: 3          # alias for val_weeks (backward-compat)
+```
+
+Helper functions: `get_frequency_profile(freq)` returns the profile dict; `freq_timedelta(freq, periods)` returns a `timedelta` for date arithmetic. All models, backtesting, validation, and data processing use these instead of hardcoded weekly values.
+
 ## Testing
 
 - Framework: pytest
 - Test files mirror source structure with `test_` prefix
 - Helper fixtures use `_make_*` factory functions (e.g., `_make_weekly_actuals`)
 - Skip `test_metrics.py` and `test_feature_engineering.py` (legacy/slow)
-- 760+ tests across 32 test files
+- 790+ tests across 32 test files
 - Key test modules: `test_platform.py` (85 tests), `test_forecast_explainability.py` (59), `test_intermittent_demand.py` (55)
 
 ## Key Dependencies

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ forecasting-platform/
 │   ├── sku_mapping/        # New/discontinued SKU mapping (4 methods + Bayesian fusion)
 │   ├── spark/              # PySpark distributed execution layer
 │   └── utils/              # Logger, config utilities
-├── tests/                  # 760+ unit + integration tests
+├── tests/                  # 790+ unit + integration tests
 ├── configs/                # YAML configuration files
 ├── scripts/                # Entry points (run_backtest, run_forecast, serve, spark_*)
 ├── notebooks/              # Jupyter notebooks for exploration
@@ -590,7 +590,8 @@ audit.log(AuditEvent(action="promote_model", resource_type="model_card",
 lob: retail
 
 forecast:
-  horizon_weeks: 39          # default; override per LOB
+  frequency: W               # D | W | M | Q (drives season_length, lags, etc.)
+  horizon_weeks: 39          # periods; use horizon_periods for clarity
   forecasters: [lgbm_direct, auto_ets, seasonal_naive]
   quantiles: [0.1, 0.5, 0.9]
   sparse_detection: true
@@ -659,7 +660,7 @@ pip install -r forecasting-platform/requirements.txt
 python -m pytest forecasting-platform/tests/ \
   --ignore=forecasting-platform/tests/test_metrics.py \
   --ignore=forecasting-platform/tests/test_feature_engineering.py -v
-# 760+ tests collected
+# 790+ tests collected
 ```
 
 | Test file | Tests | Covers |
@@ -672,6 +673,7 @@ python -m pytest forecasting-platform/tests/ \
 | `test_nixtla_models.py` | 29 | AutoTheta, MSTL extended statsforecast models |
 | `test_data_analyzer.py` | 29 | Data analysis module |
 | `test_forecastability.py` | 28 | Forecastability signals and scoring |
+| `test_frequency_profiles.py` | 25 | Multi-frequency support: FREQUENCY_PROFILES, helpers, config properties, model frequency wiring |
 | `test_causal_analyzer.py` | 27 | Causal/econometric analysis |
 | `test_probabilistic_ensemble.py` | 24 | Ensemble quantiles, weight computation, config |
 | `test_demand_cleansing.py` | 24 | Outlier detection, stockout imputation, period exclusion, CleansingReport |

--- a/forecasting-platform/src/analytics/analyzer.py
+++ b/forecasting-platform/src/analytics/analyzer.py
@@ -148,7 +148,13 @@ class DataAnalyzer:
         hierarchy = self.detect_hierarchy(df, schema)
 
         # 3. Forecastability assessment
-        fa = ForecastabilityAnalyzer(season_length=self.season_length)
+        # Use detected frequency to set the correct season_length
+        try:
+            from ..config.schema import get_frequency_profile
+            _detected_sl = get_frequency_profile(schema.frequency_guess)["season_length"]
+        except (ValueError, KeyError):
+            _detected_sl = self.season_length
+        fa = ForecastabilityAnalyzer(season_length=_detected_sl)
         # Build series_id from id_columns if needed
         analysis_df, sid_col = self._prepare_analysis_df(df, schema)
         forecastability = fa.analyze(analysis_df, schema.target_column,
@@ -597,17 +603,30 @@ class DataAnalyzer:
         """Build a PlatformConfig tailored to the data characteristics."""
         reasoning: List[str] = []
 
-        # Data length in weeks
+        # Data length in periods (frequency-aware)
+        freq = schema.frequency_guess
+        try:
+            from ..config.schema import get_frequency_profile
+            profile = get_frequency_profile(freq)
+        except ValueError:
+            from ..config.schema import FREQUENCY_PROFILES
+            profile = FREQUENCY_PROFILES["W"]
+            freq = "W"
+
         try:
             d0 = date.fromisoformat(schema.date_range[0][:10])
             d1 = date.fromisoformat(schema.date_range[1][:10])
-            data_weeks = (d1 - d0).days // 7
+            td_kwargs = profile["timedelta_kwargs"]
+            period_days = sum(v * (7 if k == "weeks" else 1) for k, v in td_kwargs.items())
+            data_periods = max(1, (d1 - d0).days // period_days)
         except (ValueError, IndexError):
-            data_weeks = 52
+            data_periods = profile["min_series_length"]
+        data_weeks = data_periods  # backward-compat alias for threshold logic
 
         # ----- Forecast config ----- #
-        horizon = min(13, max(4, data_weeks // 4))
-        reasoning.append(f"Horizon set to {horizon} weeks (data_length / 4, capped at 13)")
+        default_horizon = profile["default_horizon"]
+        horizon = min(default_horizon, max(profile["default_val_periods"], data_periods // 4))
+        reasoning.append(f"Horizon set to {horizon} periods (freq={freq!r}, data_length / 4, capped at {default_horizon})")
 
         # Model selection based on forecastability and data characteristics
         forecasters = ["naive_seasonal"]

--- a/forecasting-platform/src/backtesting/cross_validator.py
+++ b/forecasting-platform/src/backtesting/cross_validator.py
@@ -19,6 +19,8 @@ from typing import List, Tuple
 
 import polars as pl
 
+from ..config.schema import freq_timedelta
+
 
 @dataclass
 class CVFold:
@@ -43,6 +45,7 @@ class WalkForwardCV:
         n_folds: int = 3,
         val_weeks: int = 13,
         gap_weeks: int = 0,
+        frequency: str = "W",
     ):
         """
         Parameters
@@ -50,13 +53,17 @@ class WalkForwardCV:
         n_folds:
             Number of validation folds.
         val_weeks:
-            Weeks in each validation window.
+            Periods in each validation window (name kept for YAML compat).
         gap_weeks:
-            Gap between train end and val start (to simulate production lag).
+            Gap periods between train end and val start (to simulate
+            production lag).
+        frequency:
+            Data frequency — ``"D"``, ``"W"``, ``"M"``, ``"Q"``.
         """
         self.n_folds = n_folds
         self.val_weeks = val_weeks
         self.gap_weeks = gap_weeks
+        self.frequency = frequency
 
     def split(
         self,
@@ -78,9 +85,9 @@ class WalkForwardCV:
         # Work backwards from max_date
         folds: List[CVFold] = []
         for i in range(self.n_folds - 1, -1, -1):
-            val_end = max_date - timedelta(weeks=i * self.val_weeks)
-            val_start = val_end - timedelta(weeks=self.val_weeks - 1)
-            train_end = val_start - timedelta(weeks=self.gap_weeks + 1)
+            val_end = max_date - freq_timedelta(self.frequency, i * self.val_weeks)
+            val_start = val_end - freq_timedelta(self.frequency, self.val_weeks - 1)
+            train_end = val_start - freq_timedelta(self.frequency, self.gap_weeks + 1)
 
             if train_end < min_date:
                 continue

--- a/forecasting-platform/src/backtesting/engine.py
+++ b/forecasting-platform/src/backtesting/engine.py
@@ -15,7 +15,7 @@ from typing import List, Optional
 
 import polars as pl
 
-from ..config.schema import PlatformConfig
+from ..config.schema import PlatformConfig, get_frequency_profile
 from ..forecasting.base import BaseForecaster
 from ..metrics.definitions import compute_all_metrics
 from ..metrics.store import METRIC_SCHEMA, MetricStore
@@ -46,6 +46,7 @@ class BacktestEngine:
             n_folds=self.bt_config.n_folds,
             val_weeks=self.bt_config.val_weeks,
             gap_weeks=self.bt_config.gap_weeks,
+            frequency=config.forecast.frequency,
         )
         self._failures: List[dict] = []
 
@@ -312,7 +313,11 @@ class BacktestEngine:
 
             for row in s.iter_rows(named=True):
                 # forecast_step: 1-indexed week offset from validation start
-                forecast_step = (row[time_col] - val_start).days // 7 + 1
+                step_days = get_frequency_profile(self.config.forecast.frequency)["timedelta_kwargs"]
+                period_days = sum(
+                    v * (7 if k == "weeks" else 1) for k, v in step_days.items()
+                )
+                forecast_step = (row[time_col] - val_start).days // period_days + 1
 
                 record = {
                     "run_id": run_id,

--- a/forecasting-platform/src/config/loader.py
+++ b/forecasting-platform/src/config/loader.py
@@ -63,7 +63,8 @@ def _dict_to_config(d: Dict[str, Any]) -> PlatformConfig:
 
     fc_raw = d.get("forecast", {})
     forecast = ForecastConfig(
-        horizon_weeks=fc_raw.get("horizon_weeks", 39),
+        horizon_weeks=fc_raw.get("horizon_periods",
+                                 fc_raw.get("horizon_weeks", 39)),
         frequency=fc_raw.get("frequency", "W"),
         target_column=fc_raw.get("target_column", "quantity"),
         time_column=fc_raw.get("time_column", "week"),
@@ -79,8 +80,10 @@ def _dict_to_config(d: Dict[str, Any]) -> PlatformConfig:
     bt_raw = d.get("backtest", {})
     backtest = BacktestConfig(
         n_folds=bt_raw.get("n_folds", 3),
-        val_weeks=bt_raw.get("val_weeks", 13),
-        gap_weeks=bt_raw.get("gap_weeks", 0),
+        val_weeks=bt_raw.get("val_periods",
+                             bt_raw.get("val_weeks", 13)),
+        gap_weeks=bt_raw.get("gap_periods",
+                             bt_raw.get("gap_weeks", 0)),
         champion_granularity=bt_raw.get("champion_granularity", "lob"),
         primary_metric=bt_raw.get("primary_metric", "wmape"),
         secondary_metric=bt_raw.get("secondary_metric", "normalized_bias"),

--- a/forecasting-platform/src/config/schema.py
+++ b/forecasting-platform/src/config/schema.py
@@ -8,7 +8,100 @@ hard-coded to a specific LOB.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from datetime import timedelta
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Frequency profiles — single source of truth for frequency-dependent defaults
+# ---------------------------------------------------------------------------
+# Each supported frequency maps to a profile dict containing:
+#   season_length     — primary seasonal cycle length in periods
+#   secondary_season  — optional secondary cycle (e.g. yearly for daily data)
+#   default_lags      — lag set for ML models
+#   min_series_length  — minimum history length (periods) to train on
+#   default_val_periods — default backtest validation window (periods)
+#   default_horizon    — default forecast horizon (periods)
+#   statsforecast_freq — freq string accepted by statsforecast / neuralforecast
+#   timedelta_kwargs   — kwargs for datetime.timedelta representing one period
+# ---------------------------------------------------------------------------
+FREQUENCY_PROFILES: Dict[str, Dict[str, Any]] = {
+    "D": {
+        "season_length": 7,
+        "secondary_season": 365,
+        "default_lags": [1, 2, 3, 7, 14, 21, 28, 56, 91, 182, 364],
+        "min_series_length": 90,
+        "default_val_periods": 28,
+        "default_horizon": 90,
+        "statsforecast_freq": "D",
+        "timedelta_kwargs": {"days": 1},
+    },
+    "W": {
+        "season_length": 52,
+        "secondary_season": None,
+        "default_lags": [1, 2, 3, 4, 5, 6, 7, 8, 12, 13, 16, 20, 26, 52],
+        "min_series_length": 52,
+        "default_val_periods": 13,
+        "default_horizon": 39,
+        "statsforecast_freq": "W",
+        "timedelta_kwargs": {"weeks": 1},
+    },
+    "M": {
+        "season_length": 12,
+        "secondary_season": None,
+        "default_lags": [1, 2, 3, 6, 12],
+        "min_series_length": 24,
+        "default_val_periods": 3,
+        "default_horizon": 12,
+        "statsforecast_freq": "MS",
+        "timedelta_kwargs": {"days": 30},
+    },
+    "Q": {
+        "season_length": 4,
+        "secondary_season": None,
+        "default_lags": [1, 2, 4, 8],
+        "min_series_length": 8,
+        "default_val_periods": 2,
+        "default_horizon": 8,
+        "statsforecast_freq": "QS",
+        "timedelta_kwargs": {"days": 91},
+    },
+}
+
+
+def get_frequency_profile(freq: str) -> Dict[str, Any]:
+    """Look up the frequency profile; raise on unknown frequency.
+
+    Parameters
+    ----------
+    freq : str
+        One of ``"D"``, ``"W"``, ``"M"``, ``"Q"``.
+
+    Returns
+    -------
+    dict
+        Profile dict with season_length, default_lags, statsforecast_freq, etc.
+    """
+    if freq not in FREQUENCY_PROFILES:
+        raise ValueError(
+            f"Unsupported frequency {freq!r}. "
+            f"Choose from: {sorted(FREQUENCY_PROFILES)}"
+        )
+    return FREQUENCY_PROFILES[freq]
+
+
+def freq_timedelta(freq: str, periods: int = 1) -> timedelta:
+    """Return a ``timedelta`` for *periods* steps at the given frequency.
+
+    Parameters
+    ----------
+    freq : str
+        One of ``"D"``, ``"W"``, ``"M"``, ``"Q"``.
+    periods : int
+        Number of periods (default 1).
+    """
+    kwargs = get_frequency_profile(freq)["timedelta_kwargs"]
+    return timedelta(**{k: v * periods for k, v in kwargs.items()})
 
 
 @dataclass
@@ -87,9 +180,18 @@ class ConstraintConfig:
 
 @dataclass
 class ForecastConfig:
-    """Forecast horizon and model selection."""
-    horizon_weeks: int = 39              # 9 months
-    frequency: str = "W"                 # weekly
+    """Forecast horizon and model selection.
+
+    The ``frequency`` field (``"D"``, ``"W"``, ``"M"``, ``"Q"``) drives
+    downstream defaults — season length, ML lags, statsforecast freq string,
+    backtest window sizing, and date arithmetic.  See :data:`FREQUENCY_PROFILES`.
+
+    ``horizon_weeks`` is kept for backward-compatible YAML loading; it
+    represents *periods* regardless of frequency.  Use the
+    :pyattr:`horizon_periods` alias for clarity.
+    """
+    horizon_weeks: int = 39              # periods (name kept for YAML compat)
+    frequency: str = "W"                 # "D" | "W" | "M" | "Q"
     target_column: str = "quantity"
     time_column: str = "week"
     series_id_column: str = "series_id"  # unique key per time series
@@ -115,6 +217,28 @@ class ForecastConfig:
         default_factory=ConstraintConfig
     )
 
+    # -- Computed helpers (not stored in YAML) --
+
+    @property
+    def horizon_periods(self) -> int:
+        """Alias for ``horizon_weeks`` (periods, frequency-agnostic)."""
+        return self.horizon_weeks
+
+    @property
+    def season_length(self) -> int:
+        """Primary seasonal cycle length derived from ``frequency``."""
+        return get_frequency_profile(self.frequency)["season_length"]
+
+    @property
+    def statsforecast_freq(self) -> str:
+        """Frequency string accepted by statsforecast / neuralforecast."""
+        return get_frequency_profile(self.frequency)["statsforecast_freq"]
+
+    @property
+    def default_lags(self) -> List[int]:
+        """Default ML lag set for the configured frequency."""
+        return list(get_frequency_profile(self.frequency)["default_lags"])
+
 
 @dataclass
 class HorizonBucket:
@@ -126,15 +250,31 @@ class HorizonBucket:
 
 @dataclass
 class BacktestConfig:
-    """Walk-forward cross-validation settings."""
+    """Walk-forward cross-validation settings.
+
+    ``val_weeks`` and ``gap_weeks`` represent *periods* (not calendar weeks)
+    when the platform runs at non-weekly frequencies.  Names are kept for
+    backward-compatible YAML loading; use :pyattr:`val_periods` /
+    :pyattr:`gap_periods` aliases for clarity.
+    """
     n_folds: int = 3
-    val_weeks: int = 13                  # each fold validates on 13 weeks
-    gap_weeks: int = 0                   # gap between train end and val start
+    val_weeks: int = 13                  # periods per fold (name kept for compat)
+    gap_weeks: int = 0                   # gap periods between train end and val start
     champion_granularity: str = "lob"    # "lob" | "product_group" | "series"
     primary_metric: str = "wmape"
     secondary_metric: str = "normalized_bias"
     selection_strategy: str = "champion" # "champion" | "weighted_ensemble"
     horizon_buckets: List[HorizonBucket] = field(default_factory=list)  # empty = single champion
+
+    @property
+    def val_periods(self) -> int:
+        """Alias for ``val_weeks`` (periods, frequency-agnostic)."""
+        return self.val_weeks
+
+    @property
+    def gap_periods(self) -> int:
+        """Alias for ``gap_weeks`` (periods, frequency-agnostic)."""
+        return self.gap_weeks
 
 
 @dataclass
@@ -207,12 +347,21 @@ class DataQualityReportConfig:
 
 @dataclass
 class DataQualityConfig:
-    """Data quality and preprocessing settings."""
-    fill_gaps: bool = True               # fill missing weeks with fill_value
+    """Data quality and preprocessing settings.
+
+    ``min_series_length_weeks`` represents *periods* (not calendar weeks)
+    when the platform runs at non-weekly frequencies.
+    """
+    fill_gaps: bool = True               # fill missing periods with fill_value
     fill_value: float = 0.0              # value to use for gap-filling
-    min_series_length_weeks: int = 52    # drop series shorter than this
+    min_series_length_weeks: int = 52    # periods (name kept for YAML compat)
     drop_zero_series: bool = False       # drop series with all-zero target
-    validate_frequency: bool = False     # if True, raise on non-weekly gaps
+    validate_frequency: bool = False     # if True, raise on inconsistent intervals
+
+    @property
+    def min_series_length(self) -> int:
+        """Alias for ``min_series_length_weeks`` (periods, frequency-agnostic)."""
+        return self.min_series_length_weeks
     validation: ValidationConfig = field(default_factory=ValidationConfig)
     cleansing: CleansingConfig = field(default_factory=CleansingConfig)
     structural_breaks: StructuralBreakConfig = field(default_factory=StructuralBreakConfig)

--- a/forecasting-platform/src/data/cleanser.py
+++ b/forecasting-platform/src/data/cleanser.py
@@ -11,7 +11,7 @@ from typing import List
 
 import polars as pl
 
-from ..config.schema import CleansingConfig
+from ..config.schema import CleansingConfig, get_frequency_profile
 
 
 # --------------------------------------------------------------------------- #
@@ -314,10 +314,15 @@ class DemandCleanser:
         time_col: str,
         value_col: str,
         sid_col: str,
+        frequency: str = "W",
     ) -> pl.DataFrame:
-        """Replace stockout zeros with same-week-prior-year value."""
+        """Replace stockout zeros with same-period-prior-year value."""
+        sl = get_frequency_profile(frequency)["season_length"]
+        td_kwargs = get_frequency_profile(frequency)["timedelta_kwargs"]
+        seasonal_lookback = {k: v * sl for k, v in td_kwargs.items()}
+        one_period = td_kwargs
         df = df.with_columns(
-            (pl.col(time_col) - pl.duration(weeks=52)).alias("_lookup_date"),
+            (pl.col(time_col) - pl.duration(**seasonal_lookback)).alias("_lookup_date"),
         )
 
         lookup = df.select(
@@ -328,15 +333,15 @@ class DemandCleanser:
 
         df = df.join(lookup, on=[sid_col, "_lookup_date"], how="left")
 
-        # Fall back to ±1 week neighbors from prior year
+        # Fall back to ±1 period neighbors from prior year
         lookup_minus1 = df.select(
             pl.col(sid_col),
-            (pl.col(time_col) + pl.duration(weeks=1)).alias("_lookup_date"),
+            (pl.col(time_col) + pl.duration(**one_period)).alias("_lookup_date"),
             pl.col(value_col).alias("_py_minus1"),
         )
         lookup_plus1 = df.select(
             pl.col(sid_col),
-            (pl.col(time_col) - pl.duration(weeks=1)).alias("_lookup_date"),
+            (pl.col(time_col) - pl.duration(**one_period)).alias("_lookup_date"),
             pl.col(value_col).alias("_py_plus1"),
         )
 

--- a/forecasting-platform/src/data/regressors.py
+++ b/forecasting-platform/src/data/regressors.py
@@ -56,12 +56,13 @@ def generate_holiday_calendar(
     start_date: date,
     end_date: date,
     time_column: str = "week",
+    frequency: str = "W",
 ) -> pl.DataFrame:
     """
-    Generate a weekly holiday flag calendar for a given country.
+    Generate a holiday flag calendar for a given country and frequency.
 
     Requires the `holidays` package (pip install holidays).
-    Each week gets a count of holidays falling within that week.
+    Each period gets a count of holidays falling within that period.
 
     Parameters
     ----------
@@ -73,6 +74,8 @@ def generate_holiday_calendar(
         End of the date range.
     time_column:
         Name for the time column in the output.
+    frequency:
+        Data frequency — ``"D"``, ``"W"``, ``"M"``, ``"Q"``.
 
     Returns
     -------
@@ -93,14 +96,18 @@ def generate_holiday_calendar(
     years = list(range(start_date.year, end_date.year + 1))
     country_holidays = _holidays_lib.country_holidays(country, years=years)
 
-    # Generate weekly date range
-    weeks = pl.date_range(start_date, end_date, interval="1w", eager=True)
+    # Generate date range at the configured frequency
+    _interval_map = {"D": "1d", "W": "1w", "M": "1mo", "Q": "1q"}
+    interval = _interval_map.get(frequency, "1w")
+    _window_days = {"D": 1, "W": 7, "M": 30, "Q": 91}
+    window = _window_days.get(frequency, 7)
+    weeks = pl.date_range(start_date, end_date, interval=interval, eager=True)
 
     holiday_counts = []
     for week_start in weeks:
-        # Count holidays in the 7-day window starting from this date
+        # Count holidays in the period window starting from this date
         count = 0
-        for day_offset in range(7):
+        for day_offset in range(window):
             check_date = week_start + pl.duration(days=day_offset)
             if isinstance(check_date, date) and check_date in country_holidays:
                 count += 1

--- a/forecasting-platform/src/data/validator.py
+++ b/forecasting-platform/src/data/validator.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional
 
 import polars as pl
 
-from ..config.schema import ValidationConfig
+from ..config.schema import ValidationConfig, freq_timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -218,8 +218,14 @@ class DataValidator:
         df: pl.DataFrame,
         time_col: str,
         id_col: str,
+        frequency: str = "W",
     ) -> tuple:
-        """Validate consistent weekly (7-day) intervals per series.
+        """Validate consistent intervals per series for the given frequency.
+
+        Parameters
+        ----------
+        frequency:
+            Expected data frequency — ``"D"``, ``"W"``, ``"M"``, ``"Q"``.
 
         Returns (issues, violation_count).
         """
@@ -233,19 +239,20 @@ class DataValidator:
         if gaps.is_empty():
             return issues, 0
 
-        non_weekly = gaps.filter(pl.col("_gap") != timedelta(days=7))
-        if non_weekly.is_empty():
+        expected_gap = freq_timedelta(frequency)
+        non_matching = gaps.filter(pl.col("_gap") != expected_gap)
+        if non_matching.is_empty():
             return issues, 0
 
-        violating_series = non_weekly[id_col].unique()
+        violating_series = non_matching[id_col].unique()
         violation_count = violating_series.len()
 
         issues.append(ValidationIssue(
             level="warning",
             check="frequency",
             message=(
-                f"{violation_count} series have non-weekly gaps "
-                f"(expected 7-day intervals)"
+                f"{violation_count} series have inconsistent gaps "
+                f"(expected {expected_gap} intervals for frequency={frequency!r})"
             ),
             details={
                 "violation_count": violation_count,

--- a/forecasting-platform/src/forecasting/foundation.py
+++ b/forecasting-platform/src/forecasting/foundation.py
@@ -40,11 +40,11 @@ Usage
 
 import logging
 import os
-from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
 import polars as pl
 
+from ..config.schema import freq_timedelta, get_frequency_profile
 from .base import BaseForecaster
 from .registry import registry
 
@@ -92,11 +92,13 @@ class ChronosForecaster(BaseForecaster):
         device: str = "cpu",
         num_samples: int = 20,
         torch_dtype: str = "bfloat16",
+        frequency: str = "W",
     ):
         self.model_name = model_name
         self.device = device
         self.num_samples = num_samples
         self.torch_dtype = torch_dtype
+        self.frequency = frequency
 
         self._pipeline: Optional[Any] = None          # lazy-loaded on first predict
         self._context: Dict[str, List[float]] = {}    # series_id → historical values
@@ -253,7 +255,7 @@ class ChronosForecaster(BaseForecaster):
             series_samples = samples_np[i]
 
             for h in range(horizon):
-                forecast_date = last_date + timedelta(weeks=h + 1)
+                forecast_date = last_date + freq_timedelta(self.frequency, h + 1)
                 row: Dict[str, Any] = {id_col: sid, time_col: forecast_date}
 
                 if quantiles is None:
@@ -302,9 +304,11 @@ class TimeGPTForecaster(BaseForecaster):
         self,
         api_key: Optional[str] = None,
         model: str = "timegpt-1",
+        frequency: str = "W",
     ):
         self.api_key = api_key or os.environ.get("NIXTLA_API_KEY", "")
         self.model = model
+        self.frequency = frequency
 
         self._client: Optional[Any] = None          # lazy-initialised
         self._train_df: Optional[pl.DataFrame] = None  # stored as Polars; converted on API call
@@ -431,7 +435,7 @@ class TimeGPTForecaster(BaseForecaster):
         kwargs: Dict[str, Any] = {
             "df": train_pdf,
             "h": horizon,
-            "freq": "W",
+            "freq": get_frequency_profile(self.frequency)["statsforecast_freq"],
             "model": self.model,
             "time_col": "ds",
             "target_col": "y",

--- a/forecasting-platform/src/forecasting/hierarchical.py
+++ b/forecasting-platform/src/forecasting/hierarchical.py
@@ -35,6 +35,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import polars as pl
 
+from ..config.schema import freq_timedelta, get_frequency_profile
 from .base import BaseForecaster
 from .registry import registry
 
@@ -186,7 +187,9 @@ class HierarchicalForecaster(BaseForecaster):
         method: str = "mint_shrink",
         base_forecaster_name: str = "auto_ets",
         middle_level: Optional[str] = None,
+        frequency: str = "W",
     ):
+        self.frequency = frequency
         if method not in _METHOD_MAP:
             raise ValueError(
                 f"Unknown hierarchical method {method!r}. "
@@ -289,11 +292,11 @@ class HierarchicalForecaster(BaseForecaster):
                 continue
 
             last_date = times[-1]
-            season = min(52, len(vals))
+            sl = get_frequency_profile(self.frequency)["season_length"]
+            season = min(sl, len(vals))
 
             for h in range(1, horizon + 1):
-                from datetime import timedelta
-                fc_date = last_date + timedelta(weeks=h)
+                fc_date = last_date + freq_timedelta(self.frequency, h)
                 # Seasonal naive: value from season_length periods ago
                 idx = len(vals) - season + ((h - 1) % season)
                 fc_val = vals[max(0, idx)]

--- a/forecasting-platform/src/forecasting/ml.py
+++ b/forecasting-platform/src/forecasting/ml.py
@@ -7,12 +7,12 @@ horizon vector.  Uses LightGBM or XGBoost as the underlying learner.
 Falls back to a direct manual implementation if mlforecast is not installed.
 """
 
-from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 import polars as pl
 
+from ..config.schema import FREQUENCY_PROFILES, freq_timedelta, get_frequency_profile
 from .base import BaseForecaster
 from .feature_manager import MLForecastFeatureManager
 from .registry import registry
@@ -34,10 +34,8 @@ class _DirectMLBase(BaseForecaster):
     manually in Polars.
     """
 
-    # Default lags: dense short-horizon + seasonal multiples.
-    # Lag-52 provides direct year-ago signal; week_of_year date feature
-    # captures cyclical pattern.  Rolling windows capped at 26 to preserve
-    # training rows on shorter histories.
+    # Default lags for weekly frequency — used when lags=None and frequency="W".
+    # For other frequencies the profile default is used instead.
     DEFAULT_LAGS = [1, 2, 3, 4, 5, 6, 7, 8, 12, 13, 16, 20, 26, 52]
 
     def __init__(
@@ -46,9 +44,12 @@ class _DirectMLBase(BaseForecaster):
         lag_transforms: Optional[Dict] = None,
         num_threads: int = 1,
         freq: Optional[str] = None,
+        frequency: str = "W",
         **kwargs,
     ):
-        self.lags = lags or self.DEFAULT_LAGS
+        self.frequency = frequency
+        profile = get_frequency_profile(frequency)
+        self.lags = lags or list(profile["default_lags"])
         self.lag_transforms = lag_transforms or self._default_lag_transforms()
         self.num_threads = num_threads
         self._freq = freq  # auto-detected from data if None
@@ -154,36 +155,50 @@ class _DirectMLBase(BaseForecaster):
         """Extract quarter as an integer feature."""
         return dates.quarter
 
-    @staticmethod
-    def _detect_weekly_freq(df, time_col: str) -> str:
-        """Detect the pandas-compatible weekly frequency from data dates.
+    def _detect_freq(self, df, time_col: str) -> str:
+        """Detect the pandas-compatible frequency string from data dates.
 
-        Polars ``truncate("1w")`` produces Monday-start weeks, but pandas
-        ``"W"`` anchors on Sunday.  Using the wrong anchor shifts all date
-        features and predicted dates.  This helper infers the correct
-        ``W-<DAY>`` offset from the actual dates in the data.
+        For weekly data, infers the correct ``W-<DAY>`` anchor from actual
+        dates.  For other frequencies, returns the statsforecast freq string
+        from the frequency profile.
         """
+        profile = get_frequency_profile(self.frequency)
+        if self.frequency != "W":
+            return profile["statsforecast_freq"]
         dates = df[time_col].unique().sort()
         if len(dates) < 2:
             return "W"
-        # Use the weekday of the first date as the anchor
         first_date = dates[0]
         if hasattr(first_date, "weekday"):
             day_name = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"][first_date.weekday()]
             return f"W-{day_name}"
         return "W"
 
+    def _get_date_features(self):
+        """Return date feature extractors appropriate for the frequency."""
+        features = [self._month, self._quarter]
+        if self.frequency in ("D", "W"):
+            features.append(self._week_of_year)
+        if self.frequency == "D":
+            features.append(self._day_of_week)
+        return features
+
+    @staticmethod
+    def _day_of_week(dates):
+        """Extract day-of-week (0=Mon … 6=Sun) as an integer feature."""
+        return dates.weekday
+
     def _fit_mlforecast(self, df, target_col, time_col, id_col):
         train_pdf = self._feature_mgr.prepare_fit(df, id_col, time_col, target_col)
 
-        freq = self._freq or self._detect_weekly_freq(df, time_col)
+        freq = self._freq or self._detect_freq(df, time_col)
 
         self._mlf = MLForecast(
             models=[self._get_learner()],
             freq=freq,
             lags=self.lags,
             lag_transforms=self.lag_transforms,
-            date_features=[self._month, self._quarter, self._week_of_year],
+            date_features=self._get_date_features(),
             num_threads=self.num_threads,
         )
 
@@ -285,7 +300,7 @@ class _DirectMLBase(BaseForecaster):
                 freq=freq,
                 lags=self.lags,
                 lag_transforms=self.lag_transforms,
-                date_features=[self._month, self._quarter, self._week_of_year],
+                date_features=self._get_date_features(),
                 num_threads=self.num_threads,
             )
             mlf_q.fit(self._feature_mgr.train_pdf, validate_data=False)
@@ -322,7 +337,7 @@ class _DirectMLBase(BaseForecaster):
             )
             values = series[self._target_col].to_list()
             n = len(values)
-            sl = 52
+            sl = get_frequency_profile(self.frequency)["season_length"]
             residuals = [
                 values[i] - values[i - sl]
                 for i in range(sl, n)
@@ -360,14 +375,15 @@ class _DirectMLBase(BaseForecaster):
 
             # Simple: use last season_length values cyclically
             n = len(values)
+            sl = get_frequency_profile(self.frequency)["season_length"]
             for h in range(1, horizon + 1):
-                idx = n - 52 + ((h - 1) % 52)
+                idx = n - sl + ((h - 1) % sl)
                 if idx < 0:
                     idx = max(0, n - 1)
                 val = values[min(idx, n - 1)]
                 results.append({
                     id_col: sid,
-                    time_col: max_date + timedelta(weeks=h),
+                    time_col: max_date + freq_timedelta(self.frequency, h),
                     "forecast": float(val),
                 })
 

--- a/forecasting-platform/src/forecasting/naive.py
+++ b/forecasting-platform/src/forecasting/naive.py
@@ -7,12 +7,12 @@ yearly seasonality, it copies weeks from the same period one year ago.
 This serves as the "beat this" benchmark for all other models.
 """
 
-from datetime import timedelta
 from typing import Any, Dict, List
 
 import numpy as np
 import polars as pl
 
+from ..config.schema import freq_timedelta, get_frequency_profile
 from .base import BaseForecaster
 from .registry import registry
 
@@ -23,13 +23,23 @@ class SeasonalNaiveForecaster(BaseForecaster):
 
     name = "naive_seasonal"
 
-    def __init__(self, season_length: int = 52):
+    def __init__(self, season_length: int = 52, frequency: str = "W"):
         """
         Parameters
         ----------
         season_length:
-            Number of periods in one seasonal cycle (52 for weekly-yearly).
+            Number of periods in one seasonal cycle.  Defaults to the
+            value from ``FREQUENCY_PROFILES[frequency]`` when left at 52
+            and *frequency* is not ``"W"``.
+        frequency:
+            Data frequency — ``"D"``, ``"W"``, ``"M"``, or ``"Q"``.
         """
+        self.frequency = frequency
+        profile = get_frequency_profile(frequency)
+        # If caller left season_length at the old weekly default but picked
+        # a non-weekly frequency, use the profile default instead.
+        if season_length == 52 and frequency != "W":
+            season_length = profile["season_length"]
         self.season_length = season_length
         self._fitted_data: pl.DataFrame = pl.DataFrame()
         self._target_col: str = "quantity"
@@ -78,7 +88,7 @@ class SeasonalNaiveForecaster(BaseForecaster):
                 if idx < 0:
                     idx = (h - 1) % n  # fallback for short series
                 val = values[idx] if 0 <= idx < n else 0.0
-                forecast_date = max_date + timedelta(weeks=h)
+                forecast_date = max_date + freq_timedelta(self.frequency, h)
                 forecasts.append({
                     id_col: series_id,
                     time_col: forecast_date,
@@ -124,7 +134,7 @@ class SeasonalNaiveForecaster(BaseForecaster):
                 # Not enough history — fall back to degenerate intervals
                 point_rows = [
                     {id_col: series_id,
-                     time_col: max_date + timedelta(weeks=h),
+                     time_col: max_date + freq_timedelta(self.frequency, h),
                      **{f"forecast_p{int(round(q * 100))}": float(
                          values[min(len(values) - self.season_length + ((h - 1) % self.season_length),
                                     len(values) - 1)]
@@ -148,7 +158,7 @@ class SeasonalNaiveForecaster(BaseForecaster):
                 if idx < 0:
                     idx = (h - 1) % n
                 point_val = float(values[idx] if 0 <= idx < n else 0.0)
-                forecast_date = max_date + timedelta(weeks=h)
+                forecast_date = max_date + freq_timedelta(self.frequency, h)
 
                 pos = idx % sl
                 pos_residuals = residuals_by_pos.get(pos, [0.0])
@@ -171,4 +181,4 @@ class SeasonalNaiveForecaster(BaseForecaster):
         return pl.DataFrame(results)
 
     def get_params(self) -> Dict[str, Any]:
-        return {"season_length": self.season_length}
+        return {"season_length": self.season_length, "frequency": self.frequency}

--- a/forecasting-platform/src/forecasting/neural.py
+++ b/forecasting-platform/src/forecasting/neural.py
@@ -50,6 +50,7 @@ from typing import Any, Dict, List, Optional
 
 import polars as pl
 
+from ..config.schema import get_frequency_profile
 from .base import BaseForecaster
 from .registry import registry
 
@@ -94,6 +95,7 @@ class _NeuralforecastBase(BaseForecaster):
         accelerator: str = "cpu",
         enable_progress_bar: bool = False,
         quantiles: Optional[List[float]] = None,
+        frequency: str = "W",
     ):
         self.max_steps = max_steps
         self.learning_rate = learning_rate
@@ -103,6 +105,7 @@ class _NeuralforecastBase(BaseForecaster):
         self.accelerator = accelerator
         self.enable_progress_bar = enable_progress_bar
         self._quantiles = quantiles
+        self.frequency = frequency
 
         self._nf: Optional[Any] = None
         self._id_col: str = "series_id"
@@ -149,9 +152,10 @@ class _NeuralforecastBase(BaseForecaster):
         # trained horizon, we refit (neuralforecast requires h at init).
         self._horizon = 13
         model = self._get_model(self._horizon)
+        sf_freq = get_frequency_profile(self.frequency)["statsforecast_freq"]
         self._nf = NeuralForecast(
             models=[model],
-            freq="W",
+            freq=sf_freq,
         )
 
         is_cpu = self.accelerator == "cpu"

--- a/forecasting-platform/src/forecasting/registry.py
+++ b/forecasting-platform/src/forecasting/registry.py
@@ -18,6 +18,7 @@ Instantiate from config::
     forecasters = registry.build_from_config(["naive_seasonal", "lgbm_direct"])
 """
 
+import inspect
 from typing import Callable, Dict, List, Optional, Type
 
 from .base import BaseForecaster
@@ -56,8 +57,21 @@ class ForecasterRegistry:
         return self._registry[name]
 
     def build(self, name: str, **kwargs) -> BaseForecaster:
-        """Instantiate a forecaster by name."""
+        """Instantiate a forecaster by name.
+
+        Unknown kwargs are silently dropped so that pipeline-level
+        parameters (e.g. ``frequency``) can be broadcast to all models
+        without requiring every model to accept them.
+        """
         cls = self.get(name)
+        sig = inspect.signature(cls.__init__)
+        accepts_var_kw = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD
+            for p in sig.parameters.values()
+        )
+        if not accepts_var_kw:
+            valid = set(sig.parameters) - {"self"}
+            kwargs = {k: v for k, v in kwargs.items() if k in valid}
         return cls(**kwargs)
 
     def build_from_config(

--- a/forecasting-platform/src/forecasting/statistical.py
+++ b/forecasting-platform/src/forecasting/statistical.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 
 import polars as pl
 
+from ..config.schema import get_frequency_profile
 from .base import BaseForecaster
 from .registry import registry
 
@@ -36,7 +37,11 @@ class _StatsforecastBase(BaseForecaster):
     and maps columns to the expected ``unique_id / ds / y`` schema.
     """
 
-    def __init__(self, season_length: int = 52):
+    def __init__(self, season_length: int = 52, frequency: str = "W"):
+        self.frequency = frequency
+        profile = get_frequency_profile(frequency)
+        if season_length == 52 and frequency != "W":
+            season_length = profile["season_length"]
         self.season_length = season_length
         self._sf: Optional[Any] = None
         self._id_col: str = "series_id"
@@ -74,7 +79,7 @@ class _StatsforecastBase(BaseForecaster):
         model = self._get_model()
         self._sf = StatsForecast(
             models=[model],
-            freq="W",
+            freq=get_frequency_profile(self.frequency)["statsforecast_freq"],
             n_jobs=1,
         )
         self._sf.fit(pdf)
@@ -220,8 +225,9 @@ class AutoThetaForecaster(_StatsforecastBase):
         self,
         season_length: int = 52,
         decomposition_type: str = "multiplicative",
+        frequency: str = "W",
     ):
-        super().__init__(season_length=season_length)
+        super().__init__(season_length=season_length, frequency=frequency)
         self.decomposition_type = decomposition_type
 
     def _get_model(self):
@@ -265,8 +271,9 @@ class MSTLForecaster(_StatsforecastBase):
         self,
         season_length: int = 52,
         secondary_season_length: Optional[int] = None,
+        frequency: str = "W",
     ):
-        super().__init__(season_length=season_length)
+        super().__init__(season_length=season_length, frequency=frequency)
         self.secondary_season_length = secondary_season_length
 
     def _get_model(self):

--- a/forecasting-platform/src/pipeline/backtest.py
+++ b/forecasting-platform/src/pipeline/backtest.py
@@ -80,14 +80,21 @@ class BacktestPipeline:
                      len(series),
                      series[fc.series_id_column].n_unique())
 
-        # Step 2: Instantiate forecasters from config
-        forecasters = registry.build_from_config(fc.forecasters)
+        # Step 2: Instantiate forecasters from config (frequency-aware)
+        freq_kwargs = {"frequency": fc.frequency}
+        forecasters = registry.build_from_config(
+            fc.forecasters,
+            params={name: freq_kwargs for name in fc.forecasters},
+        )
         logger.info("Forecasters: %s", [f.name for f in forecasters])
 
         # Intermittent demand forecasters (optional sparse routing)
         sparse_forecasters = None
         if fc.intermittent_forecasters and fc.sparse_detection:
-            sparse_forecasters = registry.build_from_config(fc.intermittent_forecasters)
+            sparse_forecasters = registry.build_from_config(
+                fc.intermittent_forecasters,
+                params={name: freq_kwargs for name in fc.intermittent_forecasters},
+            )
             logger.info(
                 "Sparse forecasters: %s", [f.name for f in sparse_forecasters]
             )

--- a/forecasting-platform/src/pipeline/forecast.py
+++ b/forecasting-platform/src/pipeline/forecast.py
@@ -112,7 +112,9 @@ class ForecastPipeline:
 
         # Step 2: Resolve forecaster (name → registry lookup, or use directly)
         if isinstance(champion_model, str):
-            forecaster: BaseForecaster = registry.build(champion_model)
+            forecaster: BaseForecaster = registry.build(
+                champion_model, frequency=fc.frequency
+            )
         else:
             forecaster = champion_model
         logger.info("Champion model: %s", forecaster.name)
@@ -224,7 +226,7 @@ class ForecastPipeline:
                 bucket_name, start_step, end_step, model_name,
             )
 
-            forecaster = registry.build(model_name)
+            forecaster = registry.build(model_name, frequency=fc.frequency)
             forecaster.fit(
                 series,
                 target_col=fc.target_column,

--- a/forecasting-platform/src/series/builder.py
+++ b/forecasting-platform/src/series/builder.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 import polars as pl
 
-from ..config.schema import PlatformConfig
+from ..config.schema import PlatformConfig, get_frequency_profile
 from .transition import TransitionEngine
 
 logger = logging.getLogger(__name__)
@@ -33,6 +33,7 @@ class SeriesBuilder:
 
     def __init__(self, config: PlatformConfig):
         self.config = config
+        self._frequency = config.forecast.frequency
         self._transition_engine = TransitionEngine(config.transition)
         self._last_validation_report = None
         self._last_cleansing_report = None
@@ -291,8 +292,11 @@ class SeriesBuilder:
         if min_date is None or max_date is None:
             return df
 
+        _interval_map = {"D": "1d", "W": "1w", "M": "1mo", "Q": "1q"}
+        freq = getattr(self, "_frequency", "W")
+        interval = _interval_map.get(freq, "1w")
         all_weeks = pl.date_range(
-            min_date, max_date, interval="1w", eager=True
+            min_date, max_date, interval=interval, eager=True
         ).alias(time_col)
         all_weeks_df = pl.DataFrame({time_col: all_weeks})
 

--- a/forecasting-platform/tests/test_frequency_profiles.py
+++ b/forecasting-platform/tests/test_frequency_profiles.py
@@ -1,0 +1,210 @@
+"""
+Tests for multi-frequency support infrastructure.
+
+Validates that FREQUENCY_PROFILES, helper functions, and frequency-aware
+config properties work correctly for all supported frequencies (D/W/M/Q).
+"""
+
+import unittest
+from datetime import date, timedelta
+
+import polars as pl
+
+from src.config.schema import (
+    FREQUENCY_PROFILES,
+    BacktestConfig,
+    DataQualityConfig,
+    ForecastConfig,
+    freq_timedelta,
+    get_frequency_profile,
+)
+
+
+class TestFrequencyProfiles(unittest.TestCase):
+    """Tests for the FREQUENCY_PROFILES dict."""
+
+    def test_all_four_frequencies_present(self):
+        self.assertEqual(sorted(FREQUENCY_PROFILES.keys()), ["D", "M", "Q", "W"])
+
+    def test_each_profile_has_required_keys(self):
+        required = {
+            "season_length", "secondary_season", "default_lags",
+            "min_series_length", "default_val_periods", "default_horizon",
+            "statsforecast_freq", "timedelta_kwargs",
+        }
+        for freq, profile in FREQUENCY_PROFILES.items():
+            with self.subTest(freq=freq):
+                self.assertTrue(
+                    required.issubset(profile.keys()),
+                    f"Missing keys for {freq}: {required - profile.keys()}"
+                )
+
+    def test_season_lengths(self):
+        self.assertEqual(FREQUENCY_PROFILES["D"]["season_length"], 7)
+        self.assertEqual(FREQUENCY_PROFILES["W"]["season_length"], 52)
+        self.assertEqual(FREQUENCY_PROFILES["M"]["season_length"], 12)
+        self.assertEqual(FREQUENCY_PROFILES["Q"]["season_length"], 4)
+
+    def test_statsforecast_freq_strings(self):
+        self.assertEqual(FREQUENCY_PROFILES["D"]["statsforecast_freq"], "D")
+        self.assertEqual(FREQUENCY_PROFILES["W"]["statsforecast_freq"], "W")
+        self.assertEqual(FREQUENCY_PROFILES["M"]["statsforecast_freq"], "MS")
+        self.assertEqual(FREQUENCY_PROFILES["Q"]["statsforecast_freq"], "QS")
+
+    def test_default_lags_are_sorted(self):
+        for freq, profile in FREQUENCY_PROFILES.items():
+            with self.subTest(freq=freq):
+                lags = profile["default_lags"]
+                self.assertEqual(lags, sorted(lags), f"Lags not sorted for {freq}")
+
+
+class TestGetFrequencyProfile(unittest.TestCase):
+    """Tests for the get_frequency_profile() helper."""
+
+    def test_valid_frequencies(self):
+        for freq in ("D", "W", "M", "Q"):
+            profile = get_frequency_profile(freq)
+            self.assertIsInstance(profile, dict)
+            self.assertIn("season_length", profile)
+
+    def test_invalid_frequency_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            get_frequency_profile("Y")
+        self.assertIn("Unsupported frequency", str(ctx.exception))
+        self.assertIn("'Y'", str(ctx.exception))
+
+
+class TestFreqTimedelta(unittest.TestCase):
+    """Tests for the freq_timedelta() helper."""
+
+    def test_daily(self):
+        self.assertEqual(freq_timedelta("D"), timedelta(days=1))
+        self.assertEqual(freq_timedelta("D", 7), timedelta(days=7))
+
+    def test_weekly(self):
+        self.assertEqual(freq_timedelta("W"), timedelta(weeks=1))
+        self.assertEqual(freq_timedelta("W", 4), timedelta(weeks=4))
+
+    def test_monthly(self):
+        self.assertEqual(freq_timedelta("M"), timedelta(days=30))
+        self.assertEqual(freq_timedelta("M", 3), timedelta(days=90))
+
+    def test_quarterly(self):
+        self.assertEqual(freq_timedelta("Q"), timedelta(days=91))
+        self.assertEqual(freq_timedelta("Q", 2), timedelta(days=182))
+
+    def test_date_arithmetic(self):
+        """freq_timedelta should work with date addition."""
+        d = date(2024, 1, 1)
+        self.assertEqual(d + freq_timedelta("W", 1), date(2024, 1, 8))
+        self.assertEqual(d + freq_timedelta("D", 1), date(2024, 1, 2))
+
+
+class TestForecastConfigProperties(unittest.TestCase):
+    """Tests for frequency-derived ForecastConfig properties."""
+
+    def test_weekly_defaults(self):
+        fc = ForecastConfig()
+        self.assertEqual(fc.frequency, "W")
+        self.assertEqual(fc.season_length, 52)
+        self.assertEqual(fc.statsforecast_freq, "W")
+        self.assertEqual(fc.horizon_periods, 39)
+
+    def test_daily_frequency(self):
+        fc = ForecastConfig(frequency="D")
+        self.assertEqual(fc.season_length, 7)
+        self.assertEqual(fc.statsforecast_freq, "D")
+        self.assertEqual(fc.default_lags, [1, 2, 3, 7, 14, 21, 28, 56, 91, 182, 364])
+
+    def test_monthly_frequency(self):
+        fc = ForecastConfig(frequency="M")
+        self.assertEqual(fc.season_length, 12)
+        self.assertEqual(fc.statsforecast_freq, "MS")
+        self.assertEqual(fc.default_lags, [1, 2, 3, 6, 12])
+
+    def test_quarterly_frequency(self):
+        fc = ForecastConfig(frequency="Q")
+        self.assertEqual(fc.season_length, 4)
+        self.assertEqual(fc.statsforecast_freq, "QS")
+
+
+class TestBacktestConfigAliases(unittest.TestCase):
+    """Tests for BacktestConfig period aliases."""
+
+    def test_val_periods_alias(self):
+        bt = BacktestConfig(val_weeks=8)
+        self.assertEqual(bt.val_periods, 8)
+
+    def test_gap_periods_alias(self):
+        bt = BacktestConfig(gap_weeks=2)
+        self.assertEqual(bt.gap_periods, 2)
+
+
+class TestDataQualityConfigAlias(unittest.TestCase):
+    """Tests for DataQualityConfig min_series_length alias."""
+
+    def test_min_series_length_alias(self):
+        dq = DataQualityConfig(min_series_length_weeks=24)
+        self.assertEqual(dq.min_series_length, 24)
+
+
+class TestNaiveForecasterFrequency(unittest.TestCase):
+    """Tests that SeasonalNaiveForecaster respects frequency parameter."""
+
+    def test_monthly_season_length(self):
+        from src.forecasting.naive import SeasonalNaiveForecaster
+        f = SeasonalNaiveForecaster(frequency="M")
+        self.assertEqual(f.season_length, 12)
+        self.assertEqual(f.frequency, "M")
+
+    def test_weekly_default_unchanged(self):
+        from src.forecasting.naive import SeasonalNaiveForecaster
+        f = SeasonalNaiveForecaster()
+        self.assertEqual(f.season_length, 52)
+        self.assertEqual(f.frequency, "W")
+
+    def test_explicit_season_length_preserved(self):
+        from src.forecasting.naive import SeasonalNaiveForecaster
+        f = SeasonalNaiveForecaster(season_length=26, frequency="M")
+        self.assertEqual(f.season_length, 26)
+
+    def test_monthly_predict_dates(self):
+        """Monthly frequency should produce ~30-day-apart forecast dates."""
+        from src.forecasting.naive import SeasonalNaiveForecaster
+        f = SeasonalNaiveForecaster(frequency="M")
+        df = pl.DataFrame({
+            "series_id": ["A"] * 24,
+            "week": [date(2022, 1, 1) + timedelta(days=30 * i) for i in range(24)],
+            "quantity": [float(i % 12 + 1) for i in range(24)],
+        })
+        f.fit(df)
+        preds = f.predict(3)
+        dates = preds["week"].sort().to_list()
+        # Check that forecast dates are roughly monthly apart
+        for i in range(1, len(dates)):
+            gap = (dates[i] - dates[i - 1]).days
+            self.assertGreaterEqual(gap, 28)
+            self.assertLessEqual(gap, 32)
+
+
+class TestRegistryFrequencyFiltering(unittest.TestCase):
+    """Tests that registry.build() handles unknown kwargs gracefully."""
+
+    def test_build_with_frequency(self):
+        from src.forecasting.registry import registry
+        f = registry.build("naive_seasonal", frequency="M")
+        self.assertEqual(f.frequency, "M")
+
+    def test_build_drops_unknown_kwargs(self):
+        """Models that don't accept frequency should not fail."""
+        from src.forecasting.registry import registry
+        # Croston doesn't accept frequency — should not raise
+        try:
+            f = registry.build("croston", frequency="M")
+            self.assertEqual(f.name, "croston")
+        except TypeError:
+            self.fail("registry.build() should drop unknown kwargs")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduces FREQUENCY_PROFILES in src/config/schema.py as the single source
of truth for frequency-dependent defaults (season_length, lags, timedelta,
statsforecast freq string). The ForecastConfig.frequency field now drives
all downstream behavior: models, backtesting, validation, cleansing, and
data processing.

Key changes:
- FREQUENCY_PROFILES dict + get_frequency_profile() + freq_timedelta() helpers
- ForecastConfig.season_length, .statsforecast_freq, .default_lags properties
- All 6 model families accept frequency param (naive, statistical, ML, neural, foundation, hierarchical)
- Registry.build() gracefully drops unknown kwargs for models that don't accept frequency
- WalkForwardCV and BacktestEngine use frequency-aware fold boundaries
- DataValidator, DemandCleanser, holiday calendar, SeriesBuilder all frequency-aware
- DataAnalyzer.recommend_config() uses detected frequency for profile-aware defaults
- Pipeline passes frequency to all model instantiation via registry
- Backward-compatible: horizon_periods/val_periods aliases with *_weeks fallback
- 25 new tests in test_frequency_profiles.py; 834 existing tests still pass

https://claude.ai/code/session_019nDzaLrjC4xZXckMenWbK3