### PR TITLE
feat: add QUICKSTART.md and fix onboarding experience

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,78 @@
+# Quick Start
+
+Get the forecasting platform running in your browser. Pick one path:
+
+## Path A — Docker (recommended)
+
+No Python setup needed. Just Docker.
+
+```bash
+git clone https://github.com/chaitu1385/Forecasting-Platform.git
+cd Forecasting-Platform
+docker compose up
+```
+
+Open **http://localhost:8501** in your browser. That's it.
+
+<!-- screenshot: Streamlit landing page after docker compose up -->
+
+## Path B — Local Python
+
+Requires Python 3.8+.
+
+```bash
+git clone https://github.com/chaitu1385/Forecasting-Platform.git
+cd Forecasting-Platform
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+pip install -r forecasting-platform/requirements.txt
+streamlit run forecasting-platform/streamlit/app.py
+```
+
+Open **http://localhost:8501** in your browser.
+
+<!-- screenshot: Streamlit landing page running locally -->
+
+## What to do next
+
+Once the app is open, follow these four pages in order:
+
+### 1. Data Onboarding
+
+Click **Data Onboarding** in the sidebar. Then click **Use sample data** — no download needed, the platform generates a built-in retail dataset automatically.
+
+You'll see: schema detection (columns, frequency, date range), a forecastability gauge, demand classification, and a recommended model configuration. Click **Download Config YAML** to save it.
+
+<!-- screenshot: Data Onboarding page with forecastability gauge and config -->
+
+### 2. Backtest Results
+
+After running a backtest (`python forecasting-platform/scripts/run_backtest.py`), this page shows the model leaderboard, an FVA cascade chart showing which model layers add or destroy value, and a per-series champion map.
+
+<!-- screenshot: FVA cascade bar chart with ADDS_VALUE / DESTROYS_VALUE annotations -->
+
+### 3. Forecast Viewer
+
+Upload forecast output to see an interactive chart with P10/P90 confidence intervals. Add actuals to overlay historical data and see the seasonal decomposition (trend, seasonal, residual).
+
+<!-- screenshot: Fan chart with actuals overlay -->
+
+### 4. Platform Health
+
+Monitor pipeline runs, drift alerts, data quality, and compute cost. Drift alerts are colour-coded by severity (warning, critical).
+
+<!-- screenshot: Drift alerts table with severity colouring -->
+
+## Optional: AI features
+
+Set `ANTHROPIC_API_KEY` to enable Claude-powered features (natural-language explanations, config recommendations, executive commentary). Everything works without it — AI features degrade gracefully.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+## Next steps
+
+- [README.md](README.md) — full architecture and module reference
+- [CONCEPTS.md](CONCEPTS.md) — why each component exists
+- [EDGE_CASES.md](EDGE_CASES.md) — failure modes and how the platform handles them

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # Forecasting Platform
 
+```bash
+git clone https://github.com/chaitu1385/Forecasting-Platform.git
+cd Forecasting-Platform
+docker compose up          # open http://localhost:8501
+```
+
+No Docker? See [QUICKSTART.md](QUICKSTART.md) for the local Python path.
+
+---
+
 A production-grade, modular weekly sales forecasting platform. Covers the full lifecycle from raw data ingestion to hierarchically reconciled, explained, and governed forecasts — with a REST API, Microsoft Fabric/Delta Lake deployment layer, Spark distributed execution, and S&OP exception management.
 
-**See also:** [CONCEPTS.md](CONCEPTS.md) — why each component exists and when to use it | [EDGE_CASES.md](EDGE_CASES.md) — failure modes and how the platform handles them
+**See also:** [QUICKSTART.md](QUICKSTART.md) — get running in 2 minutes | [CONCEPTS.md](CONCEPTS.md) — why each component exists | [EDGE_CASES.md](EDGE_CASES.md) — failure modes and how the platform handles them
 
 ---
 

--- a/forecasting-platform/streamlit/app.py
+++ b/forecasting-platform/streamlit/app.py
@@ -32,21 +32,29 @@ st.set_page_config(
 #  Landing page
 # ---------------------------------------------------------------------------
 st.title("Forecasting Platform")
+
+st.markdown(
+    "Weekly sales forecasting for retail S&OP — statistical, ML, neural, "
+    "and foundation models with hierarchical reconciliation."
+)
+
+st.info(
+    "**Start here:** Open **Data Onboarding** in the sidebar, "
+    "then click **Use sample data** to see the platform in action."
+)
+
 st.markdown(
     """
-    Weekly sales forecasting for retail S&OP — statistical, ML, neural, and
-    foundation models with hierarchical reconciliation.
+**Pages**
 
-    Use the sidebar to navigate between pages:
+1. **Data Onboarding** — Upload data or use the built-in sample to auto-detect schema, assess forecastability, and get a recommended config.
+2. **Backtest Results** — Model leaderboard, FVA cascade showing which layers add or destroy value, per-series champion map.
+3. **Forecast Viewer** — Interactive forecast chart with P10/P90 confidence intervals, actuals overlay, and seasonal decomposition.
+4. **Platform Health** — Pipeline manifests, drift alerts, data quality summary, and compute cost.
 
-    | Page | Purpose |
-    |------|---------|
-    | **Data Onboarding** | Upload data, detect schema & hierarchy, assess forecastability, get a recommended config |
-    | **Backtest Results** | Model leaderboard, FVA cascade, champion map |
-    | **Forecast Viewer** | Interactive forecast chart with confidence intervals and decomposition |
-    | **Platform Health** | Pipeline manifests, drift alerts, data quality, compute cost |
+**Need help?** See [QUICKSTART.md](https://github.com/chaitu1385/Forecasting-Platform/blob/master/QUICKSTART.md) for setup instructions.
     """
 )
 
 st.divider()
-st.caption("Built with Streamlit · Powered by the Forecasting Platform engine")
+st.caption("Built with Streamlit")

--- a/forecasting-platform/streamlit/pages/1_Data_Onboarding.py
+++ b/forecasting-platform/streamlit/pages/1_Data_Onboarding.py
@@ -16,11 +16,14 @@ import streamlit as st
 import yaml
 
 _PLATFORM_ROOT = Path(__file__).resolve().parent.parent.parent
+_STREAMLIT_DIR = Path(__file__).resolve().parent.parent
 if str(_PLATFORM_ROOT) not in sys.path:
     sys.path.insert(0, str(_PLATFORM_ROOT))
+if str(_STREAMLIT_DIR) not in sys.path:
+    sys.path.insert(0, str(_STREAMLIT_DIR))
 
 from src.analytics.analyzer import DataAnalyzer
-from streamlit.utils import (
+from utils import (
     COLORS,
     load_sample_data,
     load_uploaded_csv,
@@ -41,22 +44,19 @@ with col_upload:
     uploaded_file = st.file_uploader("Upload CSV", type=["csv"])
 
 with col_sample:
-    use_sample = st.button("Use Rossmann sample data")
+    use_sample = st.button("Use sample data")
 
 df = None
 if uploaded_file is not None:
     df = load_uploaded_csv(uploaded_file)
-    st.success(f"Loaded {df.shape[0]:,} rows × {df.shape[1]} columns from upload.")
+    st.success(f"Loaded {df.shape[0]:,} rows x {df.shape[1]} columns from upload.")
 elif use_sample or st.session_state.get("sample_loaded"):
     df = load_sample_data()
-    if df is not None:
-        st.session_state["sample_loaded"] = True
-        st.success(f"Loaded Rossmann sample: {df.shape[0]:,} rows × {df.shape[1]} columns.")
-    else:
-        st.warning("Sample data not found. Place Rossmann train.csv in data/rossmann/.")
+    st.session_state["sample_loaded"] = True
+    st.success(f"Loaded sample data: {df.shape[0]:,} rows x {df.shape[1]} columns.")
 
 if df is None:
-    st.info("Upload a CSV or load the sample data to get started.")
+    st.info("Upload a CSV or click **Use sample data** to get started.")
     st.stop()
 
 # ---------------------------------------------------------------------------

--- a/forecasting-platform/streamlit/pages/2_Backtest_Results.py
+++ b/forecasting-platform/streamlit/pages/2_Backtest_Results.py
@@ -13,14 +13,17 @@ import plotly.graph_objects as go
 import streamlit as st
 
 _PLATFORM_ROOT = Path(__file__).resolve().parent.parent.parent
+_STREAMLIT_DIR = Path(__file__).resolve().parent.parent
 if str(_PLATFORM_ROOT) not in sys.path:
     sys.path.insert(0, str(_PLATFORM_ROOT))
+if str(_STREAMLIT_DIR) not in sys.path:
+    sys.path.insert(0, str(_STREAMLIT_DIR))
 
 import polars as pl
 
 from src.analytics.fva_analyzer import FVAAnalyzer
 from src.metrics.store import MetricStore
-from streamlit.utils import (
+from utils import (
     COLORS,
     DATA_DIR,
     FVA_COLORS,

--- a/forecasting-platform/streamlit/pages/3_Forecast_Viewer.py
+++ b/forecasting-platform/streamlit/pages/3_Forecast_Viewer.py
@@ -12,13 +12,16 @@ import plotly.graph_objects as go
 import streamlit as st
 
 _PLATFORM_ROOT = Path(__file__).resolve().parent.parent.parent
+_STREAMLIT_DIR = Path(__file__).resolve().parent.parent
 if str(_PLATFORM_ROOT) not in sys.path:
     sys.path.insert(0, str(_PLATFORM_ROOT))
+if str(_STREAMLIT_DIR) not in sys.path:
+    sys.path.insert(0, str(_STREAMLIT_DIR))
 
 import polars as pl
 
 from src.analytics.explainer import ForecastExplainer
-from streamlit.utils import COLORS, DATA_DIR, polars_to_pandas
+from utils import COLORS, DATA_DIR, polars_to_pandas
 
 st.set_page_config(page_title="Forecast Viewer", page_icon="📈", layout="wide")
 st.title("Forecast Viewer")

--- a/forecasting-platform/streamlit/pages/4_Platform_Health.py
+++ b/forecasting-platform/streamlit/pages/4_Platform_Health.py
@@ -13,15 +13,18 @@ import plotly.graph_objects as go
 import streamlit as st
 
 _PLATFORM_ROOT = Path(__file__).resolve().parent.parent.parent
+_STREAMLIT_DIR = Path(__file__).resolve().parent.parent
 if str(_PLATFORM_ROOT) not in sys.path:
     sys.path.insert(0, str(_PLATFORM_ROOT))
+if str(_STREAMLIT_DIR) not in sys.path:
+    sys.path.insert(0, str(_STREAMLIT_DIR))
 
 import polars as pl
 
 from src.metrics.drift import DriftConfig, ForecastDriftDetector
 from src.metrics.store import MetricStore
 from src.pipeline.manifest import PipelineManifest, read_manifest
-from streamlit.utils import (
+from utils import (
     COLORS,
     DATA_DIR,
     SEVERITY_COLORS,

--- a/forecasting-platform/streamlit/utils.py
+++ b/forecasting-platform/streamlit/utils.py
@@ -74,11 +74,62 @@ def polars_to_pandas(df: pl.DataFrame):
     return df.to_pandas()
 
 
-def load_sample_data() -> Optional[pl.DataFrame]:
-    """Load the bundled Rossmann sample dataset (if present)."""
+def load_sample_data() -> pl.DataFrame:
+    """Load the bundled Rossmann sample dataset, or generate synthetic data.
+
+    Tries Rossmann CSV first. If not found, generates a synthetic retail
+    dataset so the sample button always works on first click.
+    """
     if SAMPLE_DATA.exists():
-        return pl.read_csv(str(SAMPLE_DATA), try_parse_dates=True)
-    return None
+        try:
+            return pl.read_csv(
+                str(SAMPLE_DATA),
+                try_parse_dates=True,
+                infer_schema_length=10000,
+            )
+        except Exception:
+            pass  # fall through to synthetic
+    return _generate_synthetic_retail()
+
+
+def _generate_synthetic_retail() -> pl.DataFrame:
+    """Generate a synthetic retail dataset for demo purposes.
+
+    20 stores x 3 categories x 104 weeks = 6,240 rows with trend,
+    seasonality, noise, and a promo regressor.
+    """
+    import numpy as np
+    from datetime import date, timedelta
+
+    rng = np.random.RandomState(42)
+    rows = []
+    base = date(2020, 1, 6)
+    n_weeks = 104
+
+    stores = {
+        f"store_{i}": rng.choice(["North", "South", "East", "West"])
+        for i in range(20)
+    }
+    categories = ["Food", "Electronics", "Clothing"]
+
+    for store_id, region in stores.items():
+        for cat in categories:
+            base_demand = rng.uniform(50, 200)
+            for w in range(n_weeks):
+                seasonal = 30 * np.sin(2 * np.pi * w / 52)
+                trend = 0.2 * w
+                noise = rng.normal(0, 10)
+                qty = max(0, base_demand + seasonal + trend + noise)
+                rows.append({
+                    "week": base + timedelta(weeks=w),
+                    "store_id": store_id,
+                    "region": region,
+                    "category": cat,
+                    "quantity": round(qty, 2),
+                    "promo_intensity": round(rng.uniform(0, 1), 2),
+                })
+
+    return pl.DataFrame(rows)
 
 
 def format_pct(value: float, decimals: int = 1) -> str:


### PR DESCRIPTION
- QUICKSTART.md: two paths (Docker / local Python) to a working demo in under 5 minutes, guided walkthrough of all 4 Streamlit pages
- Synthetic data fallback: "Use sample data" button always works, even without Rossmann CSV — generates 6,240-row retail dataset (20 stores, 3 categories, 104 weeks) with trend, seasonality, and noise
- Fix import conflict: `from streamlit.utils` clashed with the streamlit package — changed all pages to `from utils import ...` with explicit sys.path for the streamlit directory
- Friendlier landing page: clear call-to-action pointing to Data Onboarding, 1-sentence page descriptions, link to QUICKSTART.md
- README.md: 4-line Quick Start block at the very top

https://claude.ai/code/session_01Pj1MNta99vMZqazNzmHPNm