### PR TITLE
docs: audit and improve documentation for end users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ forecasting-platform/
 │       ├── 2_Backtest_Results.py   # Leaderboard, FVA cascade, champion map
 │       ├── 3_Forecast_Viewer.py    # Time series + fan chart + decomposition
 │       └── 4_Platform_Health.py    # Manifests, drift alerts, data quality, cost
-├── tests/                  # 860+ tests (pytest)
+├── tests/                  # 1030+ tests (pytest)
 ├── configs/                # YAML configuration files
 ├── scripts/                # Entry points (run_backtest, run_forecast, serve, spark_*)
 └── notebooks/              # Jupyter notebooks for exploration
@@ -127,8 +127,7 @@ YAML-driven config system with dataclass schema validation:
 - `configs/lob/` — line-of-business overrides (inherit from base)
 - Schema defined in `src/config/schema.py`
 
-Key config dataclasses: `ForecastConfig`, `BacktestConfig`, `DataQualityConfig` (contains `ValidationConfig`, `CleansingConfig`), `ConstraintConfig`, `ExternalRegressorConfig` (contains `RegressorScreenConfig`), `ParallelismConfig`, `ObservabilityConfig` (contains `AlertConfig`)
-Key config dataclasses: `ForecastConfig`, `BacktestConfig`, `DataQualityConfig` (contains `ValidationConfig`, `CleansingConfig`), `ConstraintConfig`, `ExternalRegressorConfig` (contains `RegressorScreenConfig`), `AIConfig`
+Key config dataclasses: `ForecastConfig`, `BacktestConfig`, `DataQualityConfig` (contains `ValidationConfig`, `CleansingConfig`), `ConstraintConfig`, `ExternalRegressorConfig` (contains `RegressorScreenConfig`), `ParallelismConfig`, `ObservabilityConfig` (contains `AlertConfig`), `AIConfig`
 
 ### Multi-frequency support
 
@@ -151,7 +150,7 @@ Helper functions: `get_frequency_profile(freq)` returns the profile dict; `freq_
 - Test files mirror source structure with `test_` prefix
 - Helper fixtures use `_make_*` factory functions (e.g., `_make_weekly_actuals`)
 - Skip `test_metrics.py` and `test_feature_engineering.py` (legacy/slow)
-- 900+ tests across 40 test files
+- 1030+ tests across 48 test files
 - Key test modules: `test_platform.py` (85 tests), `test_ai_*.py` (73), `test_forecast_explainability.py` (59), `test_intermittent_demand.py` (55), `test_file_classifier.py` (26), `test_file_merger.py` (20)
 
 ## Key Dependencies
@@ -169,5 +168,7 @@ When adding a new module or capability, update these files:
 3. **`CONCEPTS.md`** (root) — Add a concept entry if the feature introduces a new "why" that non-domain-experts need to understand (3-4 sentences: what, why, when).
 4. **`EDGE_CASES.md`** (root) — Add an entry if the feature handles a new failure mode (what happens, how we handle it, what to watch for).
 5. **`ARCHITECTURE.md`** (root) — Visual Mermaid diagrams showing system overview, data flow, pipeline sequences, and component interactions. Update if adding new subsystems or changing data flow.
+6. **`QUICKSTART.md`** (root) — Get-running-in-2-minutes guide. Update if setup steps, Docker config, or prerequisites change.
+7. **`docs/`** (directory) — User-facing guides: `DATA_FORMAT.md` (input/output schemas), `DEPLOYMENT.md` (deployment & config), `USER_GUIDE.md` (end-to-end usage), `TROUBLESHOOTING.md` (common issues & FAQ). Update the relevant guide when adding user-visible features or changing data schemas.
 
 These are the only documentation files in the repo. All other docs (plans, specs, analyses) are transient working documents — delete them once the work is merged.

--- a/EDGE_CASES.md
+++ b/EDGE_CASES.md
@@ -181,7 +181,7 @@ A catalog of the failure modes that break forecasting platforms — what goes wr
 **How the platform handles it:** The `AlertConfig` has a `min_severity` filter — set to `"critical"` to suppress warning-level alerts. The `ForecastDriftDetector` uses configurable `baseline_weeks` and `recent_weeks` windows, so transient spikes in a 1-week window don't trigger alerts if the baseline window is 12+ weeks. The alert payload includes `current_value` and `baseline_value`, enabling downstream filtering rules. The `AlertDispatcher` counts dispatched alerts via `dispatched_count` for monitoring alert volume.
 
 **What to watch for:** Alert fatigue is a serious operational risk. Start with `min_severity: critical` and only drop to `warning` once you've tuned the drift detection thresholds for your data. Set `baseline_weeks` to at least 8-12 to absorb seasonal variation. Monitor `dispatched_count` — if it exceeds a few per week, your thresholds are too sensitive. Consider adding a cooldown period (not yet built-in) where the same series can't trigger the same alert type within N days.
-## 16. Claude API Unavailability (AI Features)
+## 19. Claude API Unavailability (AI Features)
 
 **What happens:** The Anthropic API is unreachable — no API key configured, network timeout, rate limiting, or the `anthropic` package is not installed. All four AI endpoints (`/ai/explain`, `/ai/triage`, `/ai/recommend-config`, `/ai/commentary`) would fail if they depended on a live API call.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ A production-grade, modular weekly sales forecasting platform. Covers the full l
 
 ---
 
+## User Guides
+
+| Guide | Description |
+|-------|-------------|
+| [Data Format](docs/DATA_FORMAT.md) | Input/output schemas, column rules, sample data |
+| [Deployment](docs/DEPLOYMENT.md) | Docker, env vars, production checklist, scaling |
+| [User Guide](docs/USER_GUIDE.md) | Model selection, backtest interpretation, AI features |
+| [Troubleshooting](docs/TROUBLESHOOTING.md) | Common errors, FAQ, debugging tips |
+
+---
+
 ## System Layers
 
 ```
@@ -130,7 +141,7 @@ forecasting-platform/
 │       ├── 2_Backtest_Results.py   # Leaderboard, FVA cascade, champion map
 │       ├── 3_Forecast_Viewer.py    # Fan chart + decomposition + narrative
 │       └── 4_Platform_Health.py    # Manifests, drift alerts, data quality, cost
-├── tests/                  # 860+ unit + integration tests
+├── tests/                  # 1030+ unit + integration tests
 ├── configs/                # YAML configuration files
 ├── scripts/                # Entry points (run_backtest, run_forecast, serve, spark_*)
 ├── notebooks/              # Jupyter notebooks for exploration
@@ -752,7 +763,7 @@ pip install -r forecasting-platform/requirements.txt
 python -m pytest forecasting-platform/tests/ \
   --ignore=forecasting-platform/tests/test_metrics.py \
   --ignore=forecasting-platform/tests/test_feature_engineering.py -v
-# 860+ tests collected
+# 1030+ tests collected across 48 test files
 ```
 
 | Test file | Tests | Covers |

--- a/docs/DATA_FORMAT.md
+++ b/docs/DATA_FORMAT.md
@@ -1,0 +1,297 @@
+# Data Format Specification
+
+This document describes the input data the platform expects, how files are auto-classified, and the output formats produced by the forecast pipeline.
+
+---
+
+## Input: Time Series File
+
+The primary input is a CSV or Parquet file containing historical demand data.
+
+### Required Columns
+
+| Column | Default Name | Type | Description |
+|--------|-------------|------|-------------|
+| Series ID | `series_id` | String / Categorical | Unique identifier per time series (e.g., SKU, store, product) |
+| Time | `week` | Date / Datetime | Period end-date for each observation |
+| Target | `quantity` | Numeric (int or float) | Demand value (sales, units, revenue) |
+
+Column names are configurable in YAML:
+
+```yaml
+forecast:
+  series_id_column: series_id    # or "Store", "sku", etc.
+  time_column: week              # or "date", "ds", "Date", etc.
+  target_column: quantity        # or "Sales", "demand", "revenue", etc.
+```
+
+### Minimal Example
+
+```csv
+series_id,week,quantity
+STORE_001,2024-01-07,1250
+STORE_001,2024-01-14,1340
+STORE_001,2024-01-21,1180
+STORE_002,2024-01-07,890
+STORE_002,2024-01-14,920
+STORE_002,2024-01-21,870
+```
+
+### Validation Rules
+
+When `data_quality.validation.enabled: true`, the platform checks:
+
+| Check | Level | What It Does |
+|-------|-------|-------------|
+| Schema | ERROR | Required columns must exist with correct types |
+| Duplicates | ERROR | No duplicate `(series_id, time)` pairs allowed |
+| Frequency | WARNING | Date gaps must be consistent (weekly = 7 days, monthly ~ 30 days) |
+| Non-negative | ERROR | Target values must be >= 0 (configurable via `min_value`) |
+| Completeness | WARNING | Series with > `max_missing_pct` missing weeks are flagged |
+
+Set `strict: true` to halt the pipeline on any validation error. Default is `false` (warnings are logged but execution continues).
+
+### Recognized Column Name Patterns
+
+The platform auto-detects columns even if they don't match the configured names:
+
+- **Time columns:** `week`, `date`, `ds`, `time`, `timestamp`, `period`, `day`
+- **Target columns:** `quantity`, `sales`, `demand`, `revenue`, `volume`, `units`, `target`, `value`, `amount`, `qty`, `count`
+- **ID columns:** Any string/categorical column with moderate cardinality (< 10,000 unique values)
+
+### Supported Frequencies
+
+| Code | Period | Min History | Default Horizon | Season Length |
+|------|--------|------------|-----------------|---------------|
+| `D` | Daily | 90 days | 90 days | 7 |
+| `W` | Weekly | 52 weeks | 39 weeks | 52 |
+| `M` | Monthly | 24 months | 12 months | 12 |
+| `Q` | Quarterly | 8 quarters | 8 quarters | 4 |
+
+Set frequency in config:
+```yaml
+forecast:
+  frequency: "W"    # "D" | "W" | "M" | "Q"
+```
+
+---
+
+## Input: Dimension File (Optional)
+
+A lookup table with attributes for each series. No date column needed.
+
+### Example
+
+```csv
+store_id,region,store_type,assortment
+1,North,a,basic
+2,South,b,extended
+3,North,c,basic
+```
+
+Used for:
+- Building hierarchy levels (e.g., store -> region -> total)
+- Enriching series with categorical attributes for ML models
+
+---
+
+## Input: External Regressor File (Optional)
+
+Numeric features aligned to time periods, used by ML models (LightGBM, XGBoost).
+
+### Example
+
+```csv
+week,store_id,promotion_flag,holiday_flag,price_index
+2024-01-07,1,1,0,1.05
+2024-01-14,1,0,0,1.00
+2024-01-21,1,0,1,0.95
+```
+
+### Requirements
+
+- Must include a time column matching the actuals
+- Numeric feature columns only (binary flags, continuous values)
+- **Must cover the forecast horizon** — if you're forecasting 39 weeks ahead, the regressor file needs future values for those 39 weeks
+- If `series_id` is present, features are series-specific; otherwise they broadcast globally
+
+### Feature Types
+
+Configure in YAML:
+```yaml
+forecast:
+  external_regressors:
+    enabled: true
+    feature_columns: [promotion_flag, holiday_flag, price_index]
+    future_features_path: data/future_features.parquet
+    feature_types:
+      promotion_flag: known_ahead     # plannable — safe for forecasting
+      holiday_flag: known_ahead
+      price_index: contemporaneous    # requires explicit future values
+```
+
+- **`known_ahead`** — Features you know in advance (holidays, scheduled promotions). Default.
+- **`contemporaneous`** — Features observed in real time (foot traffic, weather actuals). Must provide explicit future values or they'll be dropped at prediction time.
+
+### Holiday Calendar Generation
+
+Generate holiday flags automatically (requires `pip install holidays`):
+
+```python
+from src.data.regressors import generate_holiday_calendar
+
+holidays_df = generate_holiday_calendar(
+    country="US",
+    start_date="2023-01-01",
+    end_date="2025-12-31",
+    frequency="W"
+)
+# Returns: [week, holiday_flag, holiday_count]
+```
+
+---
+
+## Multi-File Upload (Streamlit)
+
+When uploading multiple files via the Data Onboarding page, the platform auto-classifies each file into a role.
+
+### Classification Roles
+
+| Role | Description | Detected By |
+|------|-------------|-------------|
+| `time_series` | Primary demand data | Date column + numeric target + repeating IDs |
+| `dimension` | Lookup/attribute table | ID columns overlapping with primary, no date column, mostly categorical |
+| `regressor` | External features | Date column + numeric features, joinable to primary |
+| `unknown` | Not recognized | Score below thresholds |
+
+### Confidence Thresholds
+
+- Time series: score >= 0.40
+- Dimension: score >= 0.30
+- Regressor: score >= 0.30
+
+You can override auto-detected roles in the interactive confirmation step.
+
+### Merge Strategy
+
+1. Start with the primary time-series file
+2. Left-join each dimension table on shared ID columns
+3. Left-join each regressor table on shared time + ID columns
+4. Duplicate column names get a `_<filename>` suffix (e.g., `quantity_stores`)
+5. Null values in regressor columns are filled with 0
+
+**Warning:** If key overlap between files is below 50%, a warning is shown in the merge preview.
+
+---
+
+## Output: Forecast Parquet
+
+The forecast pipeline writes Parquet files with this schema:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `series_id` | String | Series identifier (matches input) |
+| `week` | Date | Forecast period date |
+| `forecast` | Float64 | Point forecast (P50) |
+| `forecast_p10` | Float64 | 10th percentile (if quantiles configured) |
+| `forecast_p50` | Float64 | 50th percentile (if quantiles configured) |
+| `forecast_p90` | Float64 | 90th percentile (if quantiles configured) |
+
+Quantile columns are controlled by:
+```yaml
+forecast:
+  quantiles: [0.1, 0.5, 0.9]    # generates forecast_p10, forecast_p50, forecast_p90
+```
+
+### Example
+
+```
+series_id  | week       | forecast | forecast_p10 | forecast_p90
+-----------|------------|----------|--------------|-------------
+STORE_001  | 2024-09-07 | 1234.5   | 1050.2       | 1418.8
+STORE_001  | 2024-09-14 | 1250.0   | 1065.5       | 1434.5
+STORE_002  | 2024-09-07 | 5600.3   | 4200.1       | 7000.5
+```
+
+---
+
+## Output: Pipeline Manifest (JSON)
+
+Each forecast run produces a JSON sidecar file alongside the Parquet output (e.g., `forecast_retail_2024-09-07_manifest.json`).
+
+### Schema
+
+```json
+{
+  "run_id": "abc123def456",
+  "timestamp": "2024-09-07T14:30:45",
+  "lob": "retail",
+
+  "input_data_hash": "a1b2c3d4e5f6",
+  "input_row_count": 52000,
+  "input_series_count": 1000,
+  "date_range_start": "2023-01-07",
+  "date_range_end": "2024-09-07",
+
+  "validation_applied": true,
+  "validation_passed": true,
+  "validation_warnings": 5,
+  "validation_errors": 0,
+
+  "cleansing_applied": true,
+  "outliers_clipped": 42,
+  "stockout_periods_imputed": 127,
+  "rows_modified": 169,
+
+  "regressor_screen_applied": true,
+  "regressors_dropped": ["low_variance_feature"],
+
+  "config_hash": "a1b2c3d4",
+  "champion_model_id": "lgbm_direct",
+  "backtest_wmape": 0.087,
+
+  "forecast_horizon": 39,
+  "forecast_row_count": 39000,
+  "forecast_file": "forecast_retail_2024-09-07.parquet"
+}
+```
+
+This manifest provides full provenance — you can trace exactly what data, config, and model produced any forecast.
+
+---
+
+## Output: Metric Store (Parquet)
+
+Backtest results are stored in a date-partitioned Parquet metric store.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `run_id` | String | Unique backtest run ID |
+| `run_type` | String | `"backtest"` or `"live"` |
+| `model_id` | String | Model name (e.g., `"lgbm_direct"`) |
+| `fold` | Int | Walk-forward fold number |
+| `series_id` | String | Series identifier |
+| `wmape` | Float | Weighted Mean Absolute Percentage Error |
+| `normalized_bias` | Float | Normalized bias (positive = over-forecast) |
+| `mae` | Float | Mean Absolute Error |
+| `rmse` | Float | Root Mean Squared Error |
+
+---
+
+## Sample Dataset: Rossmann
+
+The bundled Rossmann dataset (`data/rossmann/`) provides a ready-to-use demo:
+
+| File | Role | Rows | Key Columns |
+|------|------|------|-------------|
+| `train.csv` | Time series | 1M+ | `Store` (ID), `Date` (time), `Sales` (target), `Customers`, `Open`, `Promo` |
+| `store.csv` | Dimension | 1,115 | `Store` (join key), `StoreType`, `Assortment`, `CompetitionDistance` |
+| `test.csv` | Future features | 41K+ | `Store`, `Date`, `Open`, `Promo` (no `Sales` — forecast target) |
+
+Load the demo via the Streamlit Data Onboarding page (one-click) or programmatically:
+
+```python
+import polars as pl
+actuals = pl.read_csv("data/rossmann/train.csv")
+stores = pl.read_csv("data/rossmann/store.csv")
+```

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,356 @@
+# Deployment Guide
+
+How to run the Forecasting Platform — from local development to production deployment.
+
+---
+
+## Quick Start: Docker Compose
+
+The fastest path to a running platform:
+
+```bash
+git clone https://github.com/chaitu1385/Forecasting-Platform.git
+cd Forecasting-Platform
+docker compose up
+```
+
+This starts two services:
+
+| Service | Port | URL |
+|---------|------|-----|
+| REST API (FastAPI) | 8000 | http://localhost:8000/docs (Swagger UI) |
+| Dashboard (Streamlit) | 8501 | http://localhost:8501 |
+
+Both services share a data volume at `./forecasting-platform/data`.
+
+### Docker Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `API_DATA_DIR` | `forecasting-platform/data/` | Root data directory for the API |
+| `API_METRICS_DIR` | `forecasting-platform/data/metrics/` | Metric store location |
+| `ANTHROPIC_API_KEY` | (empty) | Claude API key for AI features (optional) |
+
+Set AI features:
+```bash
+ANTHROPIC_API_KEY=sk-ant-... docker compose up
+```
+
+### Docker Health Check
+
+The API service has a built-in health check hitting `GET /health` every 30 seconds. The Streamlit service waits for the API to be healthy before starting.
+
+---
+
+## Local Python Setup
+
+### Prerequisites
+
+- Python 3.8+
+- pip
+
+### Install Dependencies
+
+```bash
+# Full install (all features)
+pip install -r forecasting-platform/requirements.txt
+
+# Fabric-compatible subset (no DuckDB, PySpark, neuralforecast)
+pip install -r forecasting-platform/requirements-fabric.txt
+```
+
+### Start the API Server
+
+```bash
+python forecasting-platform/scripts/serve.py --port 8000 --data-dir data/
+```
+
+CLI arguments:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `0.0.0.0` | Bind address |
+| `--port` | `8000` | Bind port |
+| `--data-dir` | `data/` | Root data directory |
+| `--metrics-dir` | `data/metrics/` | Metric store directory |
+| `--reload` | off | Enable hot-reload (development only) |
+| `--workers` | `1` | Number of Uvicorn worker processes |
+
+Environment variables `API_DATA_DIR` and `API_METRICS_DIR` override their CLI counterparts.
+
+### Start the Dashboard
+
+```bash
+streamlit run forecasting-platform/streamlit/app.py
+```
+
+Opens at http://localhost:8501.
+
+---
+
+## Running Pipelines
+
+### Backtest Pipeline
+
+Evaluates all configured models via walk-forward cross-validation and selects a champion:
+
+```bash
+python forecasting-platform/scripts/run_backtest.py \
+  --config forecasting-platform/configs/platform_config.yaml \
+  --lob retail
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--config` | Yes | Path to platform config YAML |
+| `--lob-override` | No | LOB-specific config override YAML |
+| `--data` | Yes | Path to actuals (Parquet or CSV) |
+| `--product-master` | No | Path to product master table |
+| `--mapping-table` | No | Path to SKU mapping table |
+
+### Forecast Pipeline
+
+Generates forecasts using the champion model:
+
+```bash
+python forecasting-platform/scripts/run_forecast.py \
+  --config forecasting-platform/configs/platform_config.yaml \
+  --lob retail
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--config` | Yes | Path to platform config YAML |
+| `--lob-override` | No | LOB-specific config override YAML |
+| `--data` | Yes | Path to actuals (Parquet or CSV) |
+| `--champion` | No | Champion model name (default: `naive_seasonal`) |
+| `--product-master` | No | Path to product master table |
+| `--mapping-table` | No | Path to SKU mapping table |
+
+---
+
+## Configuration
+
+The platform uses a YAML config system with layered overrides.
+
+### Config Files
+
+| File | Purpose |
+|------|---------|
+| `configs/base_config.yaml` | Platform defaults |
+| `configs/platform_config.yaml` | Standard deployment config |
+| `configs/fabric_config.yaml` | Microsoft Fabric settings |
+| `configs/lob/<name>.yaml` | Line-of-business overrides (inherit from base) |
+
+### Key Settings to Customize
+
+```yaml
+# What to forecast
+forecast:
+  frequency: W                          # D | W | M | Q
+  horizon_weeks: 39                     # forecast horizon (periods)
+  forecasters: [lgbm_direct, auto_ets, seasonal_naive]
+  quantiles: [0.1, 0.5, 0.9]           # prediction intervals
+
+# How to evaluate
+backtest:
+  n_folds: 3                            # walk-forward CV folds
+  val_weeks: 13                          # validation window
+  champion_granularity: lob              # lob | product_group | series
+  selection_strategy: champion           # champion | weighted_ensemble
+
+# Data quality
+data_quality:
+  validation:
+    enabled: true                        # schema + duplicate checks
+    strict: false                        # true = halt on errors
+  cleansing:
+    enabled: true                        # outlier + stockout correction
+    outlier_method: iqr                  # iqr | zscore
+
+# Performance
+parallelism:
+  backend: local                         # local | spark
+  n_workers: -1                          # -1 = all CPU cores
+  batch_size: 0                          # 0 = all series at once
+```
+
+See [DATA_FORMAT.md](DATA_FORMAT.md) for complete config schema details.
+
+---
+
+## Authentication Setup
+
+Authentication is disabled by default for development. To enable:
+
+### 1. Enable Auth in Config
+
+The API checks if auth is enabled. When disabled, all requests are treated as admin.
+
+### 2. Create Tokens
+
+```bash
+# Via the API
+curl -X POST "http://localhost:8000/auth/token?username=analyst&role=data_scientist"
+# Returns: {"access_token": "eyJ...", "token_type": "bearer"}
+```
+
+### 3. Use Tokens
+
+```bash
+curl -H "Authorization: Bearer eyJ..." http://localhost:8000/forecast/retail
+```
+
+### Role Permissions
+
+| Action | admin | data_scientist | planner | manager | viewer |
+|--------|-------|----------------|---------|---------|--------|
+| View forecasts/metrics | Y | Y | Y | Y | Y |
+| Create overrides | Y | Y | Y | - | - |
+| Approve overrides | Y | - | - | Y | - |
+| Run backtest/pipeline | Y | Y | - | - | - |
+| Promote champion model | Y | Y | - | - | - |
+| View audit log | Y | Y | - | Y | - |
+| Manage users | Y | - | - | - | - |
+
+Required package: `pip install PyJWT`
+
+---
+
+## Observability Setup
+
+### Logging
+
+```yaml
+observability:
+  log_format: json       # "text" for human-readable, "json" for structured
+  log_level: INFO         # DEBUG | INFO | WARNING | ERROR
+```
+
+JSON logs include `run_id`, `lob`, and timestamps for every pipeline operation.
+
+### Metrics
+
+```yaml
+observability:
+  metrics_backend: log      # "log" = JSON lines, "statsd" = UDP to StatsD
+  statsd_host: localhost
+  statsd_port: 8125
+  metrics_prefix: forecast_platform
+```
+
+### Drift Alerts
+
+```yaml
+observability:
+  alerts:
+    channels: [log, webhook]
+    webhook_url: "https://hooks.slack.com/services/..."    # Slack, Teams, PagerDuty
+    min_severity: warning    # "warning" | "critical"
+```
+
+Alerts fire when forecast accuracy drifts beyond configured thresholds. Start with `min_severity: critical` and lower to `warning` once you've tuned thresholds for your data.
+
+### Cost Tracking
+
+```yaml
+observability:
+  cost_per_second: 0.0001    # $/second for compute cost estimation
+```
+
+Tracks per-model compute time and estimates cloud costs per run.
+
+---
+
+## Scaling
+
+### Local (ProcessPool)
+
+```yaml
+parallelism:
+  backend: local
+  n_workers: -1              # -1 = all CPU cores
+  batch_size: 500            # chunk series into batches of 500
+```
+
+- Reduce `n_workers` if hitting memory limits
+- Increase `batch_size` to reduce memory per worker (each worker loads its batch + model)
+
+### PySpark (Distributed)
+
+For large-scale runs on Databricks or Fabric:
+
+```bash
+python forecasting-platform/scripts/spark_forecast.py \
+  --config forecasting-platform/configs/platform_config.yaml
+```
+
+Uses `SparkForecastPipeline` for distributed series processing. Configure via:
+
+```yaml
+parallelism:
+  backend: spark
+```
+
+---
+
+## Microsoft Fabric Deployment
+
+### Prerequisites
+
+- Fabric workspace with a Lakehouse
+- `requirements-fabric.txt` installed in notebook environment
+
+### Limitations
+
+Fabric's Spark runtime does **not** include:
+- DuckDB (override store auto-falls back to Parquet)
+- neuralforecast / PyTorch (neural models unavailable)
+- FastAPI (API runs externally, not in Fabric)
+
+### Notebook Deployment
+
+```python
+from src.fabric.deployment import DeploymentOrchestrator, DeploymentConfig
+
+cfg = DeploymentConfig(
+    lob="retail",
+    workspace="my-workspace",
+    lakehouse="my-lakehouse",
+    max_staleness_days=14,     # actuals must be within 14 days
+    write_mode="upsert",       # "upsert" | "overwrite_partition" | "append"
+)
+
+orch = DeploymentOrchestrator(spark, config=platform_config, deploy_config=cfg)
+result = orch.run(actuals_sdf=actuals_spark_df)
+```
+
+The orchestrator runs pre-flight checks (data freshness, schema), backtests (optional), forecasts, writes to Delta tables, and logs to the deploy audit table.
+
+### Fabric Config
+
+```yaml
+# configs/fabric_config.yaml
+fabric:
+  workspace: my-workspace
+  lakehouse: my-lakehouse
+```
+
+---
+
+## Production Checklist
+
+Before going to production, verify:
+
+- [ ] **Auth enabled** — JWT authentication active, secrets rotated
+- [ ] **HTTPS** — TLS termination configured (reverse proxy or load balancer)
+- [ ] **Logging** — `log_format: json` for structured log aggregation
+- [ ] **Alerts** — Webhook configured for drift alerts (Slack/Teams/PagerDuty)
+- [ ] **Data validation** — `validation.enabled: true` with `strict: true`
+- [ ] **Demand cleansing** — `cleansing.enabled: true` for outlier/stockout handling
+- [ ] **Parallelism** — `n_workers` tuned for available CPU/memory
+- [ ] **Batch size** — Set `batch_size > 0` for memory-constrained environments
+- [ ] **Monitoring** — Health check endpoint (`/health`) monitored
+- [ ] **Backups** — Metric store and audit log directories backed up
+- [ ] **Cost tracking** — `cost_per_second` set if tracking cloud spend
+- [ ] **API key** — `ANTHROPIC_API_KEY` set if using AI features

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,367 @@
+# Troubleshooting
+
+Common errors, frequently asked questions, and debugging tips.
+
+---
+
+## Common Errors
+
+### "Missing columns: ['week', 'quantity']"
+
+```
+ValueError: [series_id, week, quantity] missing: ['week', 'quantity']
+```
+
+**Cause:** Your CSV column names don't match what the platform expects.
+
+**Fix:** Either rename your columns or configure the expected names in YAML:
+
+```yaml
+forecast:
+  time_column: Date           # match your CSV's date column
+  target_column: Sales        # match your CSV's target column
+  series_id_column: Store     # match your CSV's ID column
+```
+
+---
+
+### "Forecaster 'xxx' not registered"
+
+```
+KeyError: "Forecaster 'unknown_model' not registered. Available: [...]"
+```
+
+**Cause:** Misspelled model name in config or the model's dependency isn't installed.
+
+**Fix:** Check the available model names:
+
+| Name | Requires |
+|------|----------|
+| `naive_seasonal` | (built-in) |
+| `auto_arima`, `auto_ets`, `auto_theta`, `mstl` | `statsforecast` |
+| `lgbm_direct` | `lightgbm`, `mlforecast` |
+| `xgboost_direct` | `xgboost`, `mlforecast` |
+| `nbeats`, `nhits`, `tft` | `neuralforecast` |
+| `chronos` | `chronos` |
+| `timegpt` | `nixtla` |
+| `croston`, `croston_sba`, `tsb` | `statsforecast` |
+
+---
+
+### "Unsupported frequency 'X'"
+
+```
+ValueError: "Unsupported frequency 'X'. Choose from: ['D', 'W', 'M', 'Q']"
+```
+
+**Cause:** Invalid frequency code in config.
+
+**Fix:** Use one of: `D` (daily), `W` (weekly), `M` (monthly), `Q` (quarterly).
+
+---
+
+### "No forecast data found for LOB 'retail'"
+
+```
+HTTPException 404: "No forecast data found for LOB 'retail'. Expected directory: ..."
+```
+
+**Cause:** You're querying the API before running the forecast pipeline.
+
+**Fix:** Run the forecast pipeline first:
+```bash
+python forecasting-platform/scripts/run_forecast.py \
+  --config configs/platform_config.yaml --lob retail
+```
+
+---
+
+### "Authentication required" / "Invalid or expired token"
+
+```
+HTTPException 401: "Authentication required. Provide a Bearer token."
+HTTPException 401: "Invalid or expired token."
+```
+
+**Cause:** Auth is enabled but no valid token was provided.
+
+**Fix:**
+1. Get a token: `curl -X POST "http://localhost:8000/auth/token?username=user&role=data_scientist"`
+2. Use it: `curl -H "Authorization: Bearer <token>" http://localhost:8000/forecast/retail`
+3. Tokens expire after 24 hours — request a new one.
+
+---
+
+### "Permission 'xxx' required"
+
+```
+HTTPException 403: "Permission 'run_backtest' required. Your role 'viewer' does not have this permission."
+```
+
+**Cause:** Your user role doesn't have the required permission.
+
+**Fix:** Request a token with the appropriate role. See [DEPLOYMENT.md](DEPLOYMENT.md) for the role-permission matrix.
+
+---
+
+### "Unsupported file format: .xlsx"
+
+```
+ValueError: "Unsupported file format: .xlsx. Use .parquet or .csv"
+```
+
+**Cause:** The platform only accepts CSV and Parquet files.
+
+**Fix:** Save your Excel file as CSV first.
+
+---
+
+### "Claude client not available" / "anthropic package not installed"
+
+```
+RuntimeError: "Claude client not available"
+RuntimeError: "anthropic package not installed"
+```
+
+**Cause:** AI features require the `anthropic` package and an API key.
+
+**Fix:**
+```bash
+pip install anthropic
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+AI features degrade gracefully when Claude is unavailable — they return template-based responses using the same data structures. No data is lost.
+
+---
+
+### "PyJWT is required for token operations"
+
+```
+RuntimeError: "PyJWT is required for token operations. Install with: pip install PyJWT"
+```
+
+**Fix:** `pip install PyJWT`
+
+---
+
+## Frequently Asked Questions
+
+### How many weeks of history do I need?
+
+Minimum history depends on frequency:
+
+| Frequency | Minimum | Recommended |
+|-----------|---------|-------------|
+| Daily | 90 days | 180+ days |
+| Weekly | 52 weeks | 104+ weeks |
+| Monthly | 24 months | 36+ months |
+| Quarterly | 8 quarters | 12+ quarters |
+
+Foundation models (Chronos, TimeGPT) can work with less history because they don't learn seasonality from scratch.
+
+---
+
+### Can I use daily data?
+
+Yes. Set `frequency: "D"` in your config. The platform auto-adjusts season lengths (7 for daily), lag features, and minimum history requirements.
+
+```yaml
+forecast:
+  frequency: "D"
+  horizon_weeks: 90    # 90-day horizon
+```
+
+---
+
+### How do I add a new model?
+
+Register it with the `ForecasterRegistry`:
+
+```python
+from src.forecasting.registry import registry
+from src.forecasting.base import BaseForecaster
+
+class MyForecaster(BaseForecaster):
+    def fit(self, data, config):
+        # your training logic
+        return self
+
+    def predict(self, horizon, **kwargs):
+        # your prediction logic
+        return forecast_df
+
+registry.register("my_model", MyForecaster)
+```
+
+Then reference it in config:
+```yaml
+forecast:
+  forecasters: [my_model, lgbm_direct]
+```
+
+---
+
+### Why are my forecasts flat?
+
+Common causes:
+1. **Constant series** — If your data has no variation, models produce flat forecasts. Check for placeholder data.
+2. **Insufficient history** — With very short series, models default to the mean. Provide more history or use foundation models.
+3. **All-zero series after cleansing** — Aggressive outlier cleansing may remove real demand signals. Check the cleansing report.
+4. **Wrong frequency** — Monthly data parsed as weekly creates gaps that get filled with zeros.
+
+---
+
+### Why are some series missing from the forecast output?
+
+Series can be dropped during processing:
+1. **Too short** — Below `min_series_length_weeks` (default: 52 for weekly)
+2. **All zeros** — Dropped when `drop_zero_series: true`
+3. **Model failure** — The model failed to fit a specific series. Check `engine.failures` for details.
+4. **Parallel batch failure** — A worker process crashed. Check logs and compare input vs output series counts.
+
+---
+
+### How do I handle sparse/intermittent demand?
+
+Enable sparse detection:
+
+```yaml
+forecast:
+  sparse_detection: true
+  intermittent_forecasters: [croston_sba, tsb]
+```
+
+The platform auto-classifies each series using the Syntetos-Boylan-Croston (SBC) matrix:
+
+| Classification | Condition | Routed To |
+|---------------|-----------|-----------|
+| Smooth | CV² < 0.49, ADI < 1.32 | Regular models |
+| Erratic | CV² >= 0.49, ADI < 1.32 | Regular models |
+| Intermittent | CV² < 0.49, ADI >= 1.32 | Intermittent models |
+| Lumpy | CV² >= 0.49, ADI >= 1.32 | Intermittent models |
+
+---
+
+### Can I use the platform without the dashboard?
+
+Yes. The platform is fully usable via:
+- **CLI scripts** — `run_backtest.py`, `run_forecast.py`
+- **Python API** — Import classes directly (see Quick Start in README)
+- **REST API** — All endpoints available via HTTP
+
+The Streamlit dashboard is a convenience layer, not a requirement.
+
+---
+
+## Debugging Tips
+
+### Enable structured logging
+
+```yaml
+observability:
+  log_format: json
+  log_level: DEBUG
+```
+
+JSON logs include `run_id` for correlating events across a pipeline run.
+
+### Check the pipeline manifest
+
+Every forecast run produces a manifest JSON file with full provenance — what data, config, and model produced the forecast. Look for:
+- `validation_warnings` — Data quality issues that were non-blocking
+- `outliers_clipped` — How many values were modified by cleansing
+- `regressors_dropped` — Features that failed screening
+- `champion_model_id` — Which model actually ran
+
+### Use drift alerts for monitoring
+
+Set up webhook alerts to catch accuracy degradation early:
+
+```yaml
+observability:
+  alerts:
+    channels: [webhook]
+    webhook_url: "https://hooks.slack.com/services/..."
+    min_severity: critical
+```
+
+Start with `critical` severity only. Lower to `warning` after tuning thresholds.
+
+### Check for model failures
+
+After a backtest:
+
+```python
+failures = engine.get_failure_summary()
+if len(failures) > 0:
+    print(failures)   # DataFrame with model_name, fold, error_type, message
+```
+
+---
+
+## Performance Issues
+
+### Backtests are slow
+
+- **Reduce models** — Start with 2-3 candidates, not all 18
+- **Reduce folds** — `n_folds: 2` instead of 5 (less robust but faster)
+- **Skip neural models** — `nbeats`, `nhits`, `tft` are orders of magnitude slower than statistical/ML
+- **Enable parallelism** — `n_workers: -1` uses all CPU cores
+- **Use batch processing** — `batch_size: 500` to chunk large datasets
+
+### Out of memory
+
+- **Reduce `n_workers`** — Each worker loads a full model + data copy
+- **Increase `batch_size`** — Smaller chunks per worker
+- **Use Spark** — `backend: spark` for datasets that don't fit in memory
+- **Drop neural models** — They have the largest memory footprint
+
+### Docker container crashes
+
+- Provision at least **2 GB RAM** for datasets with 1000+ series
+- The Rossmann demo dataset (1M rows) runs comfortably in 2 GB
+- For larger datasets, increase container memory limits
+
+---
+
+## Environment-Specific Issues
+
+### Microsoft Fabric
+
+**Issue:** DuckDB, neuralforecast, and PySpark are not available in the Fabric Spark runtime.
+
+**What happens:**
+- Override store auto-falls back to Parquet (no concurrent write support)
+- Neural models (`nbeats`, `nhits`, `tft`) are unavailable
+- `pip install` only persists for the session, not across cluster restarts
+
+**Fix:**
+- Use `requirements-fabric.txt` (excludes incompatible packages)
+- Pin libraries in Fabric workspace settings for persistent installs
+- Use a single orchestrator notebook for override management
+
+### Docker volume mounts
+
+**Issue:** Forecast/metric files aren't visible between API and Streamlit containers.
+
+**Fix:** Both services must share the same data volume:
+```yaml
+volumes:
+  - ./forecasting-platform/data:/app/forecasting-platform/data
+```
+
+### Import errors for optional dependencies
+
+**Issue:** `ImportError` or `ModuleNotFoundError` for packages like `neuralforecast`, `shap`, `holidays`.
+
+**What happens:** The platform uses optional dependency guards — it won't crash on import, but the feature will be unavailable at runtime.
+
+**Fix:** Install the specific package:
+```bash
+pip install neuralforecast    # for N-BEATS, N-HiTS, TFT
+pip install shap              # for SHAP explainability
+pip install holidays          # for holiday calendar generation
+pip install PyJWT             # for JWT authentication
+pip install anthropic         # for AI features
+```

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,370 @@
+# User Guide
+
+An end-to-end guide for using the Forecasting Platform — from choosing models to interpreting results.
+
+---
+
+## Workflow Overview
+
+```
+1. Prepare data (CSV/Parquet)
+2. Upload via Streamlit or run pipeline script
+3. Backtest: evaluate candidate models
+4. Review results: leaderboard, FVA, champion map
+5. Forecast: generate production forecasts
+6. Monitor: drift alerts, data quality, cost
+```
+
+---
+
+## Model Selection
+
+The platform includes 18 registered models across 6 families. Use this decision tree:
+
+### Quick Reference
+
+| Family | Models | Best For | Data Needs | Speed |
+|--------|--------|----------|-----------|-------|
+| **Naive** | `naive_seasonal` | Baseline benchmark | Any series length | Instant |
+| **Statistical** | `auto_arima`, `auto_ets`, `auto_theta`, `mstl` | Stable demand with clear trend/seasonality | 52+ weeks (weekly) | Fast |
+| **ML** | `lgbm_direct`, `xgboost_direct` | Complex patterns, external regressors | 52+ weeks + features | Fast |
+| **Neural** | `nbeats`, `nhits`, `tft` | Large datasets, complex interactions | 100+ series, 100+ weeks | Slow |
+| **Foundation** | `chronos`, `timegpt` | Cold start, limited history | Any (zero-shot) | Medium |
+| **Intermittent** | `croston`, `croston_sba`, `tsb` | Sparse/lumpy demand | 10+ non-zero observations | Fast |
+
+### Decision Tree
+
+1. **Is demand intermittent (many zeros)?**
+   - Yes -> Enable sparse detection (`sparse_detection: true`). The platform auto-routes sparse series to intermittent models.
+   - No -> Continue.
+
+2. **Do you have external features (promotions, holidays, price)?**
+   - Yes -> Use ML models (`lgbm_direct`, `xgboost_direct`). They automatically pick up feature columns.
+   - Statistical and naive models silently ignore external features.
+
+3. **How much history do you have?**
+   - < 52 weeks -> Foundation models (`chronos`), or `naive_seasonal` with cyclic fallback.
+   - 52-104 weeks -> Statistical (`auto_ets`, `auto_arima`) or ML (`lgbm_direct`).
+   - 104+ weeks -> All models viable. Use backtest to compare.
+
+4. **How many series?**
+   - < 100 -> Any model. Neural models may overfit.
+   - 100-10,000 -> ML models shine. Run backtest with 3-4 candidates.
+   - 10,000+ -> Enable `batch_size` and `n_workers` for parallelism.
+
+### Recommended Starting Configuration
+
+```yaml
+forecast:
+  forecasters: [naive_seasonal, auto_ets, lgbm_direct]
+  sparse_detection: true
+  intermittent_forecasters: [croston_sba, tsb]
+```
+
+This gives you a baseline (naive), a strong statistical model (ETS), and an ML model (LightGBM). The backtest will pick the best per your data.
+
+---
+
+## Running a Backtest
+
+Backtesting evaluates models using walk-forward cross-validation: train on past data, forecast the next N weeks, measure accuracy, slide the window forward.
+
+### Configuration
+
+```yaml
+backtest:
+  n_folds: 3                    # number of CV folds
+  val_weeks: 13                 # validation window (one quarter)
+  gap_weeks: 0                  # gap between train and test (for delayed data)
+  champion_granularity: lob     # pick one champion for the whole LOB
+  primary_metric: wmape          # rank by Weighted MAPE
+  selection_strategy: champion   # "champion" (single best) or "weighted_ensemble"
+```
+
+### Run
+
+```bash
+python forecasting-platform/scripts/run_backtest.py \
+  --config configs/platform_config.yaml --lob retail
+```
+
+### Champion Selection Strategies
+
+- **`champion`** — Picks the single model with lowest WMAPE across all folds. Simple, interpretable.
+- **`weighted_ensemble`** — Blends top models using inverse-WMAPE weights. Often 1-3% more accurate, but harder to explain.
+
+### Granularity Options
+
+| Granularity | What It Does | When to Use |
+|-------------|-------------|-------------|
+| `lob` | One champion for all series in the LOB | Default — simple and reliable |
+| `product_group` | Different champion per product group | When product categories have very different demand patterns |
+| `series` | Different champion per series | Large datasets (1000+ series) where per-series tuning matters |
+
+---
+
+## Interpreting Backtest Results
+
+### Metrics
+
+| Metric | Formula | What It Means | Good Range |
+|--------|---------|-------------|-----------|
+| **WMAPE** | sum(\|error\|) / sum(\|actual\|) | Overall accuracy weighted by volume | < 20% is good, < 10% is excellent |
+| **Normalized Bias** | sum(error) / sum(\|actual\|) | Systematic over/under-forecast | -5% to +5% is acceptable |
+| **MAE** | mean(\|error\|) | Average error in original units | Domain-dependent |
+| **RMSE** | sqrt(mean(error²)) | Penalizes large errors more | Domain-dependent |
+
+### Leaderboard
+
+The leaderboard ranks models by the primary metric (WMAPE by default), aggregated across all folds and series.
+
+```
+Rank | Model          | WMAPE  | Bias   | MAE
+-----|----------------|--------|--------|-----
+1    | lgbm_direct    | 12.3%  | -1.2%  | 234
+2    | auto_ets       | 14.1%  | +0.8%  | 267
+3    | naive_seasonal | 18.7%  | +2.1%  | 312
+```
+
+### Forecast Value Added (FVA)
+
+FVA measures how much accuracy each model layer contributes compared to the naive baseline.
+
+**Layers:**
+
+| Layer | Models | Purpose |
+|-------|--------|---------|
+| L1: Naive | `naive_seasonal` | Baseline — always computed |
+| L2: Statistical | `auto_arima`, `auto_ets`, `croston`, etc. | Best statistical per series |
+| L3: ML | `lgbm_direct`, `xgboost_direct` | Best ML per series |
+| L4: Override | Planner-adjusted | If planner override exists |
+
+**FVA Classification:**
+
+| Classification | WMAPE Change | Meaning |
+|---------------|-------------|---------|
+| `ADDS_VALUE` | > 2 percentage points improvement | Model is helping |
+| `NEUTRAL` | Within ±2 pp | No meaningful difference |
+| `DESTROYS_VALUE` | > 2 pp degradation | Model is hurting — consider removing |
+
+**Reading the FVA cascade chart (Streamlit Backtest Results page):**
+- Bars show WMAPE at each layer
+- Green arrows = layers that add value
+- Red arrows = layers that destroy value
+- If L3 (ML) destroys value vs L2 (Statistical), the ML model isn't learning anything useful beyond what ETS/ARIMA already captures
+
+---
+
+## Generating Forecasts
+
+After backtesting, generate production forecasts:
+
+```bash
+python forecasting-platform/scripts/run_forecast.py \
+  --config configs/platform_config.yaml \
+  --lob retail \
+  --champion lgbm_direct
+```
+
+### Output
+
+- **Forecast Parquet** — Point forecasts and prediction intervals per series per period
+- **Pipeline Manifest** — JSON provenance file tracking what data, config, and model produced the forecast
+
+See [DATA_FORMAT.md](DATA_FORMAT.md) for complete output schemas.
+
+---
+
+## Hierarchical Forecasting
+
+When you have a hierarchy (e.g., SKU -> Category -> Total), hierarchical reconciliation ensures forecasts sum correctly at every level.
+
+### Setup
+
+```yaml
+hierarchies:
+  - name: product
+    levels: [total, category, sku]
+    reconciliation:
+      method: mint     # bottom_up | top_down | ols | wls | mint
+```
+
+Your dimension data must include the hierarchy columns (e.g., `category` for each `sku`).
+
+### Reconciliation Methods
+
+| Method | When to Use |
+|--------|-------------|
+| `bottom_up` | Leaf (SKU) forecasts are accurate; upper levels are just sums |
+| `top_down` | Top-level forecast is accurate; disaggregate by historical proportions |
+| `ols` | No prior knowledge about which level is most accurate |
+| `wls` | Some levels have more data (weights by leaf count or residual variance) |
+| `mint` | Best overall accuracy — uses covariance of forecast errors (recommended) |
+
+---
+
+## External Regressors
+
+Add external features (promotions, holidays, price) to improve ML model accuracy.
+
+### End-to-End Example
+
+1. **Prepare features file** (see [DATA_FORMAT.md](DATA_FORMAT.md) for schema):
+
+```csv
+week,store_id,promotion_flag,holiday_flag,price_index
+2024-01-07,1,1,0,1.05
+...
+```
+
+2. **Configure:**
+
+```yaml
+forecast:
+  external_regressors:
+    enabled: true
+    feature_columns: [promotion_flag, holiday_flag, price_index]
+    future_features_path: data/future_features.parquet
+    screen:
+      enabled: true              # auto-drop low-quality features
+      variance_threshold: 1.0e-6
+      correlation_threshold: 0.95
+```
+
+3. **Run pipeline** — ML models (`lgbm_direct`, `xgboost_direct`) automatically use the features. Statistical models ignore them.
+
+### Regressor Screening
+
+When `screen.enabled: true`, the platform automatically drops:
+- **Near-zero variance** features (threshold: 1e-6)
+- **Highly correlated** feature pairs (threshold: 0.95, keeps first)
+- **Low mutual information** features (optional, `mi_enabled: true`)
+
+Dropped features are logged in the pipeline manifest.
+
+---
+
+## AI Features
+
+Four Claude-powered endpoints provide AI-native analysis. Requires `ANTHROPIC_API_KEY` environment variable.
+
+### Natural Language Query (`POST /ai/explain`)
+
+Ask questions about forecasts in plain English:
+
+```json
+{
+  "lob": "retail",
+  "series_id": "STORE_001",
+  "question": "Why did sales drop last week?"
+}
+```
+
+Returns an answer with supporting data, confidence level, and sources used.
+
+### Anomaly Triage (`POST /ai/triage`)
+
+Prioritizes drift alerts by business impact:
+
+```json
+{
+  "lob": "retail",
+  "severity_filter": "critical",
+  "max_alerts": 50
+}
+```
+
+Returns ranked alerts with impact scores, suggested actions, and an executive summary.
+
+### Config Recommendation (`POST /ai/recommend-config`)
+
+Analyzes backtest results and recommends config changes:
+
+```json
+{ "lob": "retail" }
+```
+
+Returns specific recommendations (e.g., "switch from `naive_seasonal` to `lgbm_direct`") with expected impact and risk level.
+
+### Executive Commentary (`POST /ai/commentary`)
+
+Generates S&OP-ready executive summaries:
+
+```json
+{ "lob": "retail" }
+```
+
+Returns a 3-5 sentence summary, key metrics with trends, exceptions, and action items.
+
+### Graceful Degradation
+
+All AI features work without Claude — they fall back to template-based responses using the same data structures. The UI and downstream consumers don't need to handle a different schema.
+
+---
+
+## Planner Overrides
+
+Demand planners can manually adjust forecasts through the override store.
+
+```python
+from src.overrides import OverrideStore
+
+store = OverrideStore()
+
+# Add an override
+store.add_override(
+    lob="retail",
+    old_sku="PROD_A",
+    new_sku="PROD_B",
+    proportion=0.6,
+    scenario="replacement",
+    ramp_shape="linear"
+)
+
+# Retrieve overrides
+overrides = store.get_overrides(lob="retail", week="2024-09-07")
+```
+
+The override store uses DuckDB by default, with automatic fallback to Parquet in environments where DuckDB is unavailable (e.g., Microsoft Fabric).
+
+---
+
+## Streamlit Dashboard
+
+### Page 1: Data Onboarding
+
+Upload CSV files, auto-detect schema, preview data quality, and get a recommended config.
+
+- Upload single or multiple files
+- Auto-classification into time series / dimension / regressor roles
+- Merge preview with conflict detection
+- Forecastability scoring (0-1 scale per series)
+- Recommended YAML config output
+
+### Page 2: Backtest Results
+
+Evaluate model performance after running a backtest.
+
+- **Leaderboard** — Models ranked by WMAPE
+- **FVA Cascade** — Accuracy improvement at each model layer
+- **Champion Map** — Which model won for which series/product group
+- **Layer Leaderboard** — Keeps/Review/Remove recommendations per layer
+
+### Page 3: Forecast Viewer
+
+Explore forecasts for individual series.
+
+- Series selector (search/filter)
+- Forecast line with actuals overlay
+- P10/P90 fan chart (prediction intervals)
+- Seasonal decomposition (trend + seasonal + residual)
+- Explainer narrative (natural language description)
+
+### Page 4: Platform Health
+
+Monitor pipeline runs and system health.
+
+- Pipeline manifests (provenance for each run)
+- Drift alerts (severity-colored: warning/critical)
+- Data quality summary (validation + cleansing reports)
+- Compute cost tracking per model


### PR DESCRIPTION
Part 1 — Fix existing issues:
- Update stale test counts (860/900 → 1030+ across 48 files) in README.md and CLAUDE.md
- Remove duplicate "Key config dataclasses" line in CLAUDE.md
- Fix EDGE_CASES.md numbering (case 19 was missing, case 16 was duplicated)
- Add QUICKSTART.md and docs/ to documentation convention in CLAUDE.md

Part 2 — Add user-facing guides:
- docs/DATA_FORMAT.md: Input/output schemas, column rules, file classification, sample data
- docs/DEPLOYMENT.md: Docker, env vars, auth setup, scaling, Fabric, production checklist
- docs/USER_GUIDE.md: Model selection, backtest interpretation, FVA, AI features, dashboard
- docs/TROUBLESHOOTING.md: Common errors, FAQ, debugging tips, performance tuning
- Add User Guides section to README.md with links to all four guides

https://claude.ai/code/session_01Pj1MNta99vMZqazNzmHPNm