### PR TITLE
feat: add smart multi-file upload with auto-classification and merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,9 @@ forecasting-platform/
 │   │   ├── validator.py    # DataValidator — schema enforcement, duplicate/frequency/range checks
 │   │   ├── cleanser.py     # DemandCleanser — outlier detection, stockout imputation, period exclusion
 │   │   ├── regressor_screen.py # RegressorScreen — variance, correlation, MI screening
-│   │   └── regressors.py   # External regressor loader, holiday calendar, validation
+│   │   ├── regressors.py   # External regressor loader, holiday calendar, validation
+│   │   ├── file_classifier.py # FileClassifier — auto-detect file roles (time_series, dimension, regressor)
+│   │   └── file_merger.py  # MultiFileMerger — join key detection, multi-file merge with preview
 │   ├── evaluation/         # Metric computations (WMAPE, RMSPE, bias, MAE)
 │   ├── forecasting/        # Model implementations + registry
 │   │   ├── naive.py        # SeasonalNaiveForecaster
@@ -149,10 +151,8 @@ Helper functions: `get_frequency_profile(freq)` returns the profile dict; `freq_
 - Test files mirror source structure with `test_` prefix
 - Helper fixtures use `_make_*` factory functions (e.g., `_make_weekly_actuals`)
 - Skip `test_metrics.py` and `test_feature_engineering.py` (legacy/slow)
-- 860+ tests across 35 test files
-- Key test modules: `test_platform.py` (85 tests), `test_forecast_explainability.py` (59), `test_intermittent_demand.py` (55)
-- 860+ tests across 38 test files
-- Key test modules: `test_platform.py` (85 tests), `test_ai_*.py` (73), `test_forecast_explainability.py` (59), `test_intermittent_demand.py` (55)
+- 900+ tests across 40 test files
+- Key test modules: `test_platform.py` (85 tests), `test_ai_*.py` (73), `test_forecast_explainability.py` (59), `test_intermittent_demand.py` (55), `test_file_classifier.py` (26), `test_file_merger.py` (20)
 
 ## Key Dependencies
 

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -186,3 +186,9 @@ Forecasting platforms generate data (metrics, drift alerts, leaderboards) that p
 A forecasting platform that only data scientists can operate is incomplete — demand planners need to see forecasts, compare models, and review exceptions; platform admins need to monitor health and drift. The Streamlit dashboard provides a browser-based interface with four pages mapped to three user personas: Data Onboarding (upload data, assess forecastability, get a recommended config), Backtest Results (model leaderboard with FVA cascade), Forecast Viewer (interactive fan chart with seasonal decomposition), and Platform Health (drift alerts, pipeline manifests, compute cost). It imports platform classes directly — no API round-trip — so a `docker compose up` gives a working demo in under two minutes.
 
 *Implementation: `streamlit/` — `app.py`, `pages/1_Data_Onboarding.py`, `pages/2_Backtest_Results.py`, `pages/3_Forecast_Viewer.py`, `pages/4_Platform_Health.py`*
+
+### Multi-File Upload Classification
+
+Real-world forecasting projects rarely have a single tidy CSV — sales history lives in one extract, store attributes in another, promotions in a third, and weather data from an external API. Asking users to pre-join everything is error-prone and kills the onboarding experience. The `FileClassifier` auto-detects each file's role (time series, dimension lookup, external regressor) using heuristics on column types, naming patterns, and cardinality, then `MultiFileMerger` detects join keys and produces a merged DataFrame for analysis. The Data Onboarding page exposes this as an interactive confirmation step: users upload N files, review the auto-detected roles, see a merge preview with join stats, and then run the full analysis on the combined data.
+
+*Implementation: `src/data/file_classifier.py` — `FileClassifier`, `src/data/file_merger.py` — `MultiFileMerger`*

--- a/EDGE_CASES.md
+++ b/EDGE_CASES.md
@@ -198,3 +198,30 @@ A catalog of the failure modes that break forecasting platforms — what goes wr
 **How the platform handles it:** The `DataAnalyzer.analyze()` call is wrapped with `@st.cache_data`, so repeat analyses of the same data are instant. Plotly charts render client-side, avoiding server-side image generation bottlenecks. Each page shows graceful empty states (info messages) when no data is loaded, so the app never crashes on missing inputs. The Rossmann sample dataset (18 MB, 1M rows) is bundled as a one-click demo to bypass upload friction.
 
 **What to watch for:** Streamlit re-runs the entire page script on every widget interaction. Heavy computations (DataAnalyzer, FVA cascade) must be cached or they re-execute on every click. If users upload datasets larger than the Rossmann sample, consider adding `st.session_state` checkpoints to avoid redundant recomputation. The Docker container should be provisioned with at least 2 GB RAM for datasets with 1000+ series.
+
+
+---
+
+## 21. Multi-File Upload: No Time-Series File Detected
+
+**What happens:** A user uploads multiple CSV files (e.g., a stores lookup table and a promotions calendar) but none contains a recognizable time-series structure — no date column paired with a numeric target and repeating identifiers.
+
+**How the platform handles it:** The `FileClassifier.classify_files()` method scores each file for the `time_series` role using heuristics: date column detection (type + name pattern), target column name matching, ID column repetition, and row count. If no file scores above the 0.4 confidence threshold, `ClassificationResult.primary_file` is `None` and a clear warning is emitted. The Data Onboarding page shows an `st.error()` explaining exactly what format is expected (date column, numeric target, identifier columns) and stops the flow before any merge or analysis is attempted.
+
+**What to watch for:** Files with date columns but no clear target (e.g., a holiday calendar with `date` and `holiday_name`) might score near the threshold. If a user's time-series file uses an unusual target column name (e.g., `y`, `total`), it may not match the known patterns and get classified as a regressor instead. Users can override the auto-detected role via the interactive confirmation step.
+
+## 22. Multi-File Upload: Duplicate Column Names Across Files
+
+**What happens:** Two files share a non-key column name — e.g., both `sales.csv` and `stores.csv` have a column called `quantity`. A naive join would silently overwrite one column or create ambiguous `_right` suffixes.
+
+**How the platform handles it:** `MultiFileMerger._resolve_column_conflicts()` detects non-key columns that exist in both the left (merged-so-far) and right DataFrames before each join. Conflicting columns in the right DataFrame are renamed with a `_<filename_stem>` suffix (e.g., `quantity` from `stores.csv` becomes `quantity_stores`). The list of renames is recorded in `MergePreview.column_name_conflicts` and displayed to the user in an expandable section.
+
+**What to watch for:** If many files have overlapping column names, the renamed columns (e.g., `temperature_weather`, `temperature_climate`) can be confusing. Review the conflict list in the merge preview. Column renames only apply to non-key columns — join keys are never renamed.
+
+## 23. Multi-File Upload: Mismatched Granularity
+
+**What happens:** The primary time series is at store-level granularity (`store_id × week`), but an external regressor file is at region-level (`region × week`). A direct join on `[week]` would broadcast region-level features to all stores, which may be correct for weather data but misleading for store-specific regressors.
+
+**How the platform handles it:** The `MultiFileMerger` performs a left join, so all primary rows are preserved regardless of granularity mismatch. When a regressor has no ID column overlap with the primary, it joins on `[time_col]` only — effectively broadcasting global features. When it has partial ID overlap (e.g., `region` but not `store_id`), the join uses the available keys. Low key overlap percentages (< 50%) trigger warnings in `JoinSpec.warnings`, displayed in the merge preview.
+
+**What to watch for:** Broadcast features can introduce multicollinearity if the same value appears across many series. The `RegressorScreen` (run during model fitting) catches near-constant columns via variance threshold, but it's worth reviewing the merge preview to ensure the join makes business sense.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,25 @@ Runs after gap-filling in `SeriesBuilder.build()` when `cleansing.enabled = True
 
 Runs after feature join in `SeriesBuilder.build()` when `external_regressors.screen.enabled = True`. Optionally auto-drops flagged columns (`auto_drop=True`).
 
+#### FileClassifier (multi-file upload role detection)
+
+| Class/Dataclass | Description |
+|-----------------|-------------|
+| `FileClassifier` | Classifies uploaded DataFrames into roles: `time_series`, `dimension`, `regressor`, `unknown`. Two-pass: isolation scoring then cross-file resolution |
+| `FileProfile` | Per-file profile with `role`, `confidence`, `time_column`, `id_columns`, `numeric_columns`, `reasoning` |
+| `ClassificationResult` | All files bucketed into `primary_file`, `dimension_files`, `regressor_files`, `unknown_files` with warnings |
+
+#### MultiFileMerger (join key detection and merge)
+
+| Class/Dataclass | Description |
+|-----------------|-------------|
+| `MultiFileMerger` | Detects join keys between classified files, generates merge preview with stats, executes left-join merge |
+| `JoinSpec` | Join specification: keys, overlap percentage, warnings |
+| `MergePreview` | Pre-merge stats: sample rows, matched/unmatched counts, column conflicts, null-fill columns |
+| `MergeResult` | Final merged DataFrame with preview metadata and join specs |
+
+Used by the Data Onboarding page to accept N CSV files, classify roles, preview the merge, and feed a single combined DataFrame to `DataAnalyzer`.
+
 ### `src/auth/` — RBAC & Authentication
 
 | Class/Function | Description |
@@ -768,6 +787,8 @@ python -m pytest forecasting-platform/tests/ \
 | `test_data_integrity.py` | 9 | Data integrity checks |
 | `test_multi_horizon.py` | 8 | Multi-horizon forecast evaluation |
 | `test_regressor_screen.py` | 16 | Variance, correlation, MI screening; auto-drop; SeriesBuilder integration |
+| `test_file_classifier.py` | 26 | File role classification: time_series, dimension, regressor, unknown; confidence scoring; cross-file resolution |
+| `test_file_merger.py` | 20 | Join key detection, merge preview, full merge, column conflict resolution, null filling |
 | `test_pipeline_manifest.py` | 15 | Manifest build, write, read roundtrip; hash determinism; ForecastPipeline integration |
 | `test_external_regressors.py` | 6 | Regressor validation, SeriesBuilder with/without features |
 | `test_data_loader.py` | 6 | Data loading from files |

--- a/forecasting-platform/src/analytics/analyzer.py
+++ b/forecasting-platform/src/analytics/analyzer.py
@@ -78,6 +78,8 @@ class AnalysisReport:
     config_reasoning: List[str]
     hypotheses: List[str]
     warnings: List[str] = field(default_factory=list)
+    regressor_columns: List[str] = field(default_factory=list)
+    dimension_sources: List[str] = field(default_factory=list)
 
 
 # --------------------------------------------------------------------------- #

--- a/forecasting-platform/src/data/file_classifier.py
+++ b/forecasting-platform/src/data/file_classifier.py
@@ -1,0 +1,514 @@
+"""
+FileClassifier — automatic role classification for multi-file uploads.
+
+Given N uploaded DataFrames, classifies each into one of:
+- ``time_series``: primary demand/sales data (date + target + IDs)
+- ``dimension``: lookup/attribute table (IDs + categorical attributes, no date)
+- ``regressor``: external feature table (date + numeric features, joinable)
+- ``unknown``: does not match any expected pattern
+
+Classification is a two-pass process:
+1. **Isolation pass** — score each file independently for ``time_series`` signals.
+2. **Resolution pass** — pick the best primary, then re-evaluate remaining files
+   as ``dimension`` or ``regressor`` relative to the primary.
+
+Usage
+-----
+>>> from src.data.file_classifier import FileClassifier
+>>> classifier = FileClassifier()
+>>> result = classifier.classify_files({"sales.csv": df_sales, "stores.csv": df_stores})
+>>> print(result.primary_file.filename)
+'sales.csv'
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import polars as pl
+
+# Reuse heuristic constants from DataAnalyzer
+_TIME_COLUMN_PATTERNS = {"week", "date", "ds", "time", "timestamp", "period", "day"}
+_TARGET_COLUMN_PATTERNS = {
+    "quantity", "sales", "demand", "revenue", "volume", "units",
+    "target", "value", "amount", "qty", "count",
+}
+
+_NUMERIC_TYPES = (
+    pl.Float32, pl.Float64,
+    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+)
+
+
+# --------------------------------------------------------------------------- #
+#  Result dataclasses
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class FileProfile:
+    """Profile of a single uploaded file."""
+
+    filename: str
+    df: pl.DataFrame
+    role: str  # "time_series" | "dimension" | "regressor" | "unknown"
+    confidence: float  # 0.0 – 1.0
+    time_column: Optional[str]  # None for dimension / unknown files
+    id_columns: List[str]
+    numeric_columns: List[str]
+    categorical_columns: List[str]
+    n_rows: int
+    n_columns: int
+    reasoning: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ClassificationResult:
+    """Result of classifying all uploaded files."""
+
+    profiles: List[FileProfile]
+    primary_file: Optional[FileProfile]
+    dimension_files: List[FileProfile]
+    regressor_files: List[FileProfile]
+    unknown_files: List[FileProfile]
+    warnings: List[str] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+#  FileClassifier
+# --------------------------------------------------------------------------- #
+
+class FileClassifier:
+    """Classify uploaded DataFrames into pipeline roles.
+
+    Parameters
+    ----------
+    id_cardinality_cap : int
+        Maximum unique values for a column to be treated as an ID (not free text).
+    """
+
+    def __init__(self, id_cardinality_cap: int = 10_000):
+        self.id_cardinality_cap = id_cardinality_cap
+
+    # ------------------------------------------------------------------ #
+    #  Public API
+    # ------------------------------------------------------------------ #
+
+    def classify_files(
+        self,
+        files: Dict[str, pl.DataFrame],
+    ) -> ClassificationResult:
+        """Classify all files and resolve roles.
+
+        Parameters
+        ----------
+        files : Dict[str, pl.DataFrame]
+            Mapping of ``filename -> DataFrame``.
+
+        Returns
+        -------
+        ClassificationResult
+        """
+        if not files:
+            return ClassificationResult(
+                profiles=[], primary_file=None,
+                dimension_files=[], regressor_files=[],
+                unknown_files=[], warnings=["No files provided"],
+            )
+
+        # Pass 1: classify each file in isolation (looking for time_series signals)
+        profiles = [self.classify_single(name, df) for name, df in files.items()]
+
+        # Pass 2: cross-file resolution
+        return self._resolve_roles(profiles)
+
+    def classify_single(
+        self,
+        filename: str,
+        df: pl.DataFrame,
+    ) -> FileProfile:
+        """Classify a single file in isolation.
+
+        In isolation we can only detect ``time_series`` signals. Dimension
+        and regressor roles require a primary to compare against, so those
+        are assigned in :meth:`_resolve_roles`.
+        """
+        reasoning: List[str] = []
+        dtypes = {c: df[c].dtype for c in df.columns}
+
+        time_col = self._find_time_column(df, dtypes)
+        target_col = self._find_target_column(df, dtypes, time_col)
+        id_cols = self._find_id_columns(df, dtypes, time_col, target_col)
+        numeric_cols = self._find_numeric_columns(df, dtypes, time_col, target_col)
+        cat_cols = self._find_categorical_columns(df, dtypes, time_col, target_col)
+
+        # Score for time_series role
+        ts_score = self._score_time_series(
+            df, time_col, target_col, id_cols, dtypes, reasoning,
+        )
+
+        role = "time_series" if ts_score >= 0.4 else "unknown"
+
+        return FileProfile(
+            filename=filename,
+            df=df,
+            role=role,
+            confidence=round(min(ts_score, 1.0), 3),
+            time_column=time_col,
+            id_columns=id_cols,
+            numeric_columns=numeric_cols,
+            categorical_columns=cat_cols,
+            n_rows=df.height,
+            n_columns=len(df.columns),
+            reasoning=reasoning,
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Column detection helpers (mirroring DataAnalyzer)
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _find_time_column(
+        df: pl.DataFrame,
+        dtypes: Dict[str, pl.DataType],
+    ) -> Optional[str]:
+        """Find a date/time column, or ``None`` if absent."""
+        cols = df.columns
+        # 1. Actual Date/Datetime types
+        for c in cols:
+            if dtypes[c] in (pl.Date, pl.Datetime):
+                return c
+        # 2. Name matching
+        for c in cols:
+            if c.lower() in _TIME_COLUMN_PATTERNS:
+                return c
+        # 3. Try parsing string columns
+        for c in cols:
+            if dtypes[c] in (pl.Utf8, pl.String):
+                try:
+                    parsed = df[c].str.to_date(strict=False)
+                    if parsed.null_count() < df.height * 0.5:
+                        return c
+                except Exception:
+                    continue
+        return None
+
+    @staticmethod
+    def _find_target_column(
+        df: pl.DataFrame,
+        dtypes: Dict[str, pl.DataType],
+        time_col: Optional[str],
+    ) -> Optional[str]:
+        """Find the most likely target column, or ``None``."""
+        numeric_cols = [
+            c for c in df.columns
+            if c != time_col and dtypes[c] in _NUMERIC_TYPES
+        ]
+        if not numeric_cols:
+            return None
+        for c in numeric_cols:
+            if c.lower() in _TARGET_COLUMN_PATTERNS:
+                return c
+        return max(numeric_cols, key=lambda c: df.height - df[c].null_count())
+
+    def _find_id_columns(
+        self,
+        df: pl.DataFrame,
+        dtypes: Dict[str, pl.DataType],
+        time_col: Optional[str],
+        target_col: Optional[str],
+    ) -> List[str]:
+        """Find categorical columns with moderate cardinality (likely IDs)."""
+        result = []
+        for c in df.columns:
+            if c in (time_col, target_col):
+                continue
+            if dtypes[c] in (pl.Utf8, pl.Categorical, pl.String):
+                n_unique = df[c].n_unique()
+                if 1 < n_unique <= self.id_cardinality_cap:
+                    result.append(c)
+        return result
+
+    @staticmethod
+    def _find_numeric_columns(
+        df: pl.DataFrame,
+        dtypes: Dict[str, pl.DataType],
+        time_col: Optional[str],
+        target_col: Optional[str],
+    ) -> List[str]:
+        """Return numeric columns excluding time and target."""
+        return [
+            c for c in df.columns
+            if c not in (time_col, target_col) and dtypes[c] in _NUMERIC_TYPES
+        ]
+
+    @staticmethod
+    def _find_categorical_columns(
+        df: pl.DataFrame,
+        dtypes: Dict[str, pl.DataType],
+        time_col: Optional[str],
+        target_col: Optional[str],
+    ) -> List[str]:
+        """Return string/categorical columns excluding time and target."""
+        return [
+            c for c in df.columns
+            if c not in (time_col, target_col)
+            and dtypes[c] in (pl.Utf8, pl.Categorical, pl.String)
+        ]
+
+    # ------------------------------------------------------------------ #
+    #  Scoring helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _score_time_series(
+        df: pl.DataFrame,
+        time_col: Optional[str],
+        target_col: Optional[str],
+        id_cols: List[str],
+        dtypes: Dict[str, pl.DataType],
+        reasoning: List[str],
+    ) -> float:
+        """Confidence score for the ``time_series`` role."""
+        score = 0.0
+
+        # +0.30  Date/Datetime column present
+        if time_col is not None:
+            if dtypes[time_col] in (pl.Date, pl.Datetime):
+                score += 0.30
+                reasoning.append(f"Date-typed column '{time_col}' (+0.30)")
+            else:
+                score += 0.15
+                reasoning.append(f"Parseable date column '{time_col}' (+0.15)")
+        else:
+            reasoning.append("No date column detected (+0.00)")
+
+        # +0.20  Target column name matches known patterns
+        if target_col is not None and target_col.lower() in _TARGET_COLUMN_PATTERNS:
+            score += 0.20
+            reasoning.append(f"Target column '{target_col}' matches known pattern (+0.20)")
+        elif target_col is not None:
+            score += 0.05
+            reasoning.append(f"Numeric column '{target_col}' found, no name match (+0.05)")
+
+        # +0.20  ID columns with repeating values
+        if id_cols and df.height > 0:
+            max_cardinality = max(df[c].n_unique() for c in id_cols)
+            if max_cardinality < df.height / 5:
+                score += 0.20
+                reasoning.append(f"ID columns have repeating values (max cardinality {max_cardinality}) (+0.20)")
+            elif max_cardinality < df.height:
+                score += 0.10
+                reasoning.append(f"ID columns have some repetition (+0.10)")
+        elif not id_cols:
+            reasoning.append("No ID columns detected (+0.00)")
+
+        # +0.15  Substantial row count
+        if df.height > 50:
+            score += 0.15
+            reasoning.append(f"Substantial data ({df.height} rows) (+0.15)")
+        elif df.height > 10:
+            score += 0.05
+            reasoning.append(f"Small data ({df.height} rows) (+0.05)")
+
+        # +0.15  Time column name matches common patterns
+        if time_col is not None and time_col.lower() in _TIME_COLUMN_PATTERNS:
+            score += 0.15
+            reasoning.append(f"Time column name '{time_col}' matches pattern (+0.15)")
+
+        return score
+
+    def _score_dimension(
+        self,
+        profile: FileProfile,
+        primary: FileProfile,
+        reasoning: List[str],
+    ) -> float:
+        """Confidence score for the ``dimension`` role."""
+        score = 0.0
+
+        # +0.30  No time column
+        if profile.time_column is None:
+            score += 0.30
+            reasoning.append("No time column detected (+0.30)")
+        else:
+            reasoning.append("Has a time column — less likely to be dimension (+0.00)")
+
+        # +0.30  ID overlap with primary
+        overlap = set(profile.id_columns) & set(primary.id_columns)
+        if overlap:
+            score += 0.30
+            reasoning.append(f"ID columns overlap with primary: {overlap} (+0.30)")
+        else:
+            # Check column name overlap (might use different dtype)
+            name_overlap = set(c.lower() for c in profile.df.columns) & set(
+                c.lower() for c in primary.id_columns
+            )
+            if name_overlap:
+                score += 0.15
+                reasoning.append(f"Column name overlap with primary IDs: {name_overlap} (+0.15)")
+
+        # +0.20  Mostly categorical columns
+        total_non_id = len(profile.df.columns) - (1 if profile.time_column else 0)
+        if total_non_id > 0:
+            cat_ratio = len(profile.categorical_columns) / total_non_id
+            if cat_ratio > 0.5:
+                score += 0.20
+                reasoning.append(f"Mostly categorical ({cat_ratio:.0%}) (+0.20)")
+            elif cat_ratio > 0.3:
+                score += 0.10
+                reasoning.append(f"Partially categorical ({cat_ratio:.0%}) (+0.10)")
+
+        # +0.20  Cardinality matches primary ID count
+        if overlap and primary.id_columns:
+            for col in overlap:
+                if col in profile.df.columns and col in primary.df.columns:
+                    dim_unique = profile.df[col].n_unique()
+                    primary_unique = primary.df[col].n_unique()
+                    ratio = dim_unique / max(primary_unique, 1)
+                    if 0.5 <= ratio <= 2.0:
+                        score += 0.20
+                        reasoning.append(
+                            f"Cardinality of '{col}' roughly matches primary "
+                            f"({dim_unique} vs {primary_unique}) (+0.20)"
+                        )
+                        break
+
+        return score
+
+    def _score_regressor(
+        self,
+        profile: FileProfile,
+        primary: FileProfile,
+        reasoning: List[str],
+    ) -> float:
+        """Confidence score for the ``regressor`` role."""
+        score = 0.0
+
+        # +0.30  Has a time column
+        if profile.time_column is not None:
+            score += 0.30
+            reasoning.append(f"Has time column '{profile.time_column}' (+0.30)")
+
+        # +0.30  Has numeric features (beyond time)
+        if profile.numeric_columns:
+            score += 0.30
+            reasoning.append(f"Has {len(profile.numeric_columns)} numeric columns (+0.30)")
+
+        # +0.20  Time range overlaps with primary
+        if profile.time_column and primary.time_column:
+            try:
+                p_min = primary.df[primary.time_column].min()
+                p_max = primary.df[primary.time_column].max()
+                s_min = profile.df[profile.time_column].min()
+                s_max = profile.df[profile.time_column].max()
+                if s_min <= p_max and s_max >= p_min:
+                    score += 0.20
+                    reasoning.append("Time range overlaps with primary (+0.20)")
+                else:
+                    reasoning.append("Time range does NOT overlap with primary (+0.00)")
+            except Exception:
+                reasoning.append("Could not compare time ranges (+0.00)")
+
+        # +0.20  ID column overlap with primary, or broadcastable (no IDs)
+        id_overlap = set(profile.id_columns) & set(primary.id_columns)
+        if id_overlap:
+            score += 0.20
+            reasoning.append(f"ID columns overlap with primary: {id_overlap} (+0.20)")
+        elif not profile.id_columns:
+            # Broadcastable: global features with just a time column
+            score += 0.10
+            reasoning.append("No ID columns — broadcastable feature (+0.10)")
+
+        return score
+
+    # ------------------------------------------------------------------ #
+    #  Cross-file resolution
+    # ------------------------------------------------------------------ #
+
+    def _resolve_roles(
+        self,
+        profiles: List[FileProfile],
+    ) -> ClassificationResult:
+        """Pick the best primary and re-evaluate remaining files."""
+        warnings: List[str] = []
+
+        # If only one file, just return it as-is
+        if len(profiles) == 1:
+            p = profiles[0]
+            primary = p if p.role == "time_series" else None
+            if primary is None:
+                warnings.append(
+                    f"'{p.filename}' was not confidently classified as time series "
+                    f"(confidence={p.confidence:.2f}). Expected a file with a date "
+                    f"column, a numeric target (e.g. 'quantity', 'sales'), and ID columns."
+                )
+            return ClassificationResult(
+                profiles=profiles,
+                primary_file=primary,
+                dimension_files=[],
+                regressor_files=[],
+                unknown_files=[p] if primary is None else [],
+                warnings=warnings,
+            )
+
+        # Find the best time_series candidate
+        ts_candidates = [p for p in profiles if p.role == "time_series"]
+
+        if not ts_candidates:
+            warnings.append(
+                "No file was classified as a time series. At least one file must "
+                "contain a date column, a numeric target, and identifier columns."
+            )
+            return ClassificationResult(
+                profiles=profiles,
+                primary_file=None,
+                dimension_files=[],
+                regressor_files=[],
+                unknown_files=profiles,
+                warnings=warnings,
+            )
+
+        # Pick highest confidence
+        primary = max(ts_candidates, key=lambda p: p.confidence)
+
+        # Re-evaluate remaining files relative to primary
+        dimension_files: List[FileProfile] = []
+        regressor_files: List[FileProfile] = []
+        unknown_files: List[FileProfile] = []
+
+        for profile in profiles:
+            if profile is primary:
+                continue
+
+            reasoning: List[str] = []
+            dim_score = self._score_dimension(profile, primary, reasoning)
+            reg_score = self._score_regressor(profile, primary, reasoning)
+
+            if dim_score > reg_score and dim_score >= 0.3:
+                profile.role = "dimension"
+                profile.confidence = round(min(dim_score, 1.0), 3)
+                profile.reasoning = reasoning
+                dimension_files.append(profile)
+            elif reg_score >= 0.3:
+                profile.role = "regressor"
+                profile.confidence = round(min(reg_score, 1.0), 3)
+                profile.reasoning = reasoning
+                regressor_files.append(profile)
+            else:
+                profile.role = "unknown"
+                profile.confidence = round(max(dim_score, reg_score), 3)
+                profile.reasoning = reasoning
+                unknown_files.append(profile)
+                warnings.append(
+                    f"'{profile.filename}' could not be confidently classified "
+                    f"(dim={dim_score:.2f}, reg={reg_score:.2f})."
+                )
+
+        return ClassificationResult(
+            profiles=profiles,
+            primary_file=primary,
+            dimension_files=dimension_files,
+            regressor_files=regressor_files,
+            unknown_files=unknown_files,
+            warnings=warnings,
+        )

--- a/forecasting-platform/src/data/file_merger.py
+++ b/forecasting-platform/src/data/file_merger.py
@@ -1,0 +1,428 @@
+"""
+MultiFileMerger — join key detection and multi-file merge for forecasting.
+
+Takes a :class:`ClassificationResult` from :class:`FileClassifier` and produces
+a single merged DataFrame suitable for :class:`DataAnalyzer` and the forecast
+pipeline.
+
+Merge order:
+1. Start with the primary time-series DataFrame.
+2. Left-join each dimension table on shared ID columns.
+3. Left-join each regressor table on ``[time_col]`` or ``[time_col, id_col]``.
+4. Resolve duplicate column names with a ``_<filename_stem>`` suffix.
+5. Fill nulls in regressor columns with ``0``.
+
+Usage
+-----
+>>> from src.data.file_classifier import FileClassifier
+>>> from src.data.file_merger import MultiFileMerger
+>>> result = FileClassifier().classify_files(files)
+>>> merger = MultiFileMerger()
+>>> merge_result = merger.merge(result)
+>>> merged_df = merge_result.df
+"""
+
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import List, Optional
+
+import polars as pl
+
+from .file_classifier import ClassificationResult, FileProfile
+
+
+# --------------------------------------------------------------------------- #
+#  Result dataclasses
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class JoinSpec:
+    """Specification for joining two files."""
+
+    left_file: str
+    right_file: str
+    join_keys: List[str]
+    join_type: str = "left"
+    key_overlap_pct: float = 0.0
+    warnings: List[str] = field(default_factory=list)
+
+
+@dataclass
+class MergePreview:
+    """Preview of the merge result before committing."""
+
+    sample_rows: pl.DataFrame
+    total_rows: int
+    total_columns: int
+    matched_rows: int
+    unmatched_primary_keys: int
+    null_fill_columns: List[str]
+    column_name_conflicts: List[str]
+    warnings: List[str] = field(default_factory=list)
+    join_specs: List[JoinSpec] = field(default_factory=list)
+
+
+@dataclass
+class MergeResult:
+    """Final merged DataFrame with metadata."""
+
+    df: pl.DataFrame
+    preview: MergePreview
+    join_specs: List[JoinSpec]
+
+
+# --------------------------------------------------------------------------- #
+#  MultiFileMerger
+# --------------------------------------------------------------------------- #
+
+class MultiFileMerger:
+    """Detect join keys and merge classified files into a single DataFrame."""
+
+    # ------------------------------------------------------------------ #
+    #  Public API
+    # ------------------------------------------------------------------ #
+
+    def detect_join_keys(
+        self,
+        primary: FileProfile,
+        secondary: FileProfile,
+    ) -> JoinSpec:
+        """Find the best join keys between *primary* and *secondary*.
+
+        Parameters
+        ----------
+        primary, secondary : FileProfile
+            Classified file profiles.
+
+        Returns
+        -------
+        JoinSpec
+        """
+        warnings: List[str] = []
+
+        if secondary.role == "dimension":
+            keys = self._dimension_join_keys(primary, secondary)
+        else:
+            keys = self._regressor_join_keys(primary, secondary)
+
+        if not keys:
+            warnings.append(
+                f"No overlapping join keys found between '{primary.filename}' "
+                f"and '{secondary.filename}'."
+            )
+            return JoinSpec(
+                left_file=primary.filename,
+                right_file=secondary.filename,
+                join_keys=[],
+                key_overlap_pct=0.0,
+                warnings=warnings,
+            )
+
+        # Compute overlap %
+        overlap_pct = self._compute_key_overlap(primary.df, secondary.df, keys)
+        if overlap_pct < 0.5:
+            warnings.append(
+                f"Low key overlap ({overlap_pct:.0%}) between "
+                f"'{primary.filename}' and '{secondary.filename}' on {keys}."
+            )
+
+        return JoinSpec(
+            left_file=primary.filename,
+            right_file=secondary.filename,
+            join_keys=keys,
+            key_overlap_pct=round(overlap_pct, 3),
+            warnings=warnings,
+        )
+
+    def preview_merge(
+        self,
+        classification: ClassificationResult,
+    ) -> MergePreview:
+        """Generate a merge preview without persisting state.
+
+        Parameters
+        ----------
+        classification : ClassificationResult
+
+        Returns
+        -------
+        MergePreview
+        """
+        primary = classification.primary_file
+        if primary is None:
+            return MergePreview(
+                sample_rows=pl.DataFrame(),
+                total_rows=0,
+                total_columns=0,
+                matched_rows=0,
+                unmatched_primary_keys=0,
+                null_fill_columns=[],
+                column_name_conflicts=[],
+                warnings=["No primary time-series file identified."],
+            )
+
+        secondaries = classification.dimension_files + classification.regressor_files
+        if not secondaries:
+            df = primary.df
+            return MergePreview(
+                sample_rows=df.head(10),
+                total_rows=df.height,
+                total_columns=len(df.columns),
+                matched_rows=df.height,
+                unmatched_primary_keys=0,
+                null_fill_columns=[],
+                column_name_conflicts=[],
+            )
+
+        # Perform the merge
+        result = self._execute_merge(primary, secondaries)
+        return result.preview
+
+    def merge(
+        self,
+        classification: ClassificationResult,
+    ) -> MergeResult:
+        """Execute the full merge and return the result.
+
+        Parameters
+        ----------
+        classification : ClassificationResult
+
+        Returns
+        -------
+        MergeResult
+        """
+        primary = classification.primary_file
+        if primary is None:
+            empty_preview = MergePreview(
+                sample_rows=pl.DataFrame(),
+                total_rows=0,
+                total_columns=0,
+                matched_rows=0,
+                unmatched_primary_keys=0,
+                null_fill_columns=[],
+                column_name_conflicts=[],
+                warnings=["No primary time-series file identified."],
+            )
+            return MergeResult(df=pl.DataFrame(), preview=empty_preview, join_specs=[])
+
+        secondaries = classification.dimension_files + classification.regressor_files
+        if not secondaries:
+            preview = MergePreview(
+                sample_rows=primary.df.head(10),
+                total_rows=primary.df.height,
+                total_columns=len(primary.df.columns),
+                matched_rows=primary.df.height,
+                unmatched_primary_keys=0,
+                null_fill_columns=[],
+                column_name_conflicts=[],
+            )
+            return MergeResult(df=primary.df, preview=preview, join_specs=[])
+
+        return self._execute_merge(primary, secondaries)
+
+    # ------------------------------------------------------------------ #
+    #  Join key detection
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _dimension_join_keys(
+        primary: FileProfile,
+        secondary: FileProfile,
+    ) -> List[str]:
+        """Join keys for a dimension table: shared ID columns (no time)."""
+        shared = [
+            c for c in secondary.df.columns
+            if c in primary.id_columns
+        ]
+        return shared
+
+    @staticmethod
+    def _regressor_join_keys(
+        primary: FileProfile,
+        secondary: FileProfile,
+    ) -> List[str]:
+        """Join keys for a regressor table: time column + optional shared IDs."""
+        keys: List[str] = []
+
+        # Time column (must match by name or both be present)
+        if (
+            secondary.time_column
+            and primary.time_column
+            and secondary.time_column == primary.time_column
+        ):
+            keys.append(primary.time_column)
+        elif secondary.time_column and primary.time_column:
+            # Different names — still try if both are date columns
+            keys.append(primary.time_column)
+
+        # Shared ID columns
+        shared_ids = [
+            c for c in secondary.id_columns
+            if c in primary.id_columns
+        ]
+        keys.extend(shared_ids)
+
+        return keys
+
+    @staticmethod
+    def _compute_key_overlap(
+        left: pl.DataFrame,
+        right: pl.DataFrame,
+        keys: List[str],
+    ) -> float:
+        """Fraction of left key values that exist in right."""
+        # Only use columns present in both
+        usable_keys = [k for k in keys if k in left.columns and k in right.columns]
+        if not usable_keys:
+            return 0.0
+
+        left_keys = left.select(usable_keys).unique()
+        right_keys = right.select(usable_keys).unique()
+
+        if left_keys.height == 0:
+            return 0.0
+
+        joined = left_keys.join(right_keys, on=usable_keys, how="inner")
+        return joined.height / left_keys.height
+
+    # ------------------------------------------------------------------ #
+    #  Merge execution
+    # ------------------------------------------------------------------ #
+
+    def _execute_merge(
+        self,
+        primary: FileProfile,
+        secondaries: List[FileProfile],
+    ) -> MergeResult:
+        """Perform left joins and build merge metadata."""
+        merged = primary.df.clone()
+        join_specs: List[JoinSpec] = []
+        all_conflicts: List[str] = []
+        null_fill_cols: List[str] = []
+        all_warnings: List[str] = []
+
+        original_height = merged.height
+
+        for sec in secondaries:
+            spec = self.detect_join_keys(primary, sec)
+            join_specs.append(spec)
+            all_warnings.extend(spec.warnings)
+
+            if not spec.join_keys:
+                all_warnings.append(
+                    f"Skipping '{sec.filename}' — no join keys detected."
+                )
+                continue
+
+            # Prepare right DataFrame
+            right = sec.df
+
+            # Handle regressor with different time column name
+            if (
+                sec.role == "regressor"
+                and sec.time_column
+                and primary.time_column
+                and sec.time_column != primary.time_column
+                and primary.time_column in spec.join_keys
+            ):
+                right = right.rename({sec.time_column: primary.time_column})
+
+            # Resolve column conflicts before joining
+            conflicts, right = self._resolve_column_conflicts(
+                merged, right, sec.filename, spec.join_keys,
+            )
+            all_conflicts.extend(conflicts)
+
+            # Only use join keys that exist in both DataFrames
+            usable_keys = [
+                k for k in spec.join_keys
+                if k in merged.columns and k in right.columns
+            ]
+            if not usable_keys:
+                all_warnings.append(
+                    f"Skipping '{sec.filename}' — join keys not in both DataFrames."
+                )
+                continue
+
+            # Left join
+            merged = merged.join(right, on=usable_keys, how="left", suffix="_dup")
+
+            # Drop any _dup columns that snuck through
+            dup_cols = [c for c in merged.columns if c.endswith("_dup")]
+            if dup_cols:
+                merged = merged.drop(dup_cols)
+
+            # Fill nulls in regressor numeric columns with 0
+            if sec.role == "regressor":
+                new_cols = [
+                    c for c in right.columns
+                    if c not in usable_keys and c in merged.columns
+                ]
+                for c in new_cols:
+                    if merged[c].dtype in (
+                        pl.Float32, pl.Float64,
+                        pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+                        pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+                    ):
+                        merged = merged.with_columns(pl.col(c).fill_null(0))
+                        null_fill_cols.append(c)
+
+        # Compute stats
+        # Count rows where at least one joined column has a non-null value
+        matched_rows = merged.height  # left join preserves all primary rows
+        # Unmatched = rows where ALL joined columns are null
+        joined_cols = [
+            c for c in merged.columns if c not in primary.df.columns
+        ]
+        if joined_cols:
+            all_null_mask = pl.all_horizontal(
+                pl.col(c).is_null() for c in joined_cols
+            )
+            unmatched = merged.filter(all_null_mask).height
+        else:
+            unmatched = 0
+
+        preview = MergePreview(
+            sample_rows=merged.head(10),
+            total_rows=merged.height,
+            total_columns=len(merged.columns),
+            matched_rows=merged.height - unmatched,
+            unmatched_primary_keys=unmatched,
+            null_fill_columns=null_fill_cols,
+            column_name_conflicts=all_conflicts,
+            warnings=all_warnings,
+            join_specs=join_specs,
+        )
+
+        return MergeResult(df=merged, preview=preview, join_specs=join_specs)
+
+    @staticmethod
+    def _resolve_column_conflicts(
+        left: pl.DataFrame,
+        right: pl.DataFrame,
+        right_filename: str,
+        join_keys: List[str],
+    ) -> tuple:
+        """Rename conflicting non-key columns in *right*.
+
+        Returns
+        -------
+        tuple of (conflicts_list, renamed_right_df)
+        """
+        stem = PurePosixPath(right_filename).stem
+        conflicts: List[str] = []
+        renames: dict = {}
+
+        for c in right.columns:
+            if c in join_keys:
+                continue
+            if c in left.columns:
+                new_name = f"{c}_{stem}"
+                renames[c] = new_name
+                conflicts.append(f"'{c}' renamed to '{new_name}' (from {right_filename})")
+
+        if renames:
+            right = right.rename(renames)
+
+        return conflicts, right

--- a/forecasting-platform/streamlit/pages/1_Data_Onboarding.py
+++ b/forecasting-platform/streamlit/pages/1_Data_Onboarding.py
@@ -1,8 +1,9 @@
 """
 Page 1 — Data Onboarding
 
-Upload CSV → run DataAnalyzer → view schema detection, hierarchy,
-forecastability scores, hypotheses, and recommended config.
+Upload one or more CSV files → auto-classify roles (time series, dimension,
+regressor) → preview merge → run DataAnalyzer → view schema detection,
+hierarchy, forecastability scores, hypotheses, and recommended config.
 Optionally invoke LLM interpreter for executive-level narrative.
 """
 
@@ -23,51 +24,222 @@ if str(_STREAMLIT_DIR) not in sys.path:
     sys.path.insert(0, str(_STREAMLIT_DIR))
 
 from src.analytics.analyzer import DataAnalyzer
+from src.data.file_classifier import FileClassifier
+from src.data.file_merger import MultiFileMerger
 from utils import (
     COLORS,
     load_sample_data,
     load_uploaded_csv,
+    load_uploaded_csvs,
     polars_to_pandas,
     format_pct,
 )
 
 st.set_page_config(page_title="Data Onboarding", page_icon="📊", layout="wide")
 st.title("Data Onboarding")
-st.markdown("Upload a CSV to auto-detect schema, assess forecastability, and get a recommended configuration.")
+st.markdown(
+    "Upload one or more CSVs to auto-detect schema, assess forecastability, "
+    "and get a recommended configuration. Multiple files are automatically "
+    "classified and merged."
+)
 
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
+#  Helpers
+# --------------------------------------------------------------------------- #
+_ROLE_LABELS = {
+    "time_series": "Time Series (primary)",
+    "dimension": "Dimension / Lookup",
+    "regressor": "External Regressor",
+    "unknown": "Unknown",
+}
+_ROLE_OPTIONS = list(_ROLE_LABELS.keys())
+_CONFIDENCE_COLORS = {
+    "high": "🟢",
+    "medium": "🟡",
+    "low": "🔴",
+}
+
+
+def _confidence_badge(score: float) -> str:
+    if score >= 0.7:
+        return f"{_CONFIDENCE_COLORS['high']} {score:.0%}"
+    elif score >= 0.4:
+        return f"{_CONFIDENCE_COLORS['medium']} {score:.0%}"
+    return f"{_CONFIDENCE_COLORS['low']} {score:.0%}"
+
+
+# --------------------------------------------------------------------------- #
 #  Data source selection
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 col_upload, col_sample = st.columns(2)
 
 with col_upload:
-    uploaded_file = st.file_uploader("Upload CSV", type=["csv"])
+    uploaded_files = st.file_uploader(
+        "Upload CSV files",
+        type=["csv"],
+        accept_multiple_files=True,
+    )
 
 with col_sample:
     use_sample = st.button("Use sample data")
 
+# --------------------------------------------------------------------------- #
+#  Single-file fast path (backward compatible)
+# --------------------------------------------------------------------------- #
 df = None
-if uploaded_file is not None:
-    df = load_uploaded_csv(uploaded_file)
+multi_file_mode = False
+
+if uploaded_files and len(uploaded_files) == 1:
+    # Single file — original flow
+    df = load_uploaded_csv(uploaded_files[0])
     st.success(f"Loaded {df.shape[0]:,} rows x {df.shape[1]} columns from upload.")
+
+elif uploaded_files and len(uploaded_files) > 1:
+    multi_file_mode = True
+
 elif use_sample or st.session_state.get("sample_loaded"):
     df = load_sample_data()
     st.session_state["sample_loaded"] = True
     st.success(f"Loaded sample data: {df.shape[0]:,} rows x {df.shape[1]} columns.")
 
+# --------------------------------------------------------------------------- #
+#  Multi-file flow
+# --------------------------------------------------------------------------- #
+if multi_file_mode:
+    # Step 1: Load and classify
+    files = load_uploaded_csvs(uploaded_files)
+    st.success(f"Loaded {len(files)} files: {', '.join(files.keys())}")
+
+    classifier = FileClassifier()
+    classification = classifier.classify_files(files)
+
+    # Store in session for persistence across reruns
+    st.session_state["classification"] = classification
+
+    # Show classification results
+    st.divider()
+    st.header("Step 1: File Classification")
+
+    if classification.warnings:
+        for w in classification.warnings:
+            st.warning(w)
+
+    if classification.primary_file is None:
+        st.error(
+            "No file was classified as a time series. At least one file must "
+            "contain a **date column**, a **numeric target** (e.g. 'quantity', "
+            "'sales'), and **identifier columns** (e.g. 'store_id')."
+        )
+        st.stop()
+
+    # Interactive confirmation table
+    st.markdown("Review the auto-detected roles below. Override if needed.")
+
+    role_overrides = {}
+    for i, profile in enumerate(classification.profiles):
+        col_name, col_role, col_conf, col_keys = st.columns([2, 2, 1, 3])
+        with col_name:
+            st.markdown(f"**{profile.filename}**")
+            st.caption(f"{profile.n_rows:,} rows, {profile.n_columns} cols")
+        with col_role:
+            selected = st.selectbox(
+                "Role",
+                options=_ROLE_OPTIONS,
+                index=_ROLE_OPTIONS.index(profile.role),
+                format_func=lambda x: _ROLE_LABELS[x],
+                key=f"role_{i}",
+                label_visibility="collapsed",
+            )
+            role_overrides[profile.filename] = selected
+        with col_conf:
+            st.markdown(_confidence_badge(profile.confidence))
+        with col_keys:
+            key_cols = profile.id_columns[:3]
+            time_info = f"time: {profile.time_column}" if profile.time_column else "no time col"
+            st.caption(f"{time_info} | IDs: {', '.join(key_cols) if key_cols else 'none'}")
+
+    # Apply overrides
+    for profile in classification.profiles:
+        override = role_overrides.get(profile.filename)
+        if override and override != profile.role:
+            profile.role = override
+
+    # Re-bucket after overrides
+    classification.primary_file = next(
+        (p for p in classification.profiles if p.role == "time_series"), None,
+    )
+    classification.dimension_files = [
+        p for p in classification.profiles if p.role == "dimension"
+    ]
+    classification.regressor_files = [
+        p for p in classification.profiles if p.role == "regressor"
+    ]
+    classification.unknown_files = [
+        p for p in classification.profiles if p.role == "unknown"
+    ]
+
+    if classification.primary_file is None:
+        st.error("No file assigned the **Time Series** role. Please select one.")
+        st.stop()
+
+    # Step 2: Merge preview
+    st.divider()
+    st.header("Step 2: Merge Preview")
+
+    merger = MultiFileMerger()
+    preview = merger.preview_merge(classification)
+
+    col_s1, col_s2, col_s3, col_s4 = st.columns(4)
+    col_s1.metric("Merged rows", f"{preview.total_rows:,}")
+    col_s2.metric("Merged columns", preview.total_columns)
+    col_s3.metric("Matched rows", f"{preview.matched_rows:,}")
+    col_s4.metric("Unmatched keys", preview.unmatched_primary_keys)
+
+    if preview.column_name_conflicts:
+        with st.expander("Column name conflicts resolved"):
+            for c in preview.column_name_conflicts:
+                st.markdown(f"- {c}")
+
+    if preview.null_fill_columns:
+        st.caption(f"Null-filled regressor columns: {', '.join(preview.null_fill_columns)}")
+
+    if preview.warnings:
+        for w in preview.warnings:
+            st.warning(w)
+
+    st.markdown("**Sample of merged data:**")
+    st.dataframe(polars_to_pandas(preview.sample_rows), use_container_width=True)
+
+    # Step 3: Merge and analyze
+    st.divider()
+    if st.button("Run Analysis on Merged Data", type="primary"):
+        merge_result = merger.merge(classification)
+        df = merge_result.df
+        st.session_state["merge_result"] = merge_result
+        st.success(
+            f"Merged {len(files)} files into {df.shape[0]:,} rows x "
+            f"{df.shape[1]} columns."
+        )
+    elif "merge_result" in st.session_state:
+        df = st.session_state["merge_result"].df
+    else:
+        st.info("Click **Run Analysis on Merged Data** to proceed.")
+        st.stop()
+
+
 if df is None:
     st.info("Upload a CSV or click **Use sample data** to get started.")
     st.stop()
 
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 #  Preview raw data
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 with st.expander("Preview raw data", expanded=False):
     st.dataframe(polars_to_pandas(df.head(500)), use_container_width=True)
 
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 #  Run DataAnalyzer
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 @st.cache_data(show_spinner="Analyzing data...")
 def run_analysis(_df):
     """Run DataAnalyzer on the uploaded DataFrame (cached)."""
@@ -78,11 +250,19 @@ def run_analysis(_df):
 
 report = run_analysis(df)
 
+# Enrich report with multi-source info if available
+if multi_file_mode and "classification" in st.session_state:
+    cls = st.session_state["classification"]
+    report.dimension_sources = [p.filename for p in cls.dimension_files]
+    report.regressor_columns = [
+        c for p in cls.regressor_files for c in p.numeric_columns
+    ]
+
 st.divider()
 
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 #  Schema Detection
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 st.header("Schema Detection")
 
 schema = report.schema
@@ -109,10 +289,14 @@ with col_b:
         st.markdown("**Numeric columns** (regressor candidates)")
         for c in schema.numeric_columns:
             st.markdown(f"- `{c}`")
+    if report.dimension_sources:
+        st.markdown("**Dimension sources**")
+        for s in report.dimension_sources:
+            st.markdown(f"- `{s}`")
 
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 #  Hierarchy Detection
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 st.divider()
 st.header("Hierarchy Detection")
 
@@ -131,9 +315,9 @@ if hier.warnings:
     for w in hier.warnings:
         st.warning(w)
 
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 #  Forecastability Assessment
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 st.divider()
 st.header("Forecastability Assessment")
 
@@ -204,9 +388,9 @@ if fa.per_series is not None and not fa.per_series.is_empty():
     with st.expander("Per-series forecastability detail"):
         st.dataframe(polars_to_pandas(fa.per_series), use_container_width=True)
 
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 #  Hypotheses & Warnings
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 st.divider()
 st.header("Insights")
 
@@ -224,9 +408,9 @@ with col_warn:
     else:
         st.success("No warnings.")
 
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 #  Recommended Configuration
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 st.divider()
 st.header("Recommended Configuration")
 
@@ -269,9 +453,9 @@ with col_accept:
         st.session_state["analysis_report"] = report
         st.success("Config accepted and stored in session.")
 
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 #  LLM Interpreter (optional)
-# ---------------------------------------------------------------------------
+# --------------------------------------------------------------------------- #
 st.divider()
 st.header("AI Interpretation (optional)")
 st.markdown(

--- a/forecasting-platform/streamlit/utils.py
+++ b/forecasting-platform/streamlit/utils.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import io
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 import polars as pl
 import streamlit as st
@@ -67,6 +67,15 @@ def load_uploaded_csv(uploaded_file) -> pl.DataFrame:
     """Read an uploaded CSV file into a Polars DataFrame."""
     raw = uploaded_file.getvalue()
     return pl.read_csv(io.BytesIO(raw), try_parse_dates=True)
+
+
+def load_uploaded_csvs(uploaded_files: List) -> Dict[str, pl.DataFrame]:
+    """Read multiple uploaded CSV files into a dict of {filename: DataFrame}."""
+    result: Dict[str, pl.DataFrame] = {}
+    for f in uploaded_files:
+        raw = f.getvalue()
+        result[f.name] = pl.read_csv(io.BytesIO(raw), try_parse_dates=True)
+    return result
 
 
 def polars_to_pandas(df: pl.DataFrame):

--- a/forecasting-platform/tests/test_file_classifier.py
+++ b/forecasting-platform/tests/test_file_classifier.py
@@ -1,0 +1,359 @@
+"""Tests for FileClassifier — automatic role classification for multi-file uploads."""
+
+import unittest
+from datetime import date, timedelta
+from typing import Dict
+
+import numpy as np
+import polars as pl
+
+from src.data.file_classifier import (
+    ClassificationResult,
+    FileClassifier,
+    FileProfile,
+)
+
+
+# --------------------------------------------------------------------------- #
+#  Factory helpers
+# --------------------------------------------------------------------------- #
+
+def _make_primary_timeseries(
+    n_stores: int = 3,
+    n_weeks: int = 52,
+    start_date: date = date(2022, 1, 3),
+    seed: int = 42,
+) -> pl.DataFrame:
+    """Create a typical weekly time-series DataFrame (week, store_id, product_id, quantity)."""
+    rng = np.random.RandomState(seed)
+    rows = []
+    products = ["prod_A", "prod_B"]
+    for s in range(n_stores):
+        for p in products:
+            for w in range(n_weeks):
+                rows.append({
+                    "week": start_date + timedelta(weeks=w),
+                    "store_id": f"store_{s}",
+                    "product_id": p,
+                    "quantity": round(rng.uniform(10, 200), 2),
+                })
+    return pl.DataFrame(rows)
+
+
+def _make_dimension_table() -> pl.DataFrame:
+    """Create a dimension/lookup table (no date column, shared IDs, mostly categorical)."""
+    return pl.DataFrame({
+        "store_id": ["store_0", "store_1", "store_2"],
+        "region": ["North", "South", "East"],
+        "store_format": ["Large", "Small", "Medium"],
+        "manager": ["Alice", "Bob", "Charlie"],
+    })
+
+
+def _make_regressor_table(
+    n_weeks: int = 52,
+    start_date: date = date(2022, 1, 3),
+    seed: int = 42,
+) -> pl.DataFrame:
+    """Create an external regressor table (date + numeric features, joinable)."""
+    rng = np.random.RandomState(seed)
+    rows = []
+    for w in range(n_weeks):
+        rows.append({
+            "week": start_date + timedelta(weeks=w),
+            "temperature": round(rng.normal(20, 5), 1),
+            "rainfall_mm": round(rng.exponential(10), 1),
+        })
+    return pl.DataFrame(rows)
+
+
+def _make_regressor_with_ids(
+    n_stores: int = 3,
+    n_weeks: int = 52,
+    start_date: date = date(2022, 1, 3),
+    seed: int = 42,
+) -> pl.DataFrame:
+    """Regressor table with store-level granularity."""
+    rng = np.random.RandomState(seed)
+    rows = []
+    for s in range(n_stores):
+        for w in range(n_weeks):
+            rows.append({
+                "week": start_date + timedelta(weeks=w),
+                "store_id": f"store_{s}",
+                "promo_discount": round(rng.uniform(0, 0.3), 2),
+            })
+    return pl.DataFrame(rows)
+
+
+def _make_non_timeseries() -> pl.DataFrame:
+    """Create a file that doesn't look like time series at all."""
+    return pl.DataFrame({
+        "name": ["Alice", "Bob", "Charlie", "Diana"],
+        "department": ["HR", "Eng", "Eng", "Sales"],
+        "salary": [70000, 95000, 102000, 80000],
+    })
+
+
+def _make_ambiguous_file(
+    n_weeks: int = 52,
+    start_date: date = date(2022, 1, 3),
+    seed: int = 42,
+) -> pl.DataFrame:
+    """File with a date and numbers but no clear target pattern — could be time_series or regressor."""
+    rng = np.random.RandomState(seed)
+    rows = []
+    for w in range(n_weeks):
+        rows.append({
+            "week": start_date + timedelta(weeks=w),
+            "metric_alpha": round(rng.normal(0, 1), 3),
+            "metric_beta": round(rng.normal(5, 2), 3),
+        })
+    return pl.DataFrame(rows)
+
+
+# --------------------------------------------------------------------------- #
+#  Tests
+# --------------------------------------------------------------------------- #
+
+class TestClassifySingle(unittest.TestCase):
+    """Test classify_single on individual files."""
+
+    def setUp(self):
+        self.clf = FileClassifier()
+
+    def test_primary_timeseries_detected(self):
+        df = _make_primary_timeseries()
+        profile = self.clf.classify_single("sales.csv", df)
+        self.assertEqual(profile.role, "time_series")
+        self.assertGreaterEqual(profile.confidence, 0.4)
+        self.assertEqual(profile.time_column, "week")
+        self.assertIn("store_id", profile.id_columns)
+
+    def test_primary_timeseries_high_confidence(self):
+        df = _make_primary_timeseries()
+        profile = self.clf.classify_single("sales.csv", df)
+        # Should be high confidence: Date type + 'quantity' target + repeating IDs + >50 rows
+        self.assertGreaterEqual(profile.confidence, 0.8)
+
+    def test_dimension_table_in_isolation(self):
+        """Dimension tables in isolation are classified as unknown (no date + few rows)."""
+        df = _make_dimension_table()
+        profile = self.clf.classify_single("stores.csv", df)
+        # Without date or strong target, should not be time_series
+        self.assertNotEqual(profile.role, "time_series")
+
+    def test_non_timeseries_detected_as_unknown(self):
+        df = _make_non_timeseries()
+        profile = self.clf.classify_single("employees.csv", df)
+        self.assertEqual(profile.role, "unknown")
+        self.assertLess(profile.confidence, 0.4)
+
+    def test_time_column_detection_date_type(self):
+        df = _make_primary_timeseries()
+        profile = self.clf.classify_single("data.csv", df)
+        self.assertEqual(profile.time_column, "week")
+
+    def test_time_column_detection_name_pattern(self):
+        """If column is not Date type but named 'date', still detected."""
+        df = pl.DataFrame({
+            "date": ["2022-01-03", "2022-01-10", "2022-01-17"] * 10,
+            "id": [f"s_{i}" for i in range(10)] * 3,
+            "quantity": list(range(30)),
+        })
+        profile = self.clf.classify_single("data.csv", df)
+        self.assertEqual(profile.time_column, "date")
+
+    def test_target_column_prefers_known_names(self):
+        df = _make_primary_timeseries()
+        profile = self.clf.classify_single("data.csv", df)
+        self.assertIn("quantity", [profile.df.columns[i] for i in range(len(df.columns)) if df.columns[i] == "quantity"])
+
+    def test_confidence_in_range(self):
+        df = _make_primary_timeseries()
+        profile = self.clf.classify_single("data.csv", df)
+        self.assertGreaterEqual(profile.confidence, 0.0)
+        self.assertLessEqual(profile.confidence, 1.0)
+
+    def test_reasoning_populated(self):
+        df = _make_primary_timeseries()
+        profile = self.clf.classify_single("data.csv", df)
+        self.assertTrue(len(profile.reasoning) > 0)
+
+    def test_profile_metadata_correct(self):
+        df = _make_primary_timeseries(n_stores=2, n_weeks=10)
+        profile = self.clf.classify_single("data.csv", df)
+        self.assertEqual(profile.n_rows, df.height)
+        self.assertEqual(profile.n_columns, len(df.columns))
+        self.assertEqual(profile.filename, "data.csv")
+
+
+class TestClassifyFiles(unittest.TestCase):
+    """Test classify_files with multiple files."""
+
+    def setUp(self):
+        self.clf = FileClassifier()
+
+    def test_single_file_timeseries(self):
+        files = {"sales.csv": _make_primary_timeseries()}
+        result = self.clf.classify_files(files)
+        self.assertIsNotNone(result.primary_file)
+        self.assertEqual(result.primary_file.filename, "sales.csv")
+        self.assertEqual(len(result.dimension_files), 0)
+        self.assertEqual(len(result.regressor_files), 0)
+
+    def test_single_file_not_timeseries(self):
+        files = {"employees.csv": _make_non_timeseries()}
+        result = self.clf.classify_files(files)
+        self.assertIsNone(result.primary_file)
+        self.assertEqual(len(result.unknown_files), 1)
+        self.assertTrue(len(result.warnings) > 0)
+
+    def test_timeseries_plus_dimension(self):
+        files = {
+            "sales.csv": _make_primary_timeseries(),
+            "stores.csv": _make_dimension_table(),
+        }
+        result = self.clf.classify_files(files)
+        self.assertIsNotNone(result.primary_file)
+        self.assertEqual(result.primary_file.filename, "sales.csv")
+        self.assertEqual(len(result.dimension_files), 1)
+        self.assertEqual(result.dimension_files[0].filename, "stores.csv")
+
+    def test_timeseries_plus_regressor(self):
+        files = {
+            "sales.csv": _make_primary_timeseries(),
+            "weather.csv": _make_regressor_table(),
+        }
+        result = self.clf.classify_files(files)
+        self.assertIsNotNone(result.primary_file)
+        self.assertEqual(len(result.regressor_files), 1)
+        self.assertEqual(result.regressor_files[0].filename, "weather.csv")
+
+    def test_timeseries_plus_regressor_with_ids(self):
+        files = {
+            "sales.csv": _make_primary_timeseries(),
+            "promos.csv": _make_regressor_with_ids(),
+        }
+        result = self.clf.classify_files(files)
+        self.assertIsNotNone(result.primary_file)
+        self.assertEqual(len(result.regressor_files), 1)
+
+    def test_three_files_mixed(self):
+        files = {
+            "sales.csv": _make_primary_timeseries(),
+            "stores.csv": _make_dimension_table(),
+            "weather.csv": _make_regressor_table(),
+        }
+        result = self.clf.classify_files(files)
+        self.assertIsNotNone(result.primary_file)
+        self.assertEqual(result.primary_file.filename, "sales.csv")
+        self.assertEqual(len(result.dimension_files), 1)
+        self.assertEqual(len(result.regressor_files), 1)
+        self.assertEqual(len(result.unknown_files), 0)
+
+    def test_two_timeseries_candidates_picks_best(self):
+        """When two files look like time_series, the one with higher confidence wins."""
+        primary = _make_primary_timeseries(n_stores=5, n_weeks=104)
+        # Smaller file — still looks like ts but lower confidence
+        secondary = _make_primary_timeseries(n_stores=1, n_weeks=20)
+        secondary = secondary.rename({"quantity": "sales"})
+
+        files = {
+            "big_sales.csv": primary,
+            "small_sales.csv": secondary,
+        }
+        result = self.clf.classify_files(files)
+        self.assertIsNotNone(result.primary_file)
+        # The bigger file should win (more rows → higher confidence)
+        self.assertEqual(result.primary_file.filename, "big_sales.csv")
+
+    def test_no_files_returns_empty(self):
+        result = self.clf.classify_files({})
+        self.assertIsNone(result.primary_file)
+        self.assertEqual(len(result.profiles), 0)
+        self.assertTrue(len(result.warnings) > 0)
+
+    def test_all_unknown_produces_warning(self):
+        files = {
+            "a.csv": _make_non_timeseries(),
+            "b.csv": _make_non_timeseries(),
+        }
+        result = self.clf.classify_files(files)
+        self.assertIsNone(result.primary_file)
+        self.assertTrue(len(result.warnings) > 0)
+
+    def test_dimension_role_assigned_correctly(self):
+        files = {
+            "sales.csv": _make_primary_timeseries(),
+            "stores.csv": _make_dimension_table(),
+        }
+        result = self.clf.classify_files(files)
+        store_profile = result.dimension_files[0]
+        self.assertEqual(store_profile.role, "dimension")
+        self.assertGreaterEqual(store_profile.confidence, 0.3)
+
+    def test_regressor_role_assigned_correctly(self):
+        files = {
+            "sales.csv": _make_primary_timeseries(),
+            "weather.csv": _make_regressor_table(),
+        }
+        result = self.clf.classify_files(files)
+        weather_profile = result.regressor_files[0]
+        self.assertEqual(weather_profile.role, "regressor")
+        self.assertGreaterEqual(weather_profile.confidence, 0.3)
+
+
+class TestEdgeCases(unittest.TestCase):
+    """Edge cases in file classification."""
+
+    def setUp(self):
+        self.clf = FileClassifier()
+
+    def test_empty_dataframe(self):
+        df = pl.DataFrame({"a": [], "b": []}).cast({"a": pl.Utf8, "b": pl.Float64})
+        profile = self.clf.classify_single("empty.csv", df)
+        self.assertLess(profile.confidence, 0.4)
+
+    def test_single_column_file(self):
+        df = pl.DataFrame({"value": [1, 2, 3, 4, 5]})
+        profile = self.clf.classify_single("single.csv", df)
+        # No time column, no ID → unlikely time_series
+        self.assertLessEqual(profile.confidence, 0.4)
+
+    def test_dimension_with_partial_id_overlap(self):
+        """Dimension table has some IDs not in primary — still classified as dimension."""
+        primary = _make_primary_timeseries()
+        dim = pl.DataFrame({
+            "store_id": ["store_0", "store_1", "store_99"],  # store_99 not in primary
+            "region": ["North", "South", "West"],
+        })
+        files = {"sales.csv": primary, "stores.csv": dim}
+        result = self.clf.classify_files(files)
+        self.assertEqual(len(result.dimension_files), 1)
+
+    def test_regressor_no_id_is_broadcastable(self):
+        """Regressor with only time column (no IDs) is broadcastable and still detected."""
+        files = {
+            "sales.csv": _make_primary_timeseries(),
+            "weather.csv": _make_regressor_table(),
+        }
+        result = self.clf.classify_files(files)
+        self.assertEqual(len(result.regressor_files), 1)
+        # weather.csv has no store_id → broadcastable
+        weather = result.regressor_files[0]
+        self.assertEqual(len(weather.id_columns), 0)
+
+    def test_profiles_count_matches_input(self):
+        files = {
+            "a.csv": _make_primary_timeseries(),
+            "b.csv": _make_dimension_table(),
+            "c.csv": _make_regressor_table(),
+            "d.csv": _make_non_timeseries(),
+        }
+        result = self.clf.classify_files(files)
+        self.assertEqual(len(result.profiles), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forecasting-platform/tests/test_file_merger.py
+++ b/forecasting-platform/tests/test_file_merger.py
@@ -1,0 +1,348 @@
+"""Tests for MultiFileMerger — join key detection and multi-file merge."""
+
+import unittest
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+
+from src.data.file_classifier import FileClassifier
+from src.data.file_merger import MultiFileMerger
+
+
+# --------------------------------------------------------------------------- #
+#  Factory helpers
+# --------------------------------------------------------------------------- #
+
+def _make_primary_timeseries(
+    n_stores: int = 3,
+    n_weeks: int = 52,
+    start_date: date = date(2022, 1, 3),
+    seed: int = 42,
+) -> pl.DataFrame:
+    """Weekly time series: week, store_id, product_id, quantity."""
+    rng = np.random.RandomState(seed)
+    rows = []
+    products = ["prod_A", "prod_B"]
+    for s in range(n_stores):
+        for p in products:
+            for w in range(n_weeks):
+                rows.append({
+                    "week": start_date + timedelta(weeks=w),
+                    "store_id": f"store_{s}",
+                    "product_id": p,
+                    "quantity": round(rng.uniform(10, 200), 2),
+                })
+    return pl.DataFrame(rows)
+
+
+def _make_dimension_table() -> pl.DataFrame:
+    """Dimension table: store_id, region, format."""
+    return pl.DataFrame({
+        "store_id": ["store_0", "store_1", "store_2"],
+        "region": ["North", "South", "East"],
+        "store_format": ["Large", "Small", "Medium"],
+    })
+
+
+def _make_regressor_table(
+    n_weeks: int = 52,
+    start_date: date = date(2022, 1, 3),
+    seed: int = 42,
+) -> pl.DataFrame:
+    """Broadcast regressor: week, temperature, rainfall_mm."""
+    rng = np.random.RandomState(seed)
+    rows = []
+    for w in range(n_weeks):
+        rows.append({
+            "week": start_date + timedelta(weeks=w),
+            "temperature": round(rng.normal(20, 5), 1),
+            "rainfall_mm": round(rng.exponential(10), 1),
+        })
+    return pl.DataFrame(rows)
+
+
+def _make_regressor_with_ids(
+    n_stores: int = 3,
+    n_weeks: int = 52,
+    start_date: date = date(2022, 1, 3),
+    seed: int = 42,
+) -> pl.DataFrame:
+    """Store-level regressor: week, store_id, promo_discount."""
+    rng = np.random.RandomState(seed)
+    rows = []
+    for s in range(n_stores):
+        for w in range(n_weeks):
+            rows.append({
+                "week": start_date + timedelta(weeks=w),
+                "store_id": f"store_{s}",
+                "promo_discount": round(rng.uniform(0, 0.3), 2),
+            })
+    return pl.DataFrame(rows)
+
+
+def _make_dimension_with_conflict() -> pl.DataFrame:
+    """Dimension table with a column that conflicts with the primary."""
+    return pl.DataFrame({
+        "store_id": ["store_0", "store_1", "store_2"],
+        "region": ["North", "South", "East"],
+        "quantity": [100, 200, 300],  # Same name as primary's target
+    })
+
+
+def _classify(files: dict):
+    """Helper: classify files and return result."""
+    return FileClassifier().classify_files(files)
+
+
+# --------------------------------------------------------------------------- #
+#  Tests: join key detection
+# --------------------------------------------------------------------------- #
+
+class TestJoinKeyDetection(unittest.TestCase):
+    """Test MultiFileMerger.detect_join_keys."""
+
+    def setUp(self):
+        self.merger = MultiFileMerger()
+        self.primary_df = _make_primary_timeseries()
+
+    def test_dimension_join_keys(self):
+        result = _classify({
+            "sales.csv": self.primary_df,
+            "stores.csv": _make_dimension_table(),
+        })
+        spec = self.merger.detect_join_keys(
+            result.primary_file, result.dimension_files[0],
+        )
+        self.assertIn("store_id", spec.join_keys)
+        self.assertNotIn("week", spec.join_keys)
+
+    def test_regressor_join_keys_broadcast(self):
+        result = _classify({
+            "sales.csv": self.primary_df,
+            "weather.csv": _make_regressor_table(),
+        })
+        spec = self.merger.detect_join_keys(
+            result.primary_file, result.regressor_files[0],
+        )
+        self.assertIn("week", spec.join_keys)
+
+    def test_regressor_join_keys_with_ids(self):
+        result = _classify({
+            "sales.csv": self.primary_df,
+            "promos.csv": _make_regressor_with_ids(),
+        })
+        spec = self.merger.detect_join_keys(
+            result.primary_file, result.regressor_files[0],
+        )
+        self.assertIn("week", spec.join_keys)
+        self.assertIn("store_id", spec.join_keys)
+
+    def test_key_overlap_percentage(self):
+        result = _classify({
+            "sales.csv": self.primary_df,
+            "stores.csv": _make_dimension_table(),
+        })
+        spec = self.merger.detect_join_keys(
+            result.primary_file, result.dimension_files[0],
+        )
+        self.assertGreater(spec.key_overlap_pct, 0.0)
+        self.assertLessEqual(spec.key_overlap_pct, 1.0)
+
+    def test_no_overlapping_keys_produces_warning(self):
+        result = _classify({
+            "sales.csv": self.primary_df,
+            "stores.csv": _make_dimension_table(),
+        })
+        # Create a profile with no matching columns
+        from src.data.file_classifier import FileProfile
+        fake = FileProfile(
+            filename="random.csv",
+            df=pl.DataFrame({"x": [1, 2], "y": ["a", "b"]}),
+            role="dimension",
+            confidence=0.5,
+            time_column=None,
+            id_columns=["x"],
+            numeric_columns=[],
+            categorical_columns=["y"],
+            n_rows=2,
+            n_columns=2,
+        )
+        spec = self.merger.detect_join_keys(result.primary_file, fake)
+        self.assertEqual(len(spec.join_keys), 0)
+        self.assertTrue(len(spec.warnings) > 0)
+
+
+# --------------------------------------------------------------------------- #
+#  Tests: merge preview
+# --------------------------------------------------------------------------- #
+
+class TestMergePreview(unittest.TestCase):
+    """Test MultiFileMerger.preview_merge."""
+
+    def setUp(self):
+        self.merger = MultiFileMerger()
+
+    def test_preview_single_file(self):
+        result = _classify({"sales.csv": _make_primary_timeseries()})
+        preview = self.merger.preview_merge(result)
+        self.assertGreater(preview.total_rows, 0)
+        self.assertEqual(preview.unmatched_primary_keys, 0)
+
+    def test_preview_no_primary(self):
+        from src.data.file_classifier import ClassificationResult
+        result = ClassificationResult(
+            profiles=[], primary_file=None,
+            dimension_files=[], regressor_files=[],
+            unknown_files=[], warnings=["test"],
+        )
+        preview = self.merger.preview_merge(result)
+        self.assertEqual(preview.total_rows, 0)
+        self.assertTrue(len(preview.warnings) > 0)
+
+    def test_preview_with_dimension(self):
+        result = _classify({
+            "sales.csv": _make_primary_timeseries(),
+            "stores.csv": _make_dimension_table(),
+        })
+        preview = self.merger.preview_merge(result)
+        self.assertGreater(preview.total_rows, 0)
+        # Should have more columns than primary alone
+        primary_cols = len(_make_primary_timeseries().columns)
+        self.assertGreater(preview.total_columns, primary_cols)
+
+    def test_preview_sample_rows_limited(self):
+        result = _classify({
+            "sales.csv": _make_primary_timeseries(),
+            "stores.csv": _make_dimension_table(),
+        })
+        preview = self.merger.preview_merge(result)
+        self.assertLessEqual(preview.sample_rows.height, 10)
+
+
+# --------------------------------------------------------------------------- #
+#  Tests: full merge
+# --------------------------------------------------------------------------- #
+
+class TestMerge(unittest.TestCase):
+    """Test MultiFileMerger.merge."""
+
+    def setUp(self):
+        self.merger = MultiFileMerger()
+
+    def test_merge_preserves_primary_rows(self):
+        primary = _make_primary_timeseries()
+        result = _classify({
+            "sales.csv": primary,
+            "stores.csv": _make_dimension_table(),
+        })
+        merged = self.merger.merge(result)
+        self.assertEqual(merged.df.height, primary.height)
+
+    def test_merge_adds_dimension_columns(self):
+        result = _classify({
+            "sales.csv": _make_primary_timeseries(),
+            "stores.csv": _make_dimension_table(),
+        })
+        merged = self.merger.merge(result)
+        self.assertIn("region", merged.df.columns)
+        self.assertIn("store_format", merged.df.columns)
+
+    def test_merge_adds_regressor_columns(self):
+        result = _classify({
+            "sales.csv": _make_primary_timeseries(),
+            "weather.csv": _make_regressor_table(),
+        })
+        merged = self.merger.merge(result)
+        self.assertIn("temperature", merged.df.columns)
+        self.assertIn("rainfall_mm", merged.df.columns)
+
+    def test_merge_three_files(self):
+        primary = _make_primary_timeseries()
+        result = _classify({
+            "sales.csv": primary,
+            "stores.csv": _make_dimension_table(),
+            "weather.csv": _make_regressor_table(),
+        })
+        merged = self.merger.merge(result)
+        self.assertEqual(merged.df.height, primary.height)
+        # Has columns from all three
+        self.assertIn("region", merged.df.columns)
+        self.assertIn("temperature", merged.df.columns)
+
+    def test_merge_fills_regressor_nulls(self):
+        result = _classify({
+            "sales.csv": _make_primary_timeseries(),
+            "weather.csv": _make_regressor_table(),
+        })
+        merged = self.merger.merge(result)
+        # Regressor nulls should be filled with 0
+        for col in ["temperature", "rainfall_mm"]:
+            if col in merged.df.columns:
+                null_count = merged.df[col].null_count()
+                self.assertEqual(null_count, 0, f"Column {col} has {null_count} nulls")
+
+    def test_merge_single_file(self):
+        primary = _make_primary_timeseries()
+        result = _classify({"sales.csv": primary})
+        merged = self.merger.merge(result)
+        self.assertEqual(merged.df.height, primary.height)
+        self.assertEqual(len(merged.df.columns), len(primary.columns))
+
+    def test_merge_no_primary_returns_empty(self):
+        from src.data.file_classifier import ClassificationResult
+        result = ClassificationResult(
+            profiles=[], primary_file=None,
+            dimension_files=[], regressor_files=[],
+            unknown_files=[], warnings=[],
+        )
+        merged = self.merger.merge(result)
+        self.assertEqual(merged.df.height, 0)
+
+    def test_merge_join_specs_populated(self):
+        result = _classify({
+            "sales.csv": _make_primary_timeseries(),
+            "stores.csv": _make_dimension_table(),
+            "weather.csv": _make_regressor_table(),
+        })
+        merged = self.merger.merge(result)
+        self.assertEqual(len(merged.join_specs), 2)
+
+    def test_merge_regressor_with_ids(self):
+        primary = _make_primary_timeseries()
+        result = _classify({
+            "sales.csv": primary,
+            "promos.csv": _make_regressor_with_ids(),
+        })
+        merged = self.merger.merge(result)
+        self.assertEqual(merged.df.height, primary.height)
+        self.assertIn("promo_discount", merged.df.columns)
+
+
+class TestColumnConflicts(unittest.TestCase):
+    """Test duplicate column name resolution."""
+
+    def setUp(self):
+        self.merger = MultiFileMerger()
+
+    def test_conflicting_column_renamed(self):
+        result = _classify({
+            "sales.csv": _make_primary_timeseries(),
+            "stores.csv": _make_dimension_with_conflict(),
+        })
+        merged = self.merger.merge(result)
+        # 'quantity' from stores.csv should be renamed to 'quantity_stores'
+        self.assertIn("quantity", merged.df.columns)  # original
+        self.assertIn("quantity_stores", merged.df.columns)  # renamed
+
+    def test_conflict_recorded_in_preview(self):
+        result = _classify({
+            "sales.csv": _make_primary_timeseries(),
+            "stores.csv": _make_dimension_with_conflict(),
+        })
+        merged = self.merger.merge(result)
+        self.assertTrue(len(merged.preview.column_name_conflicts) > 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Users often have multiple related datasets (sales history, store attributes, promotions, weather) that need to be combined before analysis. This adds:

- FileClassifier: auto-detects each uploaded file's role (time_series, dimension, regressor, unknown) using heuristics on column types, naming patterns, and cardinality with confidence scoring
- MultiFileMerger: detects join keys between files, generates merge preview with stats (matched/unmatched rows, column conflicts), and executes left-join merge with null filling for regressor columns
- Updated Data Onboarding page: multi-file upload with interactive role confirmation, merge preview, then analysis on combined data
- 46 new tests across test_file_classifier.py and test_file_merger.py

Single-file upload path remains fully backward compatible.

https://claude.ai/code/session_01Pj1MNta99vMZqazNzmHPNm