### PR TITLE
Update README: clarify multi-frequency forecasting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,5 @@
 # Forecasting Platform
 
-```bash
-git clone https://github.com/chaitu1385/Forecasting-Platform.git
-cd Forecasting-Platform
-docker compose up          # open http://localhost:8501
-```
-
-No Docker? See [QUICKSTART.md](QUICKSTART.md) for the local Python path.
-
----
-
-A production-grade, modular weekly sales forecasting platform. Covers the full lifecycle from raw data ingestion to hierarchically reconciled, explained, and governed forecasts — with a REST API, Microsoft Fabric/Delta Lake deployment layer, Spark distributed execution, and S&OP exception management.
 A production-grade, modular multi-frequency sales forecasting platform (daily, weekly, monthly, quarterly). Covers the full lifecycle from raw data ingestion to hierarchically reconciled, explained, and governed forecasts — with a REST API, Microsoft Fabric/Delta Lake deployment layer, Spark distributed execution, and S&OP exception management.
 
 **See also:** [QUICKSTART.md](QUICKSTART.md) — get running in 2 minutes | [ARCHITECTURE.md](ARCHITECTURE.md) — visual diagrams of system architecture and data flow | [CONCEPTS.md](CONCEPTS.md) — why each component exists | [EDGE_CASES.md](EDGE_CASES.md) — failure modes and how the platform handles them


### PR DESCRIPTION
## Summary
Updated the README.md to better reflect the platform's capabilities and improve documentation clarity.

## Changes
- Removed the Docker quick-start instructions and local Python setup reference from the main README (these are now consolidated in QUICKSTART.md)
- Updated the platform description to explicitly highlight **multi-frequency forecasting support** (daily, weekly, monthly, quarterly) rather than weekly-only
- Streamlined the introductory section to focus on the core value proposition and reference the detailed documentation files

## Details
The changes clarify that this is a multi-frequency forecasting platform, not limited to weekly forecasts. The setup instructions have been removed from the main README to avoid duplication, with users directed to QUICKSTART.md for getting started. This makes the README more focused on what the platform does rather than how to install it.

https://claude.ai/code/session_018m1HmEft7oc6NRUfRutBoB