### PR TITLE
docs: fix weekly-only language — platform supports D/W/M/Q frequencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Weekly sales forecasting platform for retail S&OP. Python 3.8+, built on FastAPI (REST API), PySpark (distributed execution), and Polars (data processing). Combines statistical, ML, neural, and foundation model forecasting with hierarchical reconciliation.
+Multi-frequency (daily/weekly/monthly/quarterly) sales forecasting platform for retail S&OP. Python 3.8+, built on FastAPI (REST API), PySpark (distributed execution), and Polars (data processing). Combines statistical, ML, neural, and foundation model forecasting with hierarchical reconciliation.
 
 Main code lives in `forecasting-platform/`.
 

--- a/EDGE_CASES.md
+++ b/EDGE_CASES.md
@@ -20,7 +20,7 @@ A catalog of the failure modes that break forecasting platforms — what goes wr
 
 **How the platform handles it:** `FREQUENCY_PROFILES` in `src/config/schema.py` defines frequency-aware minimum lengths (weekly: 52, monthly: 24, daily: 90, quarterly: 8). The series builder filters by `min_series_length_weeks` before training. The data quality report counts and surfaces `short_series_count`. The sparse detector returns `demand_class="insufficient_data"` for series below `min_periods` (default 10), routing them to standard models rather than intermittent ones. The seasonal naive forecaster uses cyclic index fallback for series shorter than `season_length`.
 
-**What to watch for:** Borderline series (e.g., 53 weeks for a weekly model with season_length=52) pass the filter but may still produce unstable seasonal estimates. Consider setting `min_series_length_weeks` to 1.5× the seasonal period for better reliability. Also, foundation models (Chronos, TimeGPT) can produce reasonable forecasts on shorter series since they don't need to learn seasonality from scratch.
+**What to watch for:** Borderline series (e.g., 53 weeks for a weekly model with season_length=52) pass the filter but may still produce unstable seasonal estimates. Consider setting `min_series_length` to 1.5× the seasonal period for the configured frequency for better reliability. Also, foundation models (Chronos, TimeGPT) can produce reasonable forecasts on shorter series since they don't need to learn seasonality from scratch.
 
 ---
 
@@ -90,7 +90,7 @@ A catalog of the failure modes that break forecasting platforms — what goes wr
 
 **How the platform handles it:** The data quality report (`src/data/quality_report.py`) surfaces `missing_week_pct` and `series_with_gaps`. The base forecaster class (`src/forecasting/base.py`) provides `fill_weekly_gaps()` with two strategies: `"zero"` (fill gaps with 0.0 — appropriate when missing = no demand) and `"forward_fill"` (propagate last known value — appropriate when missing = unobserved but demand likely continued). ML models default to forward-fill to avoid zero contamination in lag features. Gap filling is configurable via `DataQualityConfig(fill_gaps, fill_value)`.
 
-**What to watch for:** Long gaps (longer than one seasonal cycle) filled with zeros create artificial sparse patterns that may trigger the intermittent demand detector, routing the series to Croston when it's actually a regular-demand series with bad data. Long gaps filled with forward-fill create artificially flat regions that distort trend estimation. For gaps longer than ~4 weeks, consider excluding the pre-gap data entirely (similar to structural break truncation) rather than imputing.
+**What to watch for:** Long gaps (longer than one seasonal cycle) filled with zeros create artificial sparse patterns that may trigger the intermittent demand detector, routing the series to Croston when it's actually a regular-demand series with bad data. Long gaps filled with forward-fill create artificially flat regions that distort trend estimation. For gaps longer than ~4 periods (frequency-dependent), consider excluding the pre-gap data entirely (similar to structural break truncation) rather than imputing.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Forecasting Platform
 
-A production-grade, modular weekly sales forecasting platform. Covers the full lifecycle from raw data ingestion to hierarchically reconciled, explained, and governed forecasts — with a REST API, Microsoft Fabric/Delta Lake deployment layer, Spark distributed execution, and S&OP exception management.
+A production-grade, modular multi-frequency sales forecasting platform (daily, weekly, monthly, quarterly). Covers the full lifecycle from raw data ingestion to hierarchically reconciled, explained, and governed forecasts — with a REST API, Microsoft Fabric/Delta Lake deployment layer, Spark distributed execution, and S&OP exception management.
 
 **See also:** [CONCEPTS.md](CONCEPTS.md) — why each component exists and when to use it | [EDGE_CASES.md](EDGE_CASES.md) — failure modes and how the platform handles them
 
@@ -194,7 +194,7 @@ def predict_quantiles(self, horizon: int, quantiles: list[float]) -> pl.DataFram
 | Function | Description |
 |----------|-------------|
 | `load_external_features(path)` | Load external feature data from Parquet or CSV |
-| `generate_holiday_calendar(country, start, end)` | Generate weekly holiday flags using the `holidays` library (optional dep) |
+| `generate_holiday_calendar(country, start, end)` | Generate period-level holiday flags using the `holidays` library (optional dep) |
 | `validate_regressors(features, actuals, columns)` | Validate grain alignment, null checks, future coverage for forecast horizon |
 
 ML models (`LGBMDirectForecaster`, `XGBoostDirectForecaster`) automatically detect and use external feature columns during `fit()` and `predict()`. Statistical and naive models silently ignore them.
@@ -281,7 +281,7 @@ No UPDATE or DELETE operations — append-only by design for SOX compliance.
 
 | Class | Description |
 |-------|-------------|
-| `SeriesBuilder` | Builds weekly panel DataFrames from raw transactional data; fills gaps; integrates validation and cleansing |
+| `SeriesBuilder` | Builds frequency-aware panel DataFrames from raw transactional data; fills gaps; integrates validation and cleansing |
 | `SparseDetector` | Classifies series as smooth / intermittent / erratic / lumpy using CV-squared and ADI |
 | `TransitionEngine` | Handles new-product launches: stitches history, applies linear/S-curve/step ramps |
 | `StructuralBreakDetector` | Identifies permanent level shifts via CUSUM (zero-dependency) or PELT (`ruptures`); truncates history to post-break regime |


### PR DESCRIPTION
Update CLAUDE.md, README.md, and EDGE_CASES.md to reflect multi-frequency support instead of implying weekly-only forecasting.

https://claude.ai/code/session_019nDzaLrjC4xZXckMenWbK3