### PR TITLE
Expand Streamlit dashboard from 4 to 8 pages following DS workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,14 +94,18 @@ forecasting-platform/
 │   ├── spark/              # PySpark distributed execution
 │   ├── fabric/             # Microsoft Fabric / Delta Lake deployment
 │   └── analytics/          # BI export, comparators, explainability, governance, FVA
-├── streamlit/              # Streamlit dashboard (4 pages)
-│   ├── app.py              # Main entry point / landing page
-│   ├── utils.py            # Shared helpers, colour palette, data loaders
-│   └── pages/              # Streamlit multi-page layout
-│       ├── 1_Data_Onboarding.py    # Upload CSV → DataAnalyzer → config recommendation
-│       ├── 2_Backtest_Results.py   # Leaderboard, FVA cascade, champion map
-│       ├── 3_Forecast_Viewer.py    # Time series + fan chart + decomposition
-│       └── 4_Platform_Health.py    # Manifests, drift alerts, data quality, cost
+├── streamlit/              # Streamlit dashboard (8 pages)
+│   ├── app.py              # Main entry point / landing page (4 persona paths)
+│   ├── utils.py            # Shared helpers, colour palette, AI utilities
+│   └── pages/              # Streamlit multi-page layout (workflow-ordered)
+│       ├── 1_Data_Onboarding.py    # Upload CSV → DataAnalyzer → cleansing preview → config
+│       ├── 2_Series_Explorer.py    # SBC classification, breaks, quality, cleansing audit, AI Q&A
+│       ├── 3_SKU_Transitions.py    # SKU mapping pipeline, planner overrides, transition viz
+│       ├── 4_Hierarchy_Manager.py  # Hierarchy tree, aggregation, reconciliation (MinT/OLS/WLS)
+│       ├── 5_Backtest_Results.py   # Leaderboard, FVA, champions, calibration, SHAP, AI config tuner
+│       ├── 6_Forecast_Viewer.py    # Fan chart, decomposition, AI NL query, comparison, constraints
+│       ├── 7_Platform_Health.py    # Manifests, drift + AI triage, audit log, cost tracking
+│       └── 8_SOP_Meeting.py        # AI commentary, cross-run comparison, governance, BI export
 ├── tests/                  # 1030+ tests (pytest)
 ├── configs/                # YAML configuration files
 ├── scripts/                # Entry points (run_backtest, run_forecast, serve, spark_*)

--- a/forecasting-platform/streamlit/app.py
+++ b/forecasting-platform/streamlit/app.py
@@ -34,8 +34,8 @@ st.set_page_config(
 st.title("Forecasting Platform")
 
 st.markdown(
-    "Weekly sales forecasting for retail S&OP — statistical, ML, neural, "
-    "and foundation models with hierarchical reconciliation."
+    "Multi-frequency sales forecasting for retail S&OP — statistical, ML, neural, "
+    "and foundation models with hierarchical reconciliation and AI-powered insights."
 )
 
 st.info(
@@ -48,34 +48,43 @@ st.info(
 # ---------------------------------------------------------------------------
 st.subheader("Quick Start")
 
-col_ds, col_dp, col_eng = st.columns(3)
+col_ds, col_dp, col_sop, col_eng = st.columns(4)
 
 with col_ds:
     st.markdown("**Data Scientist**")
     st.markdown(
-        "Upload your data on **Data Onboarding**, run a backtest, "
-        "then compare models on **Backtest Results**. The platform "
-        "auto-selects the best model per series and shows FVA analysis."
+        "Upload data on **Data Onboarding**, explore series quality on "
+        "**Series Explorer**, run backtests, then compare models on "
+        "**Backtest Results** with SHAP and AI config tuning."
     )
-    st.caption("Start with: Data Onboarding → Backtest Results")
+    st.caption("Pages 1 → 2 → 5 → 6")
 
 with col_dp:
     st.markdown("**Demand Planner**")
     st.markdown(
         "Review forecasts on the **Forecast Viewer** with confidence "
-        "intervals and actuals overlay. Check which series have "
-        "accuracy issues on **Platform Health**."
+        "intervals, AI Q&A, and comparison overlays. Manage SKU "
+        "transitions and overrides on **SKU Transitions**."
     )
-    st.caption("Start with: Forecast Viewer")
+    st.caption("Pages 6 → 3 → 7")
+
+with col_sop:
+    st.markdown("**S&OP Leader**")
+    st.markdown(
+        "Generate executive commentary on **S&OP Meeting Prep** "
+        "with AI-powered narratives. Review governance and export "
+        "data for BI tools."
+    )
+    st.caption("Pages 6 → 7 → 8")
 
 with col_eng:
     st.markdown("**Platform Engineer**")
     st.markdown(
-        "Monitor pipeline runs, drift alerts, and compute costs on "
-        "**Platform Health**. Each forecast run produces a provenance "
-        "manifest for full traceability."
+        "Monitor pipelines, AI-triage drift alerts, and track compute "
+        "costs on **Platform Health**. Review audit logs for full "
+        "traceability."
     )
-    st.caption("Start with: Platform Health")
+    st.caption("Pages 1 → 7")
 
 # ---------------------------------------------------------------------------
 #  Pages overview
@@ -85,15 +94,24 @@ st.subheader("Pages")
 
 st.markdown(
     """
-1. **Data Onboarding** — Upload one or more CSVs. The platform auto-detects
-   schema, classifies file roles, assesses forecastability, and recommends a
-   configuration. Supports multi-file upload with intelligent merge.
-2. **Backtest Results** — Model leaderboard ranked by WMAPE, FVA cascade
-   showing which model layers add or destroy value, per-series champion map.
-3. **Forecast Viewer** — Interactive forecast chart with P10/P90 confidence
-   intervals, actuals overlay, and seasonal decomposition with narrative.
-4. **Platform Health** — Pipeline manifests with provenance, drift alerts
-   with severity breakdown, data quality summary, and compute cost tracking.
+**Data → Understand → Prepare → Structure → Model → Forecast → Monitor → Report**
+
+1. **Data Onboarding** — Upload CSVs, auto-detect schema, assess forecastability,
+   preview demand cleansing, screen regressors, and get a recommended config.
+2. **Series Explorer** — Deep-dive into series quality: SBC demand classification,
+   structural break detection, data quality profiling, cleansing audit, and AI Q&A.
+3. **SKU Transitions** — Run SKU mapping pipeline (attribute matching, naming
+   conventions), manage planner overrides with approval workflow.
+4. **Hierarchy Manager** — Visualize hierarchy trees, explore aggregations,
+   run forecast reconciliation (bottom-up, MinT, OLS, WLS).
+5. **Backtest Results** — Model leaderboard, FVA cascade, champion map,
+   prediction interval calibration, SHAP attribution, and AI config tuning.
+6. **Forecast Viewer** — Interactive forecast chart with fan chart, decomposition,
+   AI natural-language Q&A, forecast comparison, and constrained forecast toggle.
+7. **Platform Health** — Pipeline manifests, drift alerts with AI triage,
+   audit log viewer, data quality summary, and compute cost tracking.
+8. **S&OP Meeting Prep** — AI-generated executive commentary, cross-run
+   comparison, model governance, and BI export for Power BI / Tableau.
     """
 )
 
@@ -113,6 +131,11 @@ with st.expander("Glossary — key terms explained"):
 | **Croston / TSB** | Intermittent demand models designed for sparse or lumpy time series where many periods have zero demand. |
 | **Walk-forward backtest** | Evaluation method that trains on past data and tests on the next N periods, walking forward through time. |
 | **Champion model** | The best-performing model for a given series, selected by backtest accuracy. |
+| **SBC matrix** | Syntetos-Boylan-Croston classification — categorizes demand patterns as Smooth, Intermittent, Erratic, or Lumpy based on ADI and CV-squared. |
+| **Structural break** | A sudden level shift or trend change in a time series, detected using CUSUM or PELT algorithms. |
+| **MinT reconciliation** | Minimum Trace — optimal reconciliation method using shrinkage covariance estimation. Best for large hierarchies. |
+| **SHAP** | SHapley Additive exPlanations — explains ML model predictions by quantifying each feature's contribution. |
+| **Conformal prediction** | A calibration technique that adjusts prediction intervals to achieve desired coverage using backtest residuals. |
         """
     )
 

--- a/forecasting-platform/streamlit/pages/1_Data_Onboarding.py
+++ b/forecasting-platform/streamlit/pages/1_Data_Onboarding.py
@@ -470,6 +470,123 @@ if fa.per_series is not None and not fa.per_series.is_empty():
         st.dataframe(polars_to_pandas(fa.per_series), use_container_width=True)
 
 # --------------------------------------------------------------------------- #
+#  Demand Cleansing Preview
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Demand Cleansing Preview")
+st.caption(
+    "Preview how outlier detection and stockout imputation will affect your data. "
+    "See the full audit on the **Series Explorer** page."
+)
+
+try:
+    from src.config.schema import CleansingConfig
+    from src.data.cleanser import DemandCleanser
+
+    cleansing_cfg = CleansingConfig(enabled=True)
+    cleanser = DemandCleanser(config=cleansing_cfg)
+
+    with st.spinner("Running demand cleansing preview..."):
+        cleansing_result = cleanser.cleanse(
+            df=df,
+            time_col=schema.time_column,
+            value_col=schema.target_column,
+            sid_col=schema.id_columns[0] if schema.id_columns else "series_id",
+        )
+
+    cr = cleansing_result.report
+    col_o, col_s, col_r = st.columns(3)
+    col_o.metric("Outliers Clipped", cr.outliers_clipped)
+    col_s.metric("Stockout Periods Imputed", cr.stockout_periods_imputed)
+    col_r.metric("Rows Modified", cr.rows_modified)
+
+    st.session_state["cleansing_report"] = cr
+    st.caption("Go to **Series Explorer** for per-series cleansing audit.")
+
+except Exception as exc:
+    st.info(f"Cleansing preview not available: {exc}")
+
+# --------------------------------------------------------------------------- #
+#  Regressor Screening
+# --------------------------------------------------------------------------- #
+regressor_cols = [
+    c for c in df.columns
+    if c not in {schema.time_column, schema.target_column}
+    and c not in set(schema.id_columns)
+    and df[c].dtype in (pl.Float64, pl.Float32, pl.Int64, pl.Int32, pl.Int16, pl.Int8)
+]
+
+if regressor_cols:
+    st.divider()
+    st.header("Regressor Screening")
+    st.caption(
+        f"Screening {len(regressor_cols)} numeric columns as potential regressors."
+    )
+
+    try:
+        from src.data.regressor_screen import screen_regressors
+
+        with st.spinner("Screening regressors..."):
+            screen_report = screen_regressors(
+                df=df,
+                feature_columns=regressor_cols,
+                target_col=schema.target_column,
+            )
+
+        col_p, col_d = st.columns(2)
+        with col_p:
+            st.markdown("**Passed columns**")
+            for c in screen_report.passed_columns:
+                st.markdown(f"- `{c}`")
+        with col_d:
+            if screen_report.dropped_columns:
+                st.markdown("**Dropped columns**")
+                for c in screen_report.dropped_columns:
+                    st.markdown(f"- `{c}`")
+            else:
+                st.success("All regressor columns passed screening.")
+
+        if screen_report.warnings:
+            for w in screen_report.warnings:
+                st.warning(w)
+
+        st.session_state["regressor_screen_report"] = screen_report
+
+    except Exception as exc:
+        st.info(f"Regressor screening not available: {exc}")
+
+# --------------------------------------------------------------------------- #
+#  Structural Break Summary
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Structural Break Summary")
+
+try:
+    from src.config.schema import StructuralBreakConfig
+    from src.series.break_detector import StructuralBreakDetector
+
+    break_cfg = StructuralBreakConfig(method="cusum")
+    detector = StructuralBreakDetector(config=break_cfg)
+
+    with st.spinner("Detecting structural breaks..."):
+        break_report = detector.detect(
+            df=df,
+            target_col=schema.target_column,
+            time_col=schema.time_column,
+            id_col=schema.id_columns[0] if schema.id_columns else "series_id",
+        )
+
+    col_tb, col_sb = st.columns(2)
+    col_tb.metric("Total Breaks", break_report.total_breaks)
+    col_sb.metric("Series with Breaks", break_report.series_with_breaks)
+
+    st.session_state["break_report"] = break_report
+    st.caption("Go to **Series Explorer** for detailed break analysis.")
+
+except Exception as exc:
+    st.info(f"Structural break detection not available: {exc}")
+
+# --------------------------------------------------------------------------- #
 #  Hypotheses & Warnings
 # --------------------------------------------------------------------------- #
 st.divider()

--- a/forecasting-platform/streamlit/pages/1_Data_Onboarding.py
+++ b/forecasting-platform/streamlit/pages/1_Data_Onboarding.py
@@ -36,9 +36,11 @@ from utils import (
     load_uploaded_csvs,
     polars_to_pandas,
     format_pct,
+    render_api_key_sidebar,
 )
 
 st.set_page_config(page_title="Data Onboarding", page_icon="📊", layout="wide")
+render_api_key_sidebar()
 st.title("Data Onboarding")
 st.markdown(
     "Upload one or more CSVs to auto-detect schema, assess forecastability, "
@@ -803,7 +805,7 @@ st.divider()
 st.header("AI Interpretation (optional)")
 st.markdown(
     "Generate an executive-level narrative using Claude. "
-    "Requires `ANTHROPIC_API_KEY` environment variable."
+    "Requires an Anthropic API key (enter in sidebar or set `ANTHROPIC_API_KEY`)."
 )
 
 if st.button("Generate AI Interpretation"):
@@ -813,8 +815,8 @@ if st.button("Generate AI Interpretation"):
         llm = LLMAnalyzer()
         if not llm.available:
             st.warning(
-                "LLM not available. Set the `ANTHROPIC_API_KEY` environment variable "
-                "and install the `anthropic` package."
+                "LLM not available. Enter your API key in the sidebar "
+                "or set the `ANTHROPIC_API_KEY` environment variable."
             )
         else:
             with st.spinner("Calling Claude..."):

--- a/forecasting-platform/streamlit/pages/2_Series_Explorer.py
+++ b/forecasting-platform/streamlit/pages/2_Series_Explorer.py
@@ -1,0 +1,631 @@
+"""
+Page 2 — Series Explorer
+
+Deep-dive into series-level data quality, demand classification,
+structural breaks, cleansing audit, and regressor screening.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import plotly.express as px
+import plotly.graph_objects as go
+import polars as pl
+import streamlit as st
+
+_PLATFORM_ROOT = Path(__file__).resolve().parent.parent.parent
+_STREAMLIT_DIR = Path(__file__).resolve().parent.parent
+if str(_PLATFORM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLATFORM_ROOT))
+if str(_STREAMLIT_DIR) not in sys.path:
+    sys.path.insert(0, str(_STREAMLIT_DIR))
+
+from utils import (
+    COLORS,
+    DEMAND_CLASS_COLORS,
+    CONFIDENCE_BADGE_COLORS,
+    polars_to_pandas,
+    format_pct,
+    format_number,
+    ai_available,
+    render_ai_unavailable_notice,
+    render_ai_confidence_badge,
+    load_uploaded_csv,
+)
+
+st.set_page_config(page_title="Series Explorer", page_icon="🔍", layout="wide")
+st.title("Series Explorer")
+st.markdown(
+    "Deep-dive into series-level data quality, demand classification, "
+    "structural breaks, cleansing, and regressor screening."
+)
+
+# --------------------------------------------------------------------------- #
+#  Helpers
+# --------------------------------------------------------------------------- #
+
+_TIME_COL_CANDIDATES = ["week", "date", "ds", "time", "timestamp", "period"]
+_TARGET_COL_CANDIDATES = ["quantity", "sales", "demand", "value", "y", "target"]
+_ID_COL_CANDIDATES = ["series_id", "store_id", "product_id", "sku", "item_id", "id"]
+
+
+def _detect_col(df: pl.DataFrame, candidates: list, fallback_dtype=None) -> str | None:
+    """Detect the first matching column from a list of candidates."""
+    cols_lower = {c.lower(): c for c in df.columns}
+    for cand in candidates:
+        if cand.lower() in cols_lower:
+            return cols_lower[cand.lower()]
+    # Fallback: pick first column of the expected dtype
+    if fallback_dtype is not None:
+        for c in df.columns:
+            if df[c].dtype == fallback_dtype:
+                return c
+    return None
+
+
+def _build_series_id_col(df: pl.DataFrame, id_col: str) -> pl.DataFrame:
+    """Ensure a 'series_id' column exists; create from id_col if needed."""
+    if "series_id" in df.columns:
+        return df
+    if id_col and id_col in df.columns:
+        return df.with_columns(pl.col(id_col).cast(pl.Utf8).alias("series_id"))
+    # Combine all string columns as a composite key
+    str_cols = [c for c in df.columns if df[c].dtype == pl.Utf8]
+    if str_cols:
+        return df.with_columns(
+            pl.concat_str(str_cols, separator="_").alias("series_id")
+        )
+    return df.with_columns(pl.lit("all").alias("series_id"))
+
+
+# --------------------------------------------------------------------------- #
+#  Section 1: Data Loading
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Data Loading")
+
+df = st.session_state.get("actuals_df")
+
+if df is None:
+    st.info(
+        "No data found in session. Upload a CSV below, or go to "
+        "**Data Onboarding** to load data first."
+    )
+    uploaded = st.file_uploader("Upload CSV", type=["csv"], key="series_explorer_upload")
+    if uploaded is not None:
+        try:
+            df = load_uploaded_csv(uploaded)
+            st.session_state["actuals_df"] = df
+            st.success(f"Loaded {df.shape[0]:,} rows x {df.shape[1]} columns.")
+        except Exception as exc:
+            st.error(f"Failed to parse CSV: {exc}")
+            st.stop()
+
+if df is None:
+    st.stop()
+
+# Detect columns
+time_col = _detect_col(df, _TIME_COL_CANDIDATES, fallback_dtype=pl.Date)
+target_col = _detect_col(df, _TARGET_COL_CANDIDATES, fallback_dtype=pl.Float64)
+id_col = _detect_col(df, _ID_COL_CANDIDATES, fallback_dtype=pl.Utf8)
+
+if time_col is None:
+    st.warning("Could not auto-detect a time/date column. Check your data.")
+    time_col = st.selectbox("Select time column", options=df.columns, key="time_col_sel")
+if target_col is None:
+    st.warning("Could not auto-detect a target/quantity column.")
+    numeric_cols = [c for c in df.columns if df[c].dtype in (pl.Float64, pl.Float32, pl.Int64, pl.Int32)]
+    target_col = st.selectbox("Select target column", options=numeric_cols or df.columns, key="target_col_sel")
+if id_col is None:
+    st.warning("Could not auto-detect an ID column.")
+    id_col = st.selectbox("Select ID column", options=df.columns, key="id_col_sel")
+
+st.caption(f"Detected columns — time: `{time_col}`, target: `{target_col}`, id: `{id_col}`")
+
+# Ensure series_id exists for backend modules
+work_df = _build_series_id_col(df, id_col)
+sid_col = "series_id"
+
+# --------------------------------------------------------------------------- #
+#  Section 2: Series Overview + SBC Classification
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Series Overview & Demand Classification")
+
+series_list = sorted(work_df[sid_col].unique().to_list())
+selected_series = st.selectbox(
+    "Select a series to inspect",
+    options=series_list,
+    key="series_picker",
+)
+
+# Metric cards for selected series
+series_df = work_df.filter(pl.col(sid_col) == selected_series)
+n_periods = len(series_df)
+mean_demand = series_df[target_col].mean() if target_col in series_df.columns else 0
+zero_pct = (
+    (series_df[target_col] == 0).sum() / max(n_periods, 1)
+    if target_col in series_df.columns
+    else 0
+)
+
+# Run SBC classification
+try:
+    from src.series.sparse_detector import SparseDetector
+
+    detector = SparseDetector()
+    classification_df = detector.classify(work_df, target_col=target_col, id_col=sid_col)
+    st.session_state["sparse_classification"] = classification_df
+
+    # Get demand class for selected series
+    sel_class_row = classification_df.filter(pl.col(sid_col) == selected_series)
+    demand_class = sel_class_row["demand_class"][0] if len(sel_class_row) > 0 else "Unknown"
+except Exception as exc:
+    classification_df = None
+    demand_class = "N/A"
+    st.warning(f"SBC classification unavailable: {exc}")
+
+col_m1, col_m2, col_m3, col_m4 = st.columns(4)
+col_m1.metric("Length (periods)", f"{n_periods:,}")
+col_m2.metric("Mean Demand", format_number(mean_demand) if mean_demand is not None else "N/A")
+col_m3.metric("Zero %", format_pct(zero_pct) if zero_pct is not None else "N/A")
+col_m4.metric("Demand Class", demand_class)
+
+# SBC scatter plot
+if classification_df is not None:
+    st.subheader("SBC Demand Classification Scatter")
+    try:
+        cls_pd = polars_to_pandas(classification_df)
+
+        fig_sbc = px.scatter(
+            cls_pd,
+            x="adi",
+            y="cv2",
+            color="demand_class",
+            color_discrete_map=DEMAND_CLASS_COLORS,
+            hover_data=[sid_col],
+            labels={"adi": "ADI (Average Demand Interval)", "cv2": "CV\u00b2 (Coefficient of Variation\u00b2)"},
+        )
+        # Quadrant boundary lines
+        fig_sbc.add_vline(x=1.32, line_dash="dash", line_color=COLORS["neutral"], annotation_text="ADI=1.32")
+        fig_sbc.add_hline(y=0.49, line_dash="dash", line_color=COLORS["neutral"], annotation_text="CV\u00b2=0.49")
+        fig_sbc.update_layout(
+            height=450,
+            margin=dict(t=30, b=40, l=40, r=20),
+            legend_title_text="Demand Class",
+        )
+        st.plotly_chart(fig_sbc, use_container_width=True)
+
+        # Summary counts
+        summary = classification_df.group_by("demand_class").agg(pl.count().alias("count"))
+        st.dataframe(polars_to_pandas(summary), use_container_width=True)
+
+    except Exception as exc:
+        st.error(f"Failed to render SBC scatter: {exc}")
+
+
+# --------------------------------------------------------------------------- #
+#  Section 3: Structural Break Detection
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Structural Break Detection")
+
+try:
+    from src.series.break_detector import StructuralBreakDetector
+    from src.config.schema import StructuralBreakConfig
+
+    # Sidebar controls
+    with st.sidebar:
+        st.subheader("Break Detection Settings")
+        break_method = st.selectbox(
+            "Method",
+            options=["cusum", "pelt"],
+            index=0,
+            key="break_method",
+            help="CUSUM is zero-dependency. PELT requires the `ruptures` package.",
+        )
+        break_penalty = st.slider(
+            "Penalty",
+            min_value=1.0,
+            max_value=10.0,
+            value=3.0,
+            step=0.5,
+            key="break_penalty",
+            help="Higher penalty = fewer detected breaks.",
+        )
+
+    break_config = StructuralBreakConfig(
+        enabled=True,
+        method=break_method,
+        penalty=break_penalty,
+    )
+    break_detector = StructuralBreakDetector(break_config)
+
+    with st.spinner("Detecting structural breaks..."):
+        break_report = break_detector.detect(
+            work_df,
+            target_col=target_col,
+            time_col=time_col,
+            id_col=sid_col,
+        )
+
+    # Summary metrics
+    col_b1, col_b2 = st.columns(2)
+    col_b1.metric("Total Breaks", break_report.total_breaks)
+    col_b2.metric("Series with Breaks", break_report.series_with_breaks)
+
+    # Time series chart for selected series with break markers
+    series_ts = series_df.sort(time_col)
+    fig_breaks = go.Figure()
+    fig_breaks.add_trace(go.Scatter(
+        x=polars_to_pandas(series_ts)[time_col],
+        y=polars_to_pandas(series_ts)[target_col],
+        mode="lines",
+        name="Actual",
+        line=dict(color=COLORS["primary"]),
+    ))
+
+    # Add vertical lines for break dates
+    if break_report.per_series is not None and not break_report.per_series.is_empty():
+        sel_breaks = break_report.per_series.filter(pl.col(sid_col) == selected_series)
+        if len(sel_breaks) > 0 and "break_dates" in sel_breaks.columns:
+            break_dates_val = sel_breaks["break_dates"][0]
+            if break_dates_val is not None:
+                # break_dates may be a list or comma-separated string
+                if isinstance(break_dates_val, list):
+                    dates_list = break_dates_val
+                elif isinstance(break_dates_val, str):
+                    dates_list = [d.strip() for d in break_dates_val.split(",") if d.strip()]
+                else:
+                    dates_list = []
+                for bd in dates_list:
+                    fig_breaks.add_vline(
+                        x=str(bd),
+                        line_dash="dash",
+                        line_color=COLORS["danger"],
+                        annotation_text="Break",
+                    )
+
+    fig_breaks.update_layout(
+        title=f"Series: {selected_series} — Structural Breaks",
+        xaxis_title="Date",
+        yaxis_title=target_col,
+        height=400,
+        margin=dict(t=40, b=40, l=40, r=20),
+    )
+    st.plotly_chart(fig_breaks, use_container_width=True)
+
+    # Per-series detail
+    if break_report.per_series is not None and not break_report.per_series.is_empty():
+        with st.expander("Per-series break detail"):
+            st.dataframe(polars_to_pandas(break_report.per_series), use_container_width=True)
+
+    if break_report.warnings:
+        for w in break_report.warnings:
+            st.warning(w)
+
+except ImportError as exc:
+    st.info(
+        f"Structural break detection requires additional dependencies: {exc}. "
+        "Install the `ruptures` package for PELT, or the CUSUM method "
+        "should work out of the box."
+    )
+except Exception as exc:
+    st.warning(f"Structural break detection failed: {exc}")
+
+
+# --------------------------------------------------------------------------- #
+#  Section 4: Data Quality Deep Dive
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Data Quality Deep Dive")
+
+try:
+    from src.data.quality_report import DataQualityAnalyzer
+    from src.config.schema import PlatformConfig
+
+    # Try to use accepted config from session, otherwise create a minimal one
+    platform_config = st.session_state.get("accepted_config")
+    if platform_config is None:
+        platform_config = PlatformConfig()
+
+    analyzer = DataQualityAnalyzer(platform_config)
+    quality_report = analyzer.analyze(
+        work_df,
+        time_col=time_col,
+        value_col=target_col,
+        sid_col=sid_col,
+        cleansing_report=None,
+        break_report=break_report if "break_report" in dir() else None,
+    )
+
+    col_q1, col_q2, col_q3, col_q4 = st.columns(4)
+    col_q1.metric("Total Series", f"{quality_report.total_series:,}")
+    col_q2.metric("Missing %", format_pct(quality_report.missing_week_pct))
+    col_q3.metric("Zero Inflation", format_pct(quality_report.zero_inflation_rate))
+    col_q4.metric("Short Series", f"{quality_report.short_series_count:,}")
+
+    if quality_report.warnings:
+        st.subheader("Warnings")
+        for w in quality_report.warnings:
+            st.warning(w)
+    else:
+        st.success("No data quality warnings.")
+
+    if quality_report.per_series is not None and not quality_report.per_series.is_empty():
+        with st.expander("Per-series quality detail"):
+            st.dataframe(polars_to_pandas(quality_report.per_series), use_container_width=True)
+
+except Exception:
+    # Fallback: show basic stats from sparse classification
+    st.caption("Full quality analysis unavailable. Showing basic stats from classification.")
+    if classification_df is not None:
+        n_series = len(classification_df)
+        zero_series = (
+            classification_df.filter(pl.col("demand_class") == "insufficient_data").shape[0]
+            if "demand_class" in classification_df.columns
+            else 0
+        )
+        mean_cv = (
+            classification_df["cv2"].mean()
+            if "cv2" in classification_df.columns
+            else 0
+        )
+        col_f1, col_f2, col_f3 = st.columns(3)
+        col_f1.metric("Total Series", f"{n_series:,}")
+        col_f2.metric("Insufficient Data", f"{zero_series:,}")
+        col_f3.metric("Mean CV\u00b2", format_number(mean_cv) if mean_cv is not None else "N/A")
+    else:
+        st.info("No classification data available for quality summary.")
+
+
+# --------------------------------------------------------------------------- #
+#  Section 5: Demand Cleansing Audit
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Demand Cleansing Audit")
+
+try:
+    from src.data.cleanser import DemandCleanser
+    from src.config.schema import CleansingConfig
+
+    with st.sidebar:
+        st.subheader("Cleansing Settings")
+        cleansing_method = st.selectbox(
+            "Outlier Method",
+            options=["iqr", "zscore"],
+            index=0,
+            key="cleansing_method",
+        )
+        iqr_mult = st.slider(
+            "IQR Multiplier",
+            min_value=1.0,
+            max_value=3.0,
+            value=1.5,
+            step=0.1,
+            key="iqr_multiplier",
+            help="Higher = fewer outliers flagged. Only applies to IQR method.",
+        )
+
+    cleansing_config = CleansingConfig(
+        enabled=True,
+        outlier_method=cleansing_method,
+        iqr_multiplier=iqr_mult,
+    )
+    cleanser = DemandCleanser(cleansing_config)
+
+    with st.spinner("Running demand cleansing..."):
+        cleansing_result = cleanser.cleanse(
+            work_df,
+            time_col=time_col,
+            value_col=target_col,
+            sid_col=sid_col,
+        )
+
+    report = cleansing_result.report
+
+    # Summary metrics
+    col_c1, col_c2, col_c3 = st.columns(3)
+    col_c1.metric("Outliers Clipped", f"{report.total_outliers:,}")
+    col_c2.metric("Stockout Periods Imputed", f"{report.total_stockout_periods:,}")
+    col_c3.metric("Rows Modified", f"{report.rows_modified:,}")
+
+    # Before/after overlay chart
+    st.subheader(f"Before / After — {selected_series}")
+    original_series = work_df.filter(pl.col(sid_col) == selected_series).sort(time_col)
+    cleaned_series = cleansing_result.df.filter(pl.col(sid_col) == selected_series).sort(time_col)
+
+    orig_pd = polars_to_pandas(original_series)
+    clean_pd = polars_to_pandas(cleaned_series)
+
+    fig_cleanse = go.Figure()
+    fig_cleanse.add_trace(go.Scatter(
+        x=orig_pd[time_col],
+        y=orig_pd[target_col],
+        mode="lines",
+        name="Original",
+        line=dict(color=COLORS["neutral"], dash="dot"),
+    ))
+    fig_cleanse.add_trace(go.Scatter(
+        x=clean_pd[time_col],
+        y=clean_pd[target_col],
+        mode="lines",
+        name="Cleaned",
+        line=dict(color=COLORS["primary"]),
+    ))
+
+    # Highlight outlier points (where values differ)
+    if len(orig_pd) == len(clean_pd):
+        import numpy as np
+        diff_mask = np.array(orig_pd[target_col]) != np.array(clean_pd[target_col])
+        if diff_mask.any():
+            outlier_pts = orig_pd[diff_mask]
+            fig_cleanse.add_trace(go.Scatter(
+                x=outlier_pts[time_col],
+                y=outlier_pts[target_col],
+                mode="markers",
+                name="Outlier / Modified",
+                marker=dict(color=COLORS["danger"], size=8, symbol="x"),
+            ))
+
+    fig_cleanse.update_layout(
+        xaxis_title="Date",
+        yaxis_title=target_col,
+        height=400,
+        margin=dict(t=30, b=40, l=40, r=20),
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    )
+    st.plotly_chart(fig_cleanse, use_container_width=True)
+
+    # Per-series cleansing detail
+    if report.per_series is not None and not report.per_series.is_empty():
+        with st.expander("Per-series cleansing detail"):
+            st.dataframe(polars_to_pandas(report.per_series), use_container_width=True)
+
+except Exception as exc:
+    st.warning(f"Demand cleansing audit unavailable: {exc}")
+
+
+# --------------------------------------------------------------------------- #
+#  Section 6: Regressor Screening
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Regressor Screening")
+
+try:
+    # Detect potential regressor columns (numeric, not target or time)
+    numeric_types = (pl.Float64, pl.Float32, pl.Int64, pl.Int32, pl.Int16, pl.Int8, pl.UInt64, pl.UInt32)
+    regressor_candidates = [
+        c for c in work_df.columns
+        if work_df[c].dtype in numeric_types
+        and c != target_col
+        and c != time_col
+        and c != sid_col
+        and c != id_col
+    ]
+
+    if not regressor_candidates:
+        st.info(
+            "No numeric regressor columns detected beyond the target. "
+            "Upload data with external regressors (e.g. promo_intensity, temperature) "
+            "to use this feature."
+        )
+    else:
+        st.markdown(f"Detected **{len(regressor_candidates)}** potential regressor column(s): "
+                    f"`{'`, `'.join(regressor_candidates)}`")
+
+        from src.data.regressor_screen import screen_regressors
+
+        with st.spinner("Screening regressors..."):
+            screen_report = screen_regressors(
+                work_df,
+                feature_columns=regressor_candidates,
+                target_col=target_col,
+            )
+
+        # Passed vs dropped
+        passed = [c for c in regressor_candidates if c not in screen_report.dropped_columns]
+        col_r1, col_r2 = st.columns(2)
+        col_r1.metric("Passed", len(passed))
+        col_r2.metric("Dropped", len(screen_report.dropped_columns))
+
+        if passed:
+            st.success(f"Passed columns: `{'`, `'.join(passed)}`")
+        if screen_report.dropped_columns:
+            st.warning(f"Dropped columns: `{'`, `'.join(screen_report.dropped_columns)}`")
+
+        # Detailed reasons
+        if screen_report.low_variance_columns:
+            st.caption(f"Low variance: `{'`, `'.join(screen_report.low_variance_columns)}`")
+        if screen_report.low_mi_columns:
+            st.caption(f"Low mutual information: `{'`, `'.join(screen_report.low_mi_columns)}`")
+        if screen_report.high_correlation_pairs:
+            with st.expander("Highly correlated pairs"):
+                for pair in screen_report.high_correlation_pairs:
+                    st.markdown(f"- {pair}")
+
+        # Warnings
+        if screen_report.warnings:
+            for w in screen_report.warnings:
+                st.warning(w)
+
+        # Per-column stats
+        if screen_report.per_column_stats:
+            with st.expander("Per-column statistics"):
+                stats_rows = []
+                for col_name, stats in screen_report.per_column_stats.items():
+                    row = {"column": col_name}
+                    row.update(stats)
+                    stats_rows.append(row)
+                if stats_rows:
+                    st.dataframe(pl.DataFrame(stats_rows).to_pandas(), use_container_width=True)
+
+except Exception as exc:
+    st.warning(f"Regressor screening failed: {exc}")
+
+
+# --------------------------------------------------------------------------- #
+#  Section 7: Ask About This Series (AI)
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Ask About This Series")
+
+if not ai_available():
+    render_ai_unavailable_notice()
+else:
+    try:
+        from src.ai.nl_query import NaturalLanguageQueryEngine
+
+        st.markdown(f"Ask a question about **{selected_series}** and get an AI-powered answer.")
+
+        # Suggested question buttons
+        st.caption("Suggested questions:")
+        col_s1, col_s2, col_s3 = st.columns(3)
+        with col_s1:
+            if st.button("Why is demand volatile?", key="q_volatile"):
+                st.session_state["ai_question"] = "Why is demand volatile for this series?"
+        with col_s2:
+            if st.button("Is there a trend?", key="q_trend"):
+                st.session_state["ai_question"] = "Is there an underlying trend in this series?"
+        with col_s3:
+            if st.button("Any anomalies?", key="q_anomaly"):
+                st.session_state["ai_question"] = "Are there any anomalies or unusual patterns in this series?"
+
+        question = st.text_input(
+            "Your question",
+            value=st.session_state.get("ai_question", ""),
+            key="ai_question_input",
+            placeholder="e.g. Why did demand spike in Q3?",
+        )
+
+        if question and st.button("Ask", type="primary", key="ask_ai_btn"):
+            with st.spinner("Querying AI..."):
+                engine = NaturalLanguageQueryEngine()
+                history_df = work_df.filter(pl.col(sid_col) == selected_series)
+                forecast_df = st.session_state.get("forecast_df")
+
+                result = engine.query(
+                    series_id=selected_series,
+                    question=question,
+                    lob="explorer",
+                    history=history_df,
+                    forecast=forecast_df,
+                )
+
+            st.subheader("Answer")
+            st.markdown(result.answer)
+
+            render_ai_confidence_badge(result.confidence)
+
+            if result.sources_used:
+                st.caption(f"Sources: {', '.join(result.sources_used)}")
+
+            if result.supporting_data:
+                with st.expander("Supporting data"):
+                    st.json(result.supporting_data)
+
+    except ImportError as exc:
+        st.info(f"AI query engine not available: {exc}")
+    except Exception as exc:
+        st.error(f"AI query failed: {exc}")

--- a/forecasting-platform/streamlit/pages/2_Series_Explorer.py
+++ b/forecasting-platform/streamlit/pages/2_Series_Explorer.py
@@ -31,10 +31,12 @@ from utils import (
     ai_available,
     render_ai_unavailable_notice,
     render_ai_confidence_badge,
+    render_api_key_sidebar,
     load_uploaded_csv,
 )
 
 st.set_page_config(page_title="Series Explorer", page_icon="🔍", layout="wide")
+render_api_key_sidebar()
 st.title("Series Explorer")
 st.markdown(
     "Deep-dive into series-level data quality, demand classification, "

--- a/forecasting-platform/streamlit/pages/3_SKU_Transitions.py
+++ b/forecasting-platform/streamlit/pages/3_SKU_Transitions.py
@@ -1,0 +1,580 @@
+"""
+Page 3 — SKU Transitions
+
+Run the SKU mapping pipeline to discover product transitions, manage planner
+overrides, and visualize transition ramp shapes.
+"""
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import plotly.express as px
+import plotly.graph_objects as go
+import polars as pl
+import streamlit as st
+
+_PLATFORM_ROOT = Path(__file__).resolve().parent.parent.parent
+_STREAMLIT_DIR = Path(__file__).resolve().parent.parent
+if str(_PLATFORM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLATFORM_ROOT))
+if str(_STREAMLIT_DIR) not in sys.path:
+    sys.path.insert(0, str(_STREAMLIT_DIR))
+
+from utils import COLORS, format_number, format_pct, polars_to_pandas
+
+st.set_page_config(page_title="SKU Transitions", page_icon="🔄", layout="wide")
+st.title("SKU Transitions")
+st.markdown(
+    "Discover product transitions using the SKU mapping pipeline, manage "
+    "planner overrides, and preview ramp shapes for demand transfer."
+)
+
+# --------------------------------------------------------------------------- #
+#  Helpers
+# --------------------------------------------------------------------------- #
+_CONFIDENCE_COLORS = {
+    "High": COLORS["success"],
+    "Medium": COLORS["warning"],
+    "Low": COLORS["danger"],
+    "Very Low": COLORS["neutral"],
+}
+
+
+def _generate_ramp_curve(
+    shape: str, n_periods: int = 13, proportion: float = 1.0,
+) -> pl.DataFrame:
+    """Generate a synthetic ramp curve for visualization."""
+    import numpy as np
+
+    periods = list(range(n_periods))
+    t = np.linspace(0, 1, n_periods)
+
+    if shape == "step":
+        values = [proportion] * n_periods
+    elif shape == "exponential":
+        values = (proportion * (np.exp(3 * t) - 1) / (np.exp(3) - 1)).tolist()
+    else:  # linear
+        values = (proportion * t).tolist()
+
+    return pl.DataFrame({
+        "period": periods,
+        "proportion": values,
+    })
+
+
+# =========================================================================== #
+#  Section 1: SKU Mapping Pipeline
+# =========================================================================== #
+st.divider()
+st.header("SKU Mapping Pipeline")
+
+# Sidebar controls
+with st.sidebar:
+    st.subheader("Pipeline Parameters")
+    launch_window_days = st.slider(
+        "Launch window (days)",
+        min_value=90,
+        max_value=365,
+        value=180,
+        help="Maximum days between old-SKU discontinuation and new-SKU launch.",
+    )
+    min_base_similarity = st.slider(
+        "Min base similarity",
+        min_value=0.50,
+        max_value=1.0,
+        value=0.70,
+        step=0.05,
+        help="Minimum naming similarity score (0-1) for candidate pairs.",
+    )
+    min_confidence = st.selectbox(
+        "Min confidence",
+        options=["Low", "Medium", "High"],
+        index=0,
+        help="Drop candidates below this confidence level.",
+    )
+
+# File uploads
+col_master, col_phase = st.columns([2, 1])
+
+with col_master:
+    product_master_file = st.file_uploader(
+        "Upload product master CSV",
+        type=["csv"],
+        key="product_master_upload",
+        help="CSV with product attributes (sku_id, description, category, launch_date, etc.).",
+    )
+
+with col_phase:
+    phase = st.radio(
+        "Pipeline Phase",
+        ["Phase 1 (Attribute + Naming)", "Phase 2 (Full)"],
+        help=(
+            "Phase 1 uses attribute matching and naming conventions. "
+            "Phase 2 adds curve fitting and temporal comovement (requires sales history)."
+        ),
+    )
+
+# Optional sales history for Phase 2
+sales_df = None
+if phase == "Phase 2 (Full)":
+    sales_file = st.file_uploader(
+        "Upload sales history CSV (optional for Phase 2)",
+        type=["csv"],
+        key="sales_history_upload",
+        help="Weekly sales history with columns: sku_id, week, quantity.",
+    )
+    if sales_file is not None:
+        try:
+            sales_df = pl.read_csv(
+                sales_file.getvalue(), try_parse_dates=True,
+            )
+            st.success(
+                f"Sales history loaded: {sales_df.shape[0]:,} rows x "
+                f"{sales_df.shape[1]} columns."
+            )
+        except Exception as exc:
+            st.error(f"Failed to parse sales history CSV: {exc}")
+
+# Run pipeline
+if product_master_file is not None:
+    try:
+        product_master = pl.read_csv(
+            product_master_file.getvalue(), try_parse_dates=True,
+        )
+        st.success(
+            f"Product master loaded: {product_master.shape[0]:,} rows x "
+            f"{product_master.shape[1]} columns."
+        )
+    except Exception as exc:
+        st.error(
+            f"Failed to parse product master CSV: {exc}\n\n"
+            "Ensure the file is a valid CSV with headers in the first row."
+        )
+        product_master = None
+
+    if product_master is not None and st.button("Run Mapping", type="primary"):
+        with st.status("Running SKU mapping pipeline...", expanded=True) as status:
+            try:
+                from src.sku_mapping.pipeline import (
+                    build_phase1_pipeline,
+                    build_phase2_pipeline,
+                )
+
+                if phase == "Phase 1 (Attribute + Naming)":
+                    st.write("Building Phase 1 pipeline (attribute + naming)...")
+                    pipeline = build_phase1_pipeline(
+                        launch_window_days=launch_window_days,
+                        min_base_similarity=min_base_similarity,
+                        min_confidence=min_confidence,
+                    )
+                else:
+                    st.write("Building Phase 2 pipeline (full)...")
+                    pipeline = build_phase2_pipeline(
+                        sales_df=sales_df,
+                        launch_window_days=launch_window_days,
+                        min_base_similarity=min_base_similarity,
+                        min_confidence=min_confidence,
+                    )
+
+                st.write(
+                    f"Processing {product_master.shape[0]:,} products with "
+                    f"launch window = {launch_window_days} days..."
+                )
+                results = pipeline.run(product_master)
+
+                st.session_state["sku_mapping_results"] = results
+                status.update(label="Mapping complete!", state="complete")
+
+                st.success(f"Discovered {len(results):,} SKU transition mappings.")
+
+            except Exception as exc:
+                status.update(label="Pipeline failed", state="error")
+                st.error(
+                    f"SKU mapping pipeline failed: {exc}\n\n"
+                    "Common causes: missing required columns (sku_id, description, "
+                    "category, launch_date), or incompatible data format."
+                )
+
+# Display results
+results_df = st.session_state.get("sku_mapping_results")
+if results_df is not None and not results_df.is_empty():
+    st.subheader("Mapping Results")
+
+    # Summary metrics
+    n_mappings = len(results_df)
+    col_m1, col_m2, col_m3 = st.columns(3)
+    col_m1.metric("Total Mappings", f"{n_mappings:,}")
+
+    if "confidence" in results_df.columns:
+        confidence_counts = results_df["confidence"].value_counts()
+        high_count = confidence_counts.filter(
+            pl.col("confidence") == "High"
+        )
+        high_n = int(high_count["count"][0]) if len(high_count) > 0 else 0
+        col_m2.metric("High Confidence", f"{high_n:,}")
+    if "score" in results_df.columns:
+        avg_score = results_df["score"].mean()
+        col_m3.metric("Avg Score", format_number(avg_score))
+
+    # Results table
+    st.dataframe(polars_to_pandas(results_df), use_container_width=True)
+
+    # Confidence distribution pie chart
+    if "confidence" in results_df.columns:
+        st.subheader("Confidence Distribution")
+        conf_counts = results_df["confidence"].value_counts()
+        conf_pd = polars_to_pandas(conf_counts)
+
+        color_map = {
+            k: v for k, v in _CONFIDENCE_COLORS.items()
+            if k in conf_pd["confidence"].values
+        }
+        fig_pie = px.pie(
+            conf_pd,
+            names="confidence",
+            values="count",
+            color="confidence",
+            color_discrete_map=color_map,
+            hole=0.4,
+        )
+        fig_pie.update_layout(height=350, margin=dict(t=20, b=20))
+        st.plotly_chart(fig_pie, use_container_width=True)
+
+    # Download button
+    csv_data = polars_to_pandas(results_df).to_csv(index=False)
+    st.download_button(
+        label="Download Results CSV",
+        data=csv_data,
+        file_name="sku_mapping_results.csv",
+        mime="text/csv",
+    )
+
+elif results_df is not None and results_df.is_empty():
+    st.info(
+        "Pipeline returned no mappings. Try lowering the minimum confidence "
+        "or increasing the launch window."
+    )
+
+# =========================================================================== #
+#  Section 2: Planner Override Management
+# =========================================================================== #
+st.divider()
+st.header("Planner Overrides")
+
+store = None
+try:
+    from src.overrides.store import get_override_store
+
+    store = get_override_store()
+
+    # Add Override form
+    with st.form("add_override_form"):
+        st.subheader("Add Override")
+        col_f1, col_f2 = st.columns(2)
+
+        with col_f1:
+            ovr_old_sku = st.text_input(
+                "Old SKU",
+                help="The discontinued SKU identifier.",
+            )
+            ovr_new_sku = st.text_input(
+                "New SKU",
+                help="The replacement SKU identifier.",
+            )
+            ovr_proportion = st.slider(
+                "Proportion",
+                min_value=0.0,
+                max_value=1.0,
+                value=1.0,
+                step=0.05,
+                help="Fraction of demand to transfer (0.0 to 1.0).",
+            )
+            ovr_scenario = st.selectbox(
+                "Scenario",
+                options=["Scenario A", "Scenario B", "Scenario C", "manual"],
+                index=3,
+                help="Planning scenario for this override.",
+            )
+
+        with col_f2:
+            ovr_ramp_shape = st.selectbox(
+                "Ramp Shape",
+                options=["linear", "step", "exponential"],
+                help="Shape of the demand ramp-up curve.",
+            )
+            ovr_effective_date = st.date_input(
+                "Effective Date",
+                value=date.today(),
+                help="Date when this override takes effect.",
+            )
+            ovr_notes = st.text_area(
+                "Notes",
+                help="Optional notes or justification for this override.",
+            )
+
+        submitted = st.form_submit_button("Add Override", type="primary")
+
+        if submitted:
+            if not ovr_old_sku or not ovr_new_sku:
+                st.error("Both Old SKU and New SKU are required.")
+            else:
+                try:
+                    override_id = store.add_override(
+                        old_sku=ovr_old_sku,
+                        new_sku=ovr_new_sku,
+                        proportion=ovr_proportion,
+                        scenario=ovr_scenario,
+                        ramp_shape=ovr_ramp_shape,
+                        effective_date=str(ovr_effective_date),
+                        notes=ovr_notes if ovr_notes else None,
+                    )
+                    st.success(f"Override created: **{override_id}**")
+                except Exception as exc:
+                    st.error(f"Failed to create override: {exc}")
+
+    # Current overrides table
+    st.subheader("Current Overrides")
+    try:
+        overrides_df = store.get_all()
+        if overrides_df is not None and not overrides_df.is_empty():
+            st.dataframe(polars_to_pandas(overrides_df), use_container_width=True)
+
+            # Delete override
+            st.subheader("Delete Override")
+            override_ids = overrides_df["override_id"].to_list()
+            selected_override = st.selectbox(
+                "Select override to delete",
+                options=override_ids,
+                help="Choose the override ID to remove.",
+            )
+            if st.button("Delete Selected Override", type="secondary"):
+                try:
+                    deleted = store.delete_override(selected_override)
+                    if deleted:
+                        st.success(f"Override **{selected_override}** deleted.")
+                        st.rerun()
+                    else:
+                        st.warning(
+                            f"Override **{selected_override}** not found or "
+                            f"already deleted."
+                        )
+                except Exception as exc:
+                    st.error(f"Failed to delete override: {exc}")
+        else:
+            st.info("No overrides recorded yet. Use the form above to add one.")
+    except Exception as exc:
+        st.error(f"Failed to load overrides: {exc}")
+
+except ImportError as exc:
+    st.warning(
+        f"Override store module not available: {exc}. "
+        "Install required dependencies to enable override management."
+    )
+except Exception as exc:
+    st.error(f"Failed to initialize override store: {exc}")
+finally:
+    if store is not None:
+        try:
+            store.close()
+        except Exception:
+            pass
+
+# =========================================================================== #
+#  Section 3: Transition Visualization
+# =========================================================================== #
+st.divider()
+st.header("Transition Visualization")
+
+has_results = (
+    st.session_state.get("sku_mapping_results") is not None
+    and not st.session_state["sku_mapping_results"].is_empty()
+)
+actuals_df = st.session_state.get("actuals_df")
+has_actuals = actuals_df is not None
+
+if not has_results and not has_actuals:
+    st.info(
+        "Run the SKU mapping pipeline above or load actuals data via the "
+        "Data Onboarding page to enable transition visualizations."
+    )
+else:
+    # Pair selector
+    if has_results:
+        mapping_df = st.session_state["sku_mapping_results"]
+        if "old_sku" in mapping_df.columns and "new_sku" in mapping_df.columns:
+            pair_labels = [
+                f"{row['old_sku']} -> {row['new_sku']}"
+                for row in mapping_df.select("old_sku", "new_sku").to_dicts()
+            ]
+            selected_pair = st.selectbox(
+                "Select SKU pair",
+                options=pair_labels,
+                help="Choose a transition pair to visualize.",
+            )
+            if selected_pair:
+                old_sku, new_sku = selected_pair.split(" -> ", 1)
+            else:
+                old_sku, new_sku = None, None
+        else:
+            old_sku = st.text_input("Old SKU", key="viz_old_sku")
+            new_sku = st.text_input("New SKU", key="viz_new_sku")
+    else:
+        col_v1, col_v2 = st.columns(2)
+        with col_v1:
+            old_sku = st.text_input("Old SKU", key="viz_old_sku")
+        with col_v2:
+            new_sku = st.text_input("New SKU", key="viz_new_sku")
+
+    # Side-by-side actuals chart
+    if has_actuals and old_sku and new_sku:
+        st.subheader("Historical Sales Comparison")
+        try:
+            # Detect SKU column name
+            sku_col = None
+            for candidate in ["sku_id", "product_id", "sku", "item_id"]:
+                if candidate in actuals_df.columns:
+                    sku_col = candidate
+                    break
+
+            # Detect time column name
+            time_col = None
+            for candidate in ["week", "date", "ds"]:
+                if candidate in actuals_df.columns:
+                    time_col = candidate
+                    break
+
+            # Detect target column name
+            target_col = None
+            for candidate in ["quantity", "sales", "demand", "y"]:
+                if candidate in actuals_df.columns:
+                    target_col = candidate
+                    break
+
+            if sku_col and time_col and target_col:
+                old_data = actuals_df.filter(pl.col(sku_col) == old_sku)
+                new_data = actuals_df.filter(pl.col(sku_col) == new_sku)
+
+                if old_data.is_empty() and new_data.is_empty():
+                    st.warning(
+                        f"No actuals data found for either '{old_sku}' or "
+                        f"'{new_sku}' in column '{sku_col}'."
+                    )
+                else:
+                    fig = go.Figure()
+
+                    if not old_data.is_empty():
+                        old_pd = polars_to_pandas(
+                            old_data.select(time_col, target_col).sort(time_col)
+                        )
+                        fig.add_trace(go.Scatter(
+                            x=old_pd[time_col],
+                            y=old_pd[target_col],
+                            mode="lines+markers",
+                            name=f"Old: {old_sku}",
+                            line=dict(color=COLORS["danger"]),
+                        ))
+
+                    if not new_data.is_empty():
+                        new_pd = polars_to_pandas(
+                            new_data.select(time_col, target_col).sort(time_col)
+                        )
+                        fig.add_trace(go.Scatter(
+                            x=new_pd[time_col],
+                            y=new_pd[target_col],
+                            mode="lines+markers",
+                            name=f"New: {new_sku}",
+                            line=dict(color=COLORS["success"]),
+                        ))
+
+                    fig.update_layout(
+                        title=f"Sales: {old_sku} vs {new_sku}",
+                        xaxis_title="Date",
+                        yaxis_title=target_col.title(),
+                        height=400,
+                        margin=dict(t=40, b=40, l=40, r=20),
+                        legend=dict(orientation="h", yanchor="bottom", y=1.02),
+                    )
+                    st.plotly_chart(fig, use_container_width=True)
+            else:
+                missing = []
+                if not sku_col:
+                    missing.append("SKU identifier (sku_id, product_id)")
+                if not time_col:
+                    missing.append("time column (week, date, ds)")
+                if not target_col:
+                    missing.append("target column (quantity, sales, demand)")
+                st.warning(
+                    f"Cannot plot actuals — missing columns: {', '.join(missing)}."
+                )
+        except Exception as exc:
+            st.error(f"Failed to generate actuals chart: {exc}")
+
+    # Ramp shape preview
+    st.subheader("Ramp Shape Preview")
+    st.markdown(
+        "Preview how demand transfers from the old SKU to the new SKU over time."
+    )
+
+    col_r1, col_r2, col_r3 = st.columns(3)
+    with col_r1:
+        preview_shape = st.selectbox(
+            "Ramp shape",
+            options=["linear", "step", "exponential"],
+            key="ramp_preview_shape",
+        )
+    with col_r2:
+        preview_periods = st.slider(
+            "Transition periods",
+            min_value=1,
+            max_value=52,
+            value=13,
+            key="ramp_preview_periods",
+        )
+    with col_r3:
+        preview_proportion = st.slider(
+            "Target proportion",
+            min_value=0.0,
+            max_value=1.0,
+            value=1.0,
+            step=0.05,
+            key="ramp_preview_proportion",
+        )
+
+    try:
+        ramp_df = _generate_ramp_curve(
+            shape=preview_shape,
+            n_periods=preview_periods,
+            proportion=preview_proportion,
+        )
+        ramp_pd = polars_to_pandas(ramp_df)
+
+        fig_ramp = go.Figure()
+        fig_ramp.add_trace(go.Scatter(
+            x=ramp_pd["period"],
+            y=ramp_pd["proportion"],
+            mode="lines+markers",
+            name="New SKU share",
+            line=dict(color=COLORS["primary"], width=3),
+            fill="tozeroy",
+            fillcolor=f"rgba(67, 97, 238, 0.15)",
+        ))
+        fig_ramp.add_trace(go.Scatter(
+            x=ramp_pd["period"],
+            y=[preview_proportion - v for v in ramp_pd["proportion"]],
+            mode="lines+markers",
+            name="Old SKU share",
+            line=dict(color=COLORS["neutral"], width=2, dash="dash"),
+        ))
+        fig_ramp.update_layout(
+            title=f"Ramp Shape: {preview_shape.title()}",
+            xaxis_title="Period",
+            yaxis_title="Demand Proportion",
+            yaxis=dict(range=[0, max(preview_proportion * 1.1, 0.1)]),
+            height=350,
+            margin=dict(t=40, b=40, l=40, r=20),
+            legend=dict(orientation="h", yanchor="bottom", y=1.02),
+        )
+        st.plotly_chart(fig_ramp, use_container_width=True)
+    except Exception as exc:
+        st.error(f"Failed to generate ramp preview: {exc}")

--- a/forecasting-platform/streamlit/pages/4_Hierarchy_Manager.py
+++ b/forecasting-platform/streamlit/pages/4_Hierarchy_Manager.py
@@ -1,0 +1,692 @@
+"""
+Page 4 — Hierarchy Manager
+
+Visualize hierarchy structure, run reconciliation, compare before/after.
+Supports detected hierarchies from Data Onboarding or user-defined hierarchy
+configuration.
+"""
+
+import sys
+from pathlib import Path
+
+import plotly.express as px
+import plotly.graph_objects as go
+import polars as pl
+import streamlit as st
+
+_PLATFORM_ROOT = Path(__file__).resolve().parent.parent.parent
+_STREAMLIT_DIR = Path(__file__).resolve().parent.parent
+if str(_PLATFORM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLATFORM_ROOT))
+if str(_STREAMLIT_DIR) not in sys.path:
+    sys.path.insert(0, str(_STREAMLIT_DIR))
+
+from src.config.schema import HierarchyConfig, ReconciliationConfig
+from src.hierarchy.aggregator import HierarchyAggregator
+from src.hierarchy.reconciler import Reconciler
+from src.hierarchy.tree import HierarchyTree
+from utils import COLORS, format_number, polars_to_pandas
+
+st.set_page_config(page_title="Hierarchy Manager", page_icon="🌳", layout="wide")
+st.title("Hierarchy Manager")
+st.markdown(
+    "Visualize hierarchy structure, explore aggregations across levels, "
+    "and run forecast reconciliation to ensure coherent predictions."
+)
+
+# --------------------------------------------------------------------------- #
+#  Helpers
+# --------------------------------------------------------------------------- #
+
+def _detect_time_column(df: pl.DataFrame) -> str | None:
+    """Try to find the time column in a DataFrame."""
+    for col in df.columns:
+        if col.lower() in ("week", "date", "ds", "time", "period", "month"):
+            return col
+        if df[col].dtype in (pl.Date, pl.Datetime):
+            return col
+    return None
+
+
+def _detect_value_column(df: pl.DataFrame) -> str | None:
+    """Try to find the primary numeric value column."""
+    for col in df.columns:
+        if col.lower() in ("quantity", "sales", "demand", "value", "target", "y"):
+            if df[col].dtype in (pl.Float32, pl.Float64, pl.Int32, pl.Int64,
+                                  pl.UInt32, pl.UInt64, pl.Int16, pl.Int8):
+                return col
+    # Fallback: first numeric column that is not obviously an ID
+    for col in df.columns:
+        if df[col].dtype in (pl.Float32, pl.Float64, pl.Int32, pl.Int64,
+                              pl.UInt32, pl.UInt64):
+            if not col.lower().endswith("_id") and col.lower() != "id":
+                return col
+    return None
+
+
+def _build_sunburst_data(tree: HierarchyTree) -> pl.DataFrame:
+    """Build a DataFrame suitable for px.sunburst from the hierarchy tree."""
+    ids = []
+    labels = []
+    parents = []
+    values = []
+
+    # Add root
+    root_id = tree.name
+    ids.append(root_id)
+    labels.append(tree.name)
+    parents.append("")
+    values.append(len(tree.get_leaves()))
+
+    for level in tree.levels:
+        for node in tree.get_nodes(level):
+            node_id = f"{level}/{node.key}"
+            ids.append(node_id)
+            labels.append(node.key)
+
+            # Determine parent id
+            if node.parent is not None and node.parent.key == "__root__":
+                parents.append(root_id)
+            elif node.parent is not None:
+                parents.append(f"{node.parent.level}/{node.parent.key}")
+            else:
+                parents.append(root_id)
+
+            # Value = number of leaves under this node
+            leaf_count = len(node.leaf_descendants())
+            values.append(max(leaf_count, 1))
+
+    return pl.DataFrame({
+        "id": ids,
+        "label": labels,
+        "parent": parents,
+        "value": values,
+    })
+
+
+def _check_coherence(
+    tree: HierarchyTree,
+    forecast_df: pl.DataFrame,
+    value_col: str,
+    id_col: str,
+    time_col: str,
+) -> dict:
+    """Check whether forecasts are coherent (parent == sum of children)."""
+    leaves = tree.get_leaves()
+    leaf_keys = {n.key for n in leaves}
+
+    # Filter forecast to leaf-level rows
+    leaf_data = forecast_df.filter(pl.col(id_col).is_in(list(leaf_keys)))
+
+    violations = 0
+    total_checks = 0
+
+    for level in tree.levels[:-1]:  # All non-leaf levels
+        for node in tree.get_nodes(level):
+            child_keys = [c.key for c in node.leaf_descendants()]
+            if not child_keys:
+                continue
+
+            # Sum children per time period
+            children_sum = (
+                leaf_data.filter(pl.col(id_col).is_in(child_keys))
+                .group_by(time_col)
+                .agg(pl.col(value_col).sum().alias("_child_sum"))
+            )
+
+            if children_sum.is_empty():
+                continue
+
+            total_checks += len(children_sum)
+
+    return {
+        "total_checks": total_checks,
+        "violations": violations,
+        "coherent": violations == 0,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  Section 1: Data & Hierarchy Setup
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Data & Hierarchy Setup")
+
+actuals_df = st.session_state.get("actuals_df")
+analysis_report = st.session_state.get("analysis_report")
+
+if actuals_df is None:
+    st.warning(
+        "No data loaded. Go to **Data Onboarding** to upload data first, "
+        "or the hierarchy manager will not be able to build a tree."
+    )
+    st.stop()
+
+st.success(
+    f"Using loaded data: {actuals_df.shape[0]:,} rows x {actuals_df.shape[1]} columns."
+)
+
+# Detect or define hierarchy
+hierarchy_source = "manual"
+detected_hierarchies = []
+
+if analysis_report is not None:
+    try:
+        hier_info = analysis_report.hierarchy
+        if hier_info and hier_info.hierarchies:
+            detected_hierarchies = hier_info.hierarchies
+            hierarchy_source = "detected"
+    except (AttributeError, TypeError):
+        pass
+
+tree = None
+
+if detected_hierarchies:
+    st.info(
+        f"Found {len(detected_hierarchies)} detected "
+        f"{'hierarchy' if len(detected_hierarchies) == 1 else 'hierarchies'} "
+        f"from Data Onboarding."
+    )
+
+    hierarchy_options = [h.name for h in detected_hierarchies]
+    selected_name = st.selectbox(
+        "Select hierarchy",
+        options=hierarchy_options,
+        help="Choose a detected hierarchy to visualize and manage.",
+    )
+
+    selected_hier = next(h for h in detected_hierarchies if h.name == selected_name)
+    st.markdown(f"**Levels**: {' -> '.join(selected_hier.levels)}")
+
+    # Build HierarchyConfig from detected hierarchy
+    config = HierarchyConfig(
+        name=selected_hier.name,
+        levels=list(selected_hier.levels),
+        id_column=selected_hier.levels[-1] if selected_hier.levels else "",
+    )
+
+    try:
+        tree = HierarchyTree(config, actuals_df)
+        st.success(f"Hierarchy tree built: {tree}")
+    except Exception as exc:
+        st.error(
+            f"Failed to build hierarchy tree: {exc}\n\n"
+            "The hierarchy columns may not be present in the loaded data. "
+            "Try defining a hierarchy manually below."
+        )
+        tree = None
+
+if tree is None:
+    st.subheader("Define Hierarchy Manually")
+    st.markdown(
+        "Specify the hierarchy levels as column names from your data, "
+        "ordered from broadest (top) to most granular (bottom)."
+    )
+
+    available_cols = [
+        c for c in actuals_df.columns
+        if actuals_df[c].dtype in (pl.Utf8, pl.Categorical)
+        or (actuals_df[c].dtype in (pl.Int32, pl.Int64, pl.UInt32, pl.UInt64)
+            and actuals_df[c].n_unique() < actuals_df.shape[0] * 0.5)
+    ]
+
+    # Filter out likely time/value columns
+    time_col_guess = _detect_time_column(actuals_df)
+    value_col_guess = _detect_value_column(actuals_df)
+    available_cols = [
+        c for c in available_cols
+        if c != time_col_guess and c != value_col_guess
+    ]
+
+    if not available_cols:
+        st.warning(
+            "No suitable categorical or ID columns found in the data. "
+            "Hierarchy requires columns with discrete values (e.g. region, "
+            "category, store_id)."
+        )
+        st.stop()
+
+    st.caption(f"Available columns: {', '.join(available_cols)}")
+
+    levels_input = st.text_input(
+        "Level columns (comma-separated, top to bottom)",
+        value=", ".join(available_cols[:3]) if len(available_cols) >= 2 else "",
+        help="Example: region, store_id — where region is the broader level.",
+    )
+
+    hier_name = st.text_input(
+        "Hierarchy name",
+        value="custom",
+        help="A descriptive name for this hierarchy dimension.",
+    )
+
+    if levels_input.strip():
+        levels = [l.strip() for l in levels_input.split(",") if l.strip()]
+
+        if len(levels) < 2:
+            st.warning("At least two levels are required to form a hierarchy.")
+            st.stop()
+
+        # Validate columns exist
+        missing = [l for l in levels if l not in actuals_df.columns]
+        if missing:
+            st.error(
+                f"Columns not found in data: {', '.join(missing)}. "
+                f"Available: {', '.join(actuals_df.columns)}"
+            )
+            st.stop()
+
+        config = HierarchyConfig(
+            name=hier_name,
+            levels=levels,
+            id_column=levels[-1],
+        )
+
+        try:
+            tree = HierarchyTree(config, actuals_df)
+            st.success(f"Hierarchy tree built: {tree}")
+        except Exception as exc:
+            st.error(
+                f"Failed to build hierarchy tree: {exc}\n\n"
+                "Check that the level columns form a valid parent-child "
+                "relationship (each child belongs to exactly one parent)."
+            )
+            st.stop()
+    else:
+        st.info("Enter level column names above to build a hierarchy tree.")
+        st.stop()
+
+if tree is None:
+    st.stop()
+
+# Store tree in session for potential reuse
+st.session_state["hierarchy_tree"] = tree
+
+# --------------------------------------------------------------------------- #
+#  Section 2: Hierarchy Tree Visualization
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Hierarchy Tree")
+
+# Tree stats
+col_s1, col_s2, col_s3 = st.columns(3)
+col_s1.metric("Levels", len(tree.levels))
+col_s2.metric(
+    "Total Leaves",
+    format_number(len(tree.get_leaves()), decimals=0),
+)
+
+nodes_per_level = {level: len(tree.get_nodes(level)) for level in tree.levels}
+total_nodes = sum(nodes_per_level.values())
+col_s3.metric("Total Nodes", format_number(total_nodes, decimals=0))
+
+# Nodes per level breakdown
+st.markdown("**Nodes per level:**")
+level_cols = st.columns(len(tree.levels))
+for i, level in enumerate(tree.levels):
+    level_cols[i].metric(level, nodes_per_level[level])
+
+# Sunburst chart
+try:
+    sunburst_df = _build_sunburst_data(tree)
+    sunburst_pd = polars_to_pandas(sunburst_df)
+
+    fig_sunburst = px.sunburst(
+        sunburst_pd,
+        ids="id",
+        labels="label",
+        parents="parent",
+        values="value",
+        color_discrete_sequence=[
+            COLORS["primary"], COLORS["secondary"], COLORS["accent"],
+            COLORS["success"], COLORS["warning"], COLORS["neutral"],
+        ],
+    )
+    fig_sunburst.update_layout(
+        height=500,
+        margin=dict(t=20, b=20, l=20, r=20),
+    )
+    st.plotly_chart(fig_sunburst, use_container_width=True)
+except Exception as exc:
+    st.warning(
+        f"Could not render sunburst chart: {exc}\n\n"
+        "Falling back to text-based tree display."
+    )
+
+    # Fallback: indented tree display
+    for level in tree.levels:
+        indent = tree.levels.index(level)
+        with st.expander(f"{'  ' * indent}Level: {level} ({nodes_per_level[level]} nodes)"):
+            nodes = tree.get_nodes(level)
+            display_nodes = nodes[:50]
+            node_keys = [n.key for n in display_nodes]
+            st.markdown(", ".join(f"`{k}`" for k in node_keys))
+            if len(nodes) > 50:
+                st.caption(f"...and {len(nodes) - 50} more nodes")
+
+# Summing matrix preview
+with st.expander("Summing Matrix (S)"):
+    try:
+        s_matrix = tree.summing_matrix()
+        st.markdown(
+            f"Matrix shape: **{s_matrix.shape[0]}** rows (all nodes) x "
+            f"**{s_matrix.shape[1] - 2}** columns (leaf nodes)"
+        )
+        # Show a sample if the matrix is large
+        if s_matrix.shape[0] > 50 or s_matrix.shape[1] > 20:
+            st.caption("Showing first 50 rows and 20 columns.")
+            display_cols = s_matrix.columns[:20]
+            st.dataframe(
+                polars_to_pandas(s_matrix.select(display_cols).head(50)),
+                use_container_width=True,
+            )
+        else:
+            st.dataframe(polars_to_pandas(s_matrix), use_container_width=True)
+    except Exception as exc:
+        st.error(f"Could not compute summing matrix: {exc}")
+
+# --------------------------------------------------------------------------- #
+#  Section 3: Aggregation Explorer
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Aggregation Explorer")
+
+time_col = _detect_time_column(actuals_df)
+value_col = _detect_value_column(actuals_df)
+
+if time_col is None:
+    st.warning("Could not detect a time column in the data. Aggregation requires a time column.")
+elif value_col is None:
+    st.warning("Could not detect a numeric value column in the data.")
+else:
+    st.caption(f"Using time column: `{time_col}` | value column: `{value_col}`")
+
+    # Exclude leaf level from target options (already at that level)
+    non_leaf_levels = tree.levels[:-1]
+
+    if not non_leaf_levels:
+        st.info("Only one hierarchy level — no aggregation possible.")
+    else:
+        target_level = st.selectbox(
+            "Aggregate to level",
+            options=non_leaf_levels,
+            help="Select a hierarchy level to aggregate leaf-level data up to.",
+        )
+
+        top_n = st.slider(
+            "Top N nodes to display",
+            min_value=1,
+            max_value=min(20, len(tree.get_nodes(target_level))),
+            value=min(5, len(tree.get_nodes(target_level))),
+        )
+
+        try:
+            aggregator = HierarchyAggregator(tree)
+            agg_df = aggregator.aggregate_to(
+                df=actuals_df,
+                target_level=target_level,
+                value_columns=[value_col],
+                time_column=time_col,
+                agg="sum",
+            )
+
+            if agg_df.is_empty():
+                st.warning("Aggregation returned no results. Check that leaf-level data matches the hierarchy.")
+            else:
+                # Find top N nodes by total value
+                totals = (
+                    agg_df.group_by(target_level)
+                    .agg(pl.col(value_col).sum().alias("_total"))
+                    .sort("_total", descending=True)
+                    .head(top_n)
+                )
+                top_keys = totals[target_level].to_list()
+
+                plot_df = agg_df.filter(pl.col(target_level).is_in(top_keys))
+                plot_pd = polars_to_pandas(plot_df)
+
+                fig_agg = px.line(
+                    plot_pd,
+                    x=time_col,
+                    y=value_col,
+                    color=target_level,
+                    title=f"Aggregated {value_col} by {target_level} (Top {top_n})",
+                    color_discrete_sequence=[
+                        COLORS["primary"], COLORS["accent"], COLORS["success"],
+                        COLORS["warning"], COLORS["secondary"], COLORS["danger"],
+                        COLORS["neutral"],
+                    ],
+                )
+                fig_agg.update_layout(
+                    height=400,
+                    margin=dict(t=40, b=40, l=40, r=20),
+                    xaxis_title=time_col,
+                    yaxis_title=value_col,
+                )
+                st.plotly_chart(fig_agg, use_container_width=True)
+
+                with st.expander("Aggregated data"):
+                    st.dataframe(
+                        polars_to_pandas(agg_df.sort(time_col)),
+                        use_container_width=True,
+                    )
+
+        except Exception as exc:
+            st.error(
+                f"Aggregation failed: {exc}\n\n"
+                "This can happen when the leaf-level ID column does not match "
+                "the hierarchy tree's expected column. Verify that "
+                f"`{tree.config.id_column}` exists in your data."
+            )
+
+# --------------------------------------------------------------------------- #
+#  Section 4: Reconciliation
+# --------------------------------------------------------------------------- #
+st.divider()
+st.header("Forecast Reconciliation")
+
+forecast_df = st.session_state.get("forecast_df")
+
+if forecast_df is None:
+    st.info(
+        "No forecast data available. Run a forecast from the **Data Onboarding** "
+        "page or the **Forecast Viewer** page first, then return here to reconcile."
+    )
+else:
+    st.success(
+        f"Forecast data loaded: {forecast_df.shape[0]:,} rows x "
+        f"{forecast_df.shape[1]} columns."
+    )
+
+    # Detect forecast columns
+    forecast_time_col = _detect_time_column(forecast_df)
+    forecast_value_col = None
+    for col in forecast_df.columns:
+        if col.lower() in ("forecast", "prediction", "yhat", "forecast_value"):
+            forecast_value_col = col
+            break
+    if forecast_value_col is None:
+        forecast_value_col = _detect_value_column(forecast_df)
+
+    # Detect ID column in forecast
+    leaf_col = tree.config.id_column
+    forecast_id_col = None
+    if leaf_col in forecast_df.columns:
+        forecast_id_col = leaf_col
+    else:
+        # Try to find a matching column
+        for col in forecast_df.columns:
+            if col == tree.leaf_level or col.lower() == tree.leaf_level.lower():
+                forecast_id_col = col
+                break
+
+    if forecast_time_col is None or forecast_value_col is None:
+        st.warning(
+            "Could not detect time or value columns in the forecast data. "
+            f"Columns available: {', '.join(forecast_df.columns)}"
+        )
+    elif forecast_id_col is None:
+        st.warning(
+            f"Could not find hierarchy ID column `{leaf_col}` in the forecast data. "
+            f"Columns available: {', '.join(forecast_df.columns)}"
+        )
+    else:
+        st.caption(
+            f"Forecast columns — time: `{forecast_time_col}` | "
+            f"value: `{forecast_value_col}` | ID: `{forecast_id_col}`"
+        )
+
+        method = st.selectbox(
+            "Reconciliation method",
+            options=["bottom_up", "top_down", "middle_out", "ols", "wls", "mint"],
+            help=(
+                "**bottom_up**: Leaf forecasts are authoritative; parents = sum of children.\n\n"
+                "**top_down**: Top-level forecast disaggregated by historical proportions.\n\n"
+                "**middle_out**: Mid-level forecast, disaggregated down and aggregated up.\n\n"
+                "**ols**: Optimal least squares reconciliation.\n\n"
+                "**wls**: Weighted least squares with structural weights.\n\n"
+                "**mint**: Minimum trace reconciliation (most sophisticated)."
+            ),
+        )
+
+        run_reconciliation = st.button("Run Reconciliation", type="primary")
+
+        if run_reconciliation:
+            with st.status("Running reconciliation...", expanded=True) as status:
+                try:
+                    st.write(f"Building reconciler with method: **{method}**...")
+
+                    recon_config = ReconciliationConfig(
+                        method=method,
+                        enabled=True,
+                    )
+
+                    reconciler = Reconciler(
+                        trees={tree.name: tree},
+                        config=recon_config,
+                    )
+
+                    # Prepare forecasts dict keyed by level
+                    forecasts_dict = {
+                        tree.leaf_level: forecast_df.rename(
+                            {forecast_id_col: tree.leaf_level}
+                        ) if forecast_id_col != tree.leaf_level else forecast_df,
+                    }
+
+                    st.write("Reconciling forecasts...")
+                    reconciled_df = reconciler.reconcile(
+                        forecasts=forecasts_dict,
+                        actuals=actuals_df if method in ("top_down", "middle_out") else None,
+                        value_columns=[forecast_value_col],
+                        time_column=forecast_time_col,
+                    )
+
+                    st.session_state["reconciled_forecast"] = reconciled_df
+
+                    status.update(label="Reconciliation complete!", state="complete")
+
+                    # Before/After comparison
+                    st.subheader("Before vs. After Reconciliation")
+
+                    original_total = forecast_df[forecast_value_col].sum()
+                    reconciled_total = reconciled_df[forecast_value_col].sum()
+
+                    col_b, col_a, col_d = st.columns(3)
+                    col_b.metric(
+                        "Original Total",
+                        format_number(original_total),
+                    )
+                    col_a.metric(
+                        "Reconciled Total",
+                        format_number(reconciled_total),
+                    )
+                    diff_pct = (
+                        (reconciled_total - original_total) / original_total * 100
+                        if original_total != 0 else 0.0
+                    )
+                    col_d.metric(
+                        "Change",
+                        f"{diff_pct:+.2f}%",
+                    )
+
+                    # Time series comparison
+                    try:
+                        orig_by_time = (
+                            forecast_df.group_by(forecast_time_col)
+                            .agg(pl.col(forecast_value_col).sum().alias("Original"))
+                            .sort(forecast_time_col)
+                        )
+                        recon_by_time = (
+                            reconciled_df.group_by(forecast_time_col)
+                            .agg(pl.col(forecast_value_col).sum().alias("Reconciled"))
+                            .sort(forecast_time_col)
+                        )
+                        comparison = orig_by_time.join(
+                            recon_by_time, on=forecast_time_col, how="outer"
+                        )
+
+                        comp_pd = polars_to_pandas(comparison)
+
+                        fig_compare = go.Figure()
+                        fig_compare.add_trace(go.Scatter(
+                            x=comp_pd[forecast_time_col],
+                            y=comp_pd["Original"],
+                            mode="lines",
+                            name="Original",
+                            line=dict(color=COLORS["neutral"], dash="dash"),
+                        ))
+                        fig_compare.add_trace(go.Scatter(
+                            x=comp_pd[forecast_time_col],
+                            y=comp_pd["Reconciled"],
+                            mode="lines",
+                            name="Reconciled",
+                            line=dict(color=COLORS["primary"]),
+                        ))
+                        fig_compare.update_layout(
+                            title="Total Forecast: Original vs Reconciled",
+                            xaxis_title=forecast_time_col,
+                            yaxis_title=forecast_value_col,
+                            height=350,
+                            margin=dict(t=40, b=40, l=40, r=20),
+                        )
+                        st.plotly_chart(fig_compare, use_container_width=True)
+                    except Exception:
+                        st.caption("Could not generate comparison chart.")
+
+                    # Reconciled data preview
+                    with st.expander("Reconciled forecast data"):
+                        st.dataframe(
+                            polars_to_pandas(reconciled_df.head(500)),
+                            use_container_width=True,
+                        )
+
+                    st.success(
+                        f"Reconciled forecast stored in session "
+                        f"({reconciled_df.shape[0]:,} rows). "
+                        f"Method: **{method}**."
+                    )
+
+                except Exception as exc:
+                    status.update(label="Reconciliation failed", state="error")
+                    st.error(
+                        f"Reconciliation failed: {exc}\n\n"
+                        "Common causes:\n"
+                        "- **top_down / middle_out**: Requires historical actuals in session.\n"
+                        "- **Column mismatch**: The forecast ID column must match the "
+                        f"hierarchy leaf level (`{tree.leaf_level}`).\n"
+                        "- **Missing data**: Forecasts must cover all leaf nodes in the hierarchy."
+                    )
+
+        # Show previous reconciliation result if available
+        elif st.session_state.get("reconciled_forecast") is not None:
+            reconciled_df = st.session_state["reconciled_forecast"]
+            st.info(
+                f"Previous reconciliation result available: "
+                f"{reconciled_df.shape[0]:,} rows. "
+                f"Click **Run Reconciliation** to re-run with a different method."
+            )
+            with st.expander("Previous reconciled forecast"):
+                st.dataframe(
+                    polars_to_pandas(reconciled_df.head(500)),
+                    use_container_width=True,
+                )

--- a/forecasting-platform/streamlit/pages/5_Backtest_Results.py
+++ b/forecasting-platform/streamlit/pages/5_Backtest_Results.py
@@ -1,8 +1,9 @@
 """
-Page 2 — Backtest Results
+Page 5 — Backtest Results
 
 Model leaderboard, FVA cascade chart, per-series champion map,
-and layer leaderboard with Keep/Review/Remove recommendations.
+layer leaderboard, prediction interval calibration, SHAP feature
+attribution, and AI-powered configuration recommendations.
 """
 
 import sys
@@ -29,9 +30,12 @@ from utils import (
     FVA_COLORS,
     METRIC_TOOLTIPS,
     MODEL_LAYER_COLORS,
+    RISK_COLORS,
     model_display_name,
     polars_to_pandas,
     format_pct,
+    ai_available,
+    render_ai_unavailable_notice,
 )
 
 st.set_page_config(page_title="Backtest Results", page_icon="🏆", layout="wide")
@@ -362,3 +366,212 @@ else:
         f"Champion map requires `series_id` and `model_id` columns.\n\n"
         f"Available columns: {available}"
     )
+
+# ---------------------------------------------------------------------------
+#  Prediction Interval Calibration
+# ---------------------------------------------------------------------------
+st.divider()
+st.header("Prediction Interval Calibration")
+
+# Check if quantile columns exist in the metrics
+quantile_cols = [c for c in metrics_df.columns if c.startswith("forecast_p") or c.startswith("p")]
+has_quantiles = bool(quantile_cols) or ("actual" in metrics_df.columns and "forecast" in metrics_df.columns)
+
+if has_quantiles:
+    try:
+        from src.evaluation.calibration import (
+            compute_calibration_report,
+            compute_conformal_residuals,
+        )
+
+        quantiles = [0.1, 0.5, 0.9]
+        coverage_targets = {"p10_p90": 0.80}
+
+        with st.spinner("Computing calibration report..."):
+            cal_report = compute_calibration_report(
+                backtest_results=metrics_df,
+                quantiles=quantiles,
+                coverage_targets=coverage_targets,
+            )
+
+        if cal_report is not None:
+            # Per-model coverage
+            if hasattr(cal_report, "per_model") and cal_report.per_model is not None:
+                st.subheader("Coverage by Model")
+                cal_pd = polars_to_pandas(cal_report.per_model) if isinstance(
+                    cal_report.per_model, pl.DataFrame
+                ) else cal_report.per_model
+                st.dataframe(cal_pd, use_container_width=True)
+
+            # Calibration plot
+            if hasattr(cal_report, "nominal_vs_empirical"):
+                nve = cal_report.nominal_vs_empirical
+                if nve:
+                    fig_cal = go.Figure()
+                    fig_cal.add_trace(go.Scatter(
+                        x=[0, 1], y=[0, 1],
+                        mode="lines", line=dict(dash="dash", color=COLORS["neutral"]),
+                        name="Perfect calibration",
+                    ))
+                    nominals = list(nve.keys())
+                    empiricals = list(nve.values())
+                    fig_cal.add_trace(go.Scatter(
+                        x=nominals, y=empiricals,
+                        mode="markers+lines",
+                        marker=dict(size=8, color=COLORS["primary"]),
+                        name="Empirical",
+                    ))
+                    fig_cal.update_layout(
+                        title="Calibration Plot",
+                        xaxis_title="Nominal Coverage",
+                        yaxis_title="Empirical Coverage",
+                        height=350, margin=dict(t=40, b=40),
+                    )
+                    st.plotly_chart(fig_cal, use_container_width=True)
+
+            st.session_state["calibration_report"] = cal_report
+        else:
+            st.info("Calibration report could not be computed with the available data.")
+
+    except Exception as exc:
+        st.info(
+            f"Calibration analysis not available: {exc}\n\n"
+            "Calibration requires quantile forecast columns (e.g., forecast_p10, forecast_p90) "
+            "and actual values in the backtest results."
+        )
+else:
+    st.info(
+        "Calibration requires prediction interval columns in the backtest results. "
+        "Enable quantile forecasting in your config to use this feature."
+    )
+
+# ---------------------------------------------------------------------------
+#  SHAP Feature Attribution
+# ---------------------------------------------------------------------------
+st.divider()
+st.header("SHAP Feature Attribution")
+
+# Check if ML models are in the leaderboard
+ml_models = {"lgbm_direct", "xgboost_direct"}
+model_ids_in_data = set(metrics_df["model_id"].unique().to_list()) if "model_id" in metrics_df.columns else set()
+ml_in_leaderboard = ml_models & model_ids_in_data
+
+if ml_in_leaderboard:
+    st.caption(
+        "View feature importance for tree-based models using SHAP values."
+    )
+
+    try:
+        from src.analytics.explainer import ForecastExplainer
+
+        selected_ml = st.selectbox(
+            "Select ML model",
+            sorted(ml_in_leaderboard),
+            format_func=model_display_name,
+            key="shap_model",
+        )
+
+        if st.button("Compute SHAP", key="compute_shap"):
+            with st.spinner("Computing SHAP values..."):
+                explainer = ForecastExplainer(season_length=7)
+                actuals_df = st.session_state.get("actuals_df")
+                if actuals_df is not None:
+                    shap_result = explainer.explain_ml(
+                        model_name=selected_ml,
+                        history=actuals_df,
+                    )
+
+                    if shap_result is not None and not shap_result.is_empty():
+                        shap_pd = polars_to_pandas(shap_result.head(10))
+                        fig_shap = go.Figure()
+                        fig_shap.add_trace(go.Bar(
+                            x=shap_pd.iloc[:, 1] if shap_pd.shape[1] > 1 else [],
+                            y=shap_pd.iloc[:, 0] if shap_pd.shape[0] > 0 else [],
+                            orientation="h",
+                            marker_color=COLORS["accent"],
+                        ))
+                        fig_shap.update_layout(
+                            title=f"Top Features — {model_display_name(selected_ml)}",
+                            xaxis_title="Mean |SHAP|",
+                            height=350, margin=dict(t=40, b=40, l=150),
+                        )
+                        st.plotly_chart(fig_shap, use_container_width=True)
+                    else:
+                        st.info("SHAP values could not be computed.")
+                else:
+                    st.warning("Upload actuals data on the Data Onboarding page first.")
+
+    except ImportError:
+        st.info(
+            "SHAP analysis requires the `shap` package. "
+            "Install it with: `pip install shap`"
+        )
+    except Exception as exc:
+        st.info(f"SHAP analysis not available: {exc}")
+else:
+    st.info(
+        "SHAP attribution is available for ML models (LightGBM, XGBoost). "
+        "Include `lgbm_direct` or `xgboost_direct` in your backtest to enable."
+    )
+
+# ---------------------------------------------------------------------------
+#  AI Config Tuner
+# ---------------------------------------------------------------------------
+st.divider()
+st.header("AI Configuration Recommendations")
+st.caption(
+    "Get AI-powered suggestions to improve your forecasting configuration "
+    "based on backtest performance."
+)
+
+if ai_available():
+    accepted_config = st.session_state.get("accepted_config")
+    if accepted_config is None:
+        st.info("Accept a config on the Data Onboarding page first.")
+    elif st.button("Get AI Recommendations", type="primary", key="config_tune_btn"):
+        try:
+            from src.ai.config_tuner import ConfigTunerEngine
+
+            engine = ConfigTunerEngine()
+            with st.spinner("Analyzing configuration with Claude..."):
+                tune_result = engine.recommend(
+                    lob="uploaded",
+                    current_config=accepted_config,
+                    leaderboard=leaderboard if "leaderboard" in dir() else None,
+                )
+
+            # Overall assessment
+            st.info(tune_result.overall_assessment)
+            if tune_result.risk_summary:
+                st.caption(f"Risk: {tune_result.risk_summary}")
+
+            # Recommendations
+            if tune_result.recommendations:
+                for i, rec in enumerate(tune_result.recommendations):
+                    with st.expander(
+                        f"{rec.field_path} — {rec.expected_impact}",
+                        expanded=(i == 0),
+                    ):
+                        col_cur, col_arrow, col_new = st.columns([2, 1, 2])
+                        with col_cur:
+                            st.markdown(f"**Current:** `{rec.current_value}`")
+                        with col_arrow:
+                            st.markdown("**→**")
+                        with col_new:
+                            st.markdown(f"**Recommended:** `{rec.recommended_value}`")
+
+                        st.markdown(rec.reasoning)
+
+                        risk_color = RISK_COLORS.get(rec.risk, COLORS["neutral"])
+                        st.markdown(
+                            f'Risk: <span style="color:{risk_color};font-weight:bold">'
+                            f'{rec.risk.upper()}</span>',
+                            unsafe_allow_html=True,
+                        )
+            else:
+                st.success("No configuration changes recommended — current config looks good.")
+
+        except Exception as exc:
+            st.warning(f"AI config tuning failed: {exc}")
+else:
+    render_ai_unavailable_notice()

--- a/forecasting-platform/streamlit/pages/5_Backtest_Results.py
+++ b/forecasting-platform/streamlit/pages/5_Backtest_Results.py
@@ -36,9 +36,11 @@ from utils import (
     format_pct,
     ai_available,
     render_ai_unavailable_notice,
+    render_api_key_sidebar,
 )
 
 st.set_page_config(page_title="Backtest Results", page_icon="🏆", layout="wide")
+render_api_key_sidebar()
 st.title("Backtest Results")
 
 # ---------------------------------------------------------------------------

--- a/forecasting-platform/streamlit/pages/6_Forecast_Viewer.py
+++ b/forecasting-platform/streamlit/pages/6_Forecast_Viewer.py
@@ -29,9 +29,11 @@ from utils import (
     ai_available,
     render_ai_unavailable_notice,
     render_ai_confidence_badge,
+    render_api_key_sidebar,
 )
 
 st.set_page_config(page_title="Forecast Viewer", page_icon="🔮", layout="wide")
+render_api_key_sidebar()
 st.title("Forecast Viewer")
 
 # ---------------------------------------------------------------------------

--- a/forecasting-platform/streamlit/pages/6_Forecast_Viewer.py
+++ b/forecasting-platform/streamlit/pages/6_Forecast_Viewer.py
@@ -1,8 +1,9 @@
 """
-Page 3 — Forecast Viewer
+Page 6 — Forecast Viewer
 
 Interactive forecast chart with P10/P90 fan chart, actuals overlay,
-seasonal decomposition, and explainer narrative.
+seasonal decomposition, explainer narrative, AI natural-language query,
+forecast comparison, and constrained forecast toggle.
 """
 
 import sys
@@ -21,9 +22,16 @@ if str(_STREAMLIT_DIR) not in sys.path:
 import polars as pl
 
 from src.analytics.explainer import ForecastExplainer
-from utils import COLORS, DATA_DIR, polars_to_pandas
+from utils import (
+    COLORS,
+    DATA_DIR,
+    polars_to_pandas,
+    ai_available,
+    render_ai_unavailable_notice,
+    render_ai_confidence_badge,
+)
 
-st.set_page_config(page_title="Forecast Viewer", page_icon="📈", layout="wide")
+st.set_page_config(page_title="Forecast Viewer", page_icon="🔮", layout="wide")
 st.title("Forecast Viewer")
 
 # ---------------------------------------------------------------------------
@@ -348,6 +356,215 @@ else:
         "Upload actuals data in the sidebar to enable seasonal decomposition. "
         "Actuals are optional — leave blank to view forecasts only."
     )
+
+# ---------------------------------------------------------------------------
+#  Ask About This Forecast (AI)
+# ---------------------------------------------------------------------------
+st.divider()
+st.header("Ask About This Forecast")
+
+if ai_available():
+    st.caption("Ask a natural-language question about this series forecast.")
+
+    col_q, col_suggest = st.columns([3, 1])
+    with col_q:
+        user_question = st.text_input(
+            "Your question",
+            placeholder="Why is the forecast trending up?",
+            key="nl_query_input",
+        )
+    with col_suggest:
+        st.caption("Suggestions:")
+        if st.button("Why this trend?", key="suggest_trend"):
+            user_question = "Why is the forecast trending in this direction?"
+        if st.button("What drives seasonality?", key="suggest_season"):
+            user_question = "What drives the seasonal pattern in this series?"
+
+    if user_question and st.button("Ask", type="primary", key="ask_ai"):
+        try:
+            from src.ai.nl_query import NaturalLanguageQueryEngine
+
+            engine = NaturalLanguageQueryEngine()
+            with st.spinner("Analyzing with Claude..."):
+                result = engine.query(
+                    series_id=str(selected_series),
+                    question=user_question,
+                    lob=st.session_state.get("accepted_config", None)
+                    and "uploaded"
+                    or "uploaded",
+                    history=actuals_df,
+                    forecast=forecast_df,
+                    metrics_df=st.session_state.get("backtest_metrics"),
+                )
+
+            st.subheader("Answer")
+            st.markdown(result.answer)
+            render_ai_confidence_badge(result.confidence)
+
+            if result.supporting_data:
+                with st.expander("Supporting data"):
+                    st.json(result.supporting_data)
+            if result.sources_used:
+                st.caption(f"Sources: {', '.join(result.sources_used)}")
+
+        except Exception as exc:
+            st.warning(f"AI query failed: {exc}")
+else:
+    render_ai_unavailable_notice()
+
+# ---------------------------------------------------------------------------
+#  Forecast Comparison
+# ---------------------------------------------------------------------------
+st.divider()
+st.header("Forecast Comparison")
+st.caption("Upload an external forecast to compare against the current forecast.")
+
+comparison_file = st.file_uploader(
+    "External forecast (CSV/Parquet)", type=["csv", "parquet"], key="comparison_upload"
+)
+
+if comparison_file is not None:
+    try:
+        external_df = _load_file(comparison_file)
+        if external_df is not None:
+            from src.analytics.comparator import ForecastComparator
+
+            comparator = ForecastComparator()
+            with st.spinner("Comparing forecasts..."):
+                comparison = comparator.compare(
+                    model_forecast=forecast_df,
+                    external_forecasts={"external": external_df},
+                    id_col=id_col,
+                    time_col=time_col,
+                    value_col=value_col,
+                )
+
+            # Filter to selected series
+            if id_col in comparison.columns:
+                comp_series = comparison.filter(pl.col(id_col) == selected_series)
+            else:
+                comp_series = comparison
+
+            if not comp_series.is_empty():
+                comp_pd = polars_to_pandas(comp_series)
+
+                fig_comp = go.Figure()
+                if value_col in comp_pd.columns:
+                    fig_comp.add_trace(go.Scatter(
+                        x=comp_pd[time_col],
+                        y=comp_pd[value_col],
+                        mode="lines+markers",
+                        line=dict(color=COLORS["primary"], width=2),
+                        name="Model Forecast",
+                    ))
+                ext_col = _detect_col(
+                    comp_series, ["external", "external_forecast", "comparison"]
+                )
+                if ext_col and ext_col in comp_pd.columns:
+                    fig_comp.add_trace(go.Scatter(
+                        x=comp_pd[time_col],
+                        y=comp_pd[ext_col],
+                        mode="lines+markers",
+                        line=dict(color=COLORS["accent"], width=2),
+                        name="External Forecast",
+                    ))
+
+                fig_comp.update_layout(
+                    title=f"Comparison — {selected_series}",
+                    xaxis_title="Date",
+                    yaxis_title="Value",
+                    hovermode="x unified",
+                    height=400,
+                    margin=dict(t=40, b=40),
+                )
+                st.plotly_chart(fig_comp, use_container_width=True)
+
+                # Summary
+                try:
+                    summary = comparator.summary(comparison, id_col=id_col, time_col=time_col)
+                    if not summary.is_empty():
+                        with st.expander("Comparison summary"):
+                            st.dataframe(polars_to_pandas(summary), use_container_width=True)
+                except Exception:
+                    pass
+            else:
+                st.info(f"No comparison data for series `{selected_series}`.")
+    except Exception as exc:
+        st.warning(f"Comparison failed: {exc}")
+
+# ---------------------------------------------------------------------------
+#  Constrained Forecast
+# ---------------------------------------------------------------------------
+st.divider()
+st.header("Constrained Forecast")
+st.caption("Apply capacity or budget constraints to the forecast.")
+
+enable_constraints = st.checkbox("Enable constraints", key="enable_constraints")
+
+if enable_constraints:
+    col_cap, col_budget = st.columns(2)
+    with col_cap:
+        capacity = st.number_input(
+            "Max capacity per period",
+            min_value=0.0,
+            value=0.0,
+            help="Maximum forecast value per series per period. Set 0 to disable.",
+        )
+    with col_budget:
+        budget = st.number_input(
+            "Aggregate budget",
+            min_value=0.0,
+            value=0.0,
+            help="Total budget across all series. Set 0 to disable.",
+        )
+
+    if (capacity > 0 or budget > 0) and st.button("Apply Constraints", key="apply_constraints"):
+        try:
+            from src.config.schema import ConstraintConfig
+            from src.forecasting.constrained import ConstrainedDemandEstimator
+            from src.forecasting.registry import ForecasterRegistry
+
+            constraint_cfg = ConstraintConfig(
+                enabled=True,
+                capacity=capacity if capacity > 0 else None,
+                aggregate_max=budget if budget > 0 else None,
+            )
+
+            # Apply element-wise constraints directly to the forecast
+            constrained = fc_series.clone()
+            if capacity > 0:
+                constrained = constrained.with_columns(
+                    pl.col(value_col).clip(upper_bound=capacity).alias(value_col)
+                )
+
+            const_pd = polars_to_pandas(constrained)
+
+            fig_const = go.Figure()
+            fig_const.add_trace(go.Scatter(
+                x=fc_pd[time_col], y=fc_pd[value_col],
+                mode="lines", line=dict(color=COLORS["neutral"], width=1.5, dash="dot"),
+                name="Unconstrained",
+            ))
+            fig_const.add_trace(go.Scatter(
+                x=const_pd[time_col], y=const_pd[value_col],
+                mode="lines+markers", line=dict(color=COLORS["primary"], width=2),
+                name="Constrained",
+            ))
+            if capacity > 0:
+                fig_const.add_hline(
+                    y=capacity, line_dash="dash", line_color=COLORS["danger"],
+                    annotation_text="Capacity",
+                )
+
+            fig_const.update_layout(
+                title="Constrained vs Unconstrained",
+                height=350, margin=dict(t=40, b=40),
+                hovermode="x unified",
+            )
+            st.plotly_chart(fig_const, use_container_width=True)
+
+        except Exception as exc:
+            st.warning(f"Constraint application failed: {exc}")
 
 # ---------------------------------------------------------------------------
 #  Raw data preview

--- a/forecasting-platform/streamlit/pages/7_Platform_Health.py
+++ b/forecasting-platform/streamlit/pages/7_Platform_Health.py
@@ -1,11 +1,13 @@
 """
-Page 4 — Platform Health
+Page 7 — Platform Health
 
-Pipeline manifests, drift alerts, data quality summary, and compute cost.
+Pipeline manifests, drift alerts with AI triage, audit log,
+data quality summary, and compute cost tracking.
 """
 
 import json
 import sys
+from datetime import date, timedelta
 from pathlib import Path
 
 import plotly.express as px
@@ -32,6 +34,8 @@ from utils import (
     format_pct,
     format_number,
     format_duration,
+    ai_available,
+    render_ai_unavailable_notice,
 )
 
 st.set_page_config(page_title="Platform Health", page_icon="🏥", layout="wide")
@@ -244,6 +248,78 @@ if drift_alerts:
     )
     fig_alert.update_layout(height=300, margin=dict(t=40, b=40))
     st.plotly_chart(fig_alert, use_container_width=True)
+
+    # -------------------------------------------------------------------
+    #  AI Anomaly Triage
+    # -------------------------------------------------------------------
+    st.subheader("AI Anomaly Triage")
+    st.caption(
+        "Rank alerts by business impact and get AI-suggested corrective actions."
+    )
+
+    if ai_available():
+        if st.button("Triage Alerts with AI", type="primary", key="triage_btn"):
+            try:
+                from src.ai.anomaly_triage import AnomalyTriageEngine
+
+                engine = AnomalyTriageEngine()
+                with st.spinner("Triaging alerts with Claude..."):
+                    triage_result = engine.query(
+                        lob=lob,
+                        drift_alerts=drift_alerts,
+                        max_alerts=50,
+                    )
+
+                # Executive summary
+                st.info(triage_result.executive_summary)
+
+                # Ranked alerts table
+                if triage_result.ranked_alerts:
+                    triage_data = []
+                    for ta in triage_result.ranked_alerts:
+                        triage_data.append({
+                            "impact_score": ta.business_impact_score,
+                            "series_id": ta.series_id,
+                            "metric": ta.metric,
+                            "severity": ta.severity,
+                            "suggested_action": ta.suggested_action,
+                            "reasoning": ta.reasoning,
+                        })
+                    triage_df = pl.DataFrame(triage_data).sort(
+                        "impact_score", descending=True
+                    )
+                    st.dataframe(
+                        polars_to_pandas(triage_df),
+                        use_container_width=True,
+                        column_config={
+                            "impact_score": st.column_config.NumberColumn(
+                                "Impact Score", format="%.0f",
+                                help="Business impact score (0-100). Higher = more urgent.",
+                            ),
+                        },
+                    )
+
+                    # Select triaged series to view in Forecast Viewer
+                    triaged_series = triage_df["series_id"].unique().to_list()
+                    selected_triage = st.selectbox(
+                        "Investigate series in Forecast Viewer",
+                        triaged_series,
+                        index=None,
+                        placeholder="Choose a series...",
+                        key="triage_series_select",
+                    )
+                    if selected_triage:
+                        st.session_state["selected_series_id"] = selected_triage
+                        st.success(
+                            f"Series `{selected_triage}` selected. "
+                            f"Go to **Forecast Viewer** to investigate."
+                        )
+
+            except Exception as exc:
+                st.warning(f"AI triage failed: {exc}")
+    else:
+        render_ai_unavailable_notice()
+
 elif st.session_state.get("drift_alerts") is not None:
     st.success("No drift alerts detected.")
 else:
@@ -358,6 +434,41 @@ if manifest_files:
             margin=dict(t=40, b=40),
         )
         st.plotly_chart(fig_cost, use_container_width=True)
+
+        # Cost per series
+        if any(d.get("series_count", 0) > 0 for d in cost_data):
+            st.subheader("Cost Efficiency")
+            efficiency_data = [
+                {
+                    "run_id": d["run_id"],
+                    "seconds_per_series": round(
+                        d["total_seconds"] / d["series_count"], 2
+                    )
+                    if d.get("series_count", 0) > 0
+                    else 0,
+                }
+                for d in cost_data
+                if d.get("series_count", 0) > 0
+            ]
+            if efficiency_data:
+                eff_df = pl.DataFrame(efficiency_data)
+                eff_pd = polars_to_pandas(eff_df)
+                fig_eff = go.Figure()
+                fig_eff.add_trace(go.Bar(
+                    x=eff_pd["run_id"],
+                    y=eff_pd["seconds_per_series"],
+                    marker_color=COLORS["accent"],
+                    text=[f"{v:.2f}s" for v in eff_pd["seconds_per_series"]],
+                    textposition="auto",
+                ))
+                fig_eff.update_layout(
+                    title="Seconds per Series",
+                    xaxis_title="Run ID",
+                    yaxis_title="Seconds / Series",
+                    height=300,
+                    margin=dict(t=40, b=40),
+                )
+                st.plotly_chart(fig_eff, use_container_width=True)
     else:
         st.info(
             "No compute cost data found in manifests. "
@@ -365,3 +476,44 @@ if manifest_files:
         )
 else:
     st.info("No pipeline runs found. Cost data is collected from pipeline manifests.")
+
+# ---------------------------------------------------------------------------
+#  Audit Log
+# ---------------------------------------------------------------------------
+st.divider()
+st.header("Audit Log")
+
+try:
+    from src.audit.logger import AuditLogger
+
+    audit_path = str(DATA_DIR / "audit_log")
+    logger = AuditLogger(base_path=audit_path)
+
+    col_action, col_limit = st.columns(2)
+    with col_action:
+        action_filter = st.text_input(
+            "Filter by action", value="", key="audit_action_filter",
+            help="Leave blank to show all actions.",
+        )
+    with col_limit:
+        audit_limit = st.number_input(
+            "Max entries", min_value=10, max_value=1000, value=100, key="audit_limit"
+        )
+
+    if st.button("Load Audit Log", key="load_audit"):
+        with st.spinner("Querying audit log..."):
+            audit_df = logger.query(
+                action=action_filter or None,
+                limit=audit_limit,
+            )
+        if audit_df is not None and not audit_df.is_empty():
+            st.dataframe(polars_to_pandas(audit_df), use_container_width=True)
+            st.caption(f"Showing {audit_df.shape[0]} entries.")
+        else:
+            st.info("No audit log entries found.")
+
+except Exception as exc:
+    st.info(
+        f"Audit log not available: {exc}\n\n"
+        "Audit entries are generated when pipeline actions are performed via the API."
+    )

--- a/forecasting-platform/streamlit/pages/7_Platform_Health.py
+++ b/forecasting-platform/streamlit/pages/7_Platform_Health.py
@@ -36,9 +36,11 @@ from utils import (
     format_duration,
     ai_available,
     render_ai_unavailable_notice,
+    render_api_key_sidebar,
 )
 
 st.set_page_config(page_title="Platform Health", page_icon="🏥", layout="wide")
+render_api_key_sidebar()
 st.title("Platform Health")
 
 # ---------------------------------------------------------------------------

--- a/forecasting-platform/streamlit/pages/8_SOP_Meeting.py
+++ b/forecasting-platform/streamlit/pages/8_SOP_Meeting.py
@@ -31,10 +31,12 @@ from utils import (
     format_pct,
     polars_to_pandas,
     render_ai_unavailable_notice,
+    render_api_key_sidebar,
     render_metric_card_with_trend,
 )
 
 st.set_page_config(page_title="S&OP Meeting Prep", page_icon="📋", layout="wide")
+render_api_key_sidebar()
 st.title("S&OP Meeting Prep")
 
 metrics_dir = str(DATA_DIR / "metrics")

--- a/forecasting-platform/streamlit/pages/8_SOP_Meeting.py
+++ b/forecasting-platform/streamlit/pages/8_SOP_Meeting.py
@@ -1,0 +1,362 @@
+"""
+Page 8 — S&OP Meeting Prep
+
+Executive-level output — AI commentary, cross-run comparison, model
+governance, and BI export for Power BI / Tableau consumption.
+"""
+
+import io
+import sys
+from datetime import date
+from pathlib import Path
+
+import plotly.graph_objects as go
+import polars as pl
+import streamlit as st
+
+_PLATFORM_ROOT = Path(__file__).resolve().parent.parent.parent
+_STREAMLIT_DIR = Path(__file__).resolve().parent.parent
+if str(_PLATFORM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLATFORM_ROOT))
+if str(_STREAMLIT_DIR) not in sys.path:
+    sys.path.insert(0, str(_STREAMLIT_DIR))
+
+from src.metrics.store import MetricStore
+from utils import (
+    COLORS,
+    DATA_DIR,
+    TREND_ICONS,
+    ai_available,
+    format_number,
+    format_pct,
+    polars_to_pandas,
+    render_ai_unavailable_notice,
+    render_metric_card_with_trend,
+)
+
+st.set_page_config(page_title="S&OP Meeting Prep", page_icon="📋", layout="wide")
+st.title("S&OP Meeting Prep")
+
+metrics_dir = str(DATA_DIR / "metrics")
+
+# =========================================================================== #
+#  Section 1: AI Commentary Generation
+# =========================================================================== #
+st.header("Executive Commentary")
+st.caption("Generate VP-level S&OP meeting narratives powered by Claude.")
+
+col_lob, col_start, col_end = st.columns(3)
+with col_lob:
+    commentary_lob = st.text_input("Line of Business", value="retail", key="commentary_lob")
+with col_start:
+    period_start = st.date_input("Period start", value=None, key="commentary_start")
+with col_end:
+    period_end = st.date_input("Period end", value=None, key="commentary_end")
+
+# Resolve metrics_df from session state or MetricStore
+commentary_metrics_df = st.session_state.get("backtest_metrics")
+if commentary_metrics_df is None:
+    try:
+        store = MetricStore(base_path=metrics_dir)
+        commentary_metrics_df = store.read(run_type="backtest", lob=commentary_lob)
+    except Exception:
+        commentary_metrics_df = None
+
+if st.button("Generate Commentary", type="primary", key="gen_commentary"):
+    if not ai_available():
+        render_ai_unavailable_notice()
+    elif commentary_metrics_df is None or commentary_metrics_df.is_empty():
+        st.warning(
+            f"No metrics data available for LOB '{commentary_lob}'. "
+            "Run a backtest first or load data on the Backtest Results page."
+        )
+    else:
+        try:
+            from src.ai.commentary import CommentaryEngine
+
+            engine = CommentaryEngine()
+            if not engine.available:
+                render_ai_unavailable_notice()
+            else:
+                drift_alerts = st.session_state.get("drift_alerts")
+                with st.spinner("Generating executive commentary..."):
+                    result = engine.generate(
+                        lob=commentary_lob,
+                        metrics_df=commentary_metrics_df,
+                        drift_alerts=drift_alerts,
+                        period_start=period_start,
+                        period_end=period_end,
+                    )
+
+                # Executive summary
+                st.info(result.executive_summary)
+
+                # Key metrics as cards
+                if result.key_metrics:
+                    metric_cols = st.columns(min(len(result.key_metrics), 4))
+                    for i, km in enumerate(result.key_metrics):
+                        with metric_cols[i % len(metric_cols)]:
+                            render_metric_card_with_trend(
+                                name=km.get("name", ""),
+                                value=km.get("value", ""),
+                                unit=km.get("unit", ""),
+                                trend=km.get("trend", ""),
+                            )
+
+                # Exceptions
+                if result.exceptions:
+                    st.subheader("Exceptions")
+                    for exc_item in result.exceptions:
+                        st.warning(exc_item)
+
+                # Action items
+                if result.action_items:
+                    st.subheader("Action Items")
+                    for j, action in enumerate(result.action_items):
+                        st.checkbox(action, value=False, key=f"action_{j}")
+
+        except ImportError:
+            st.warning("Commentary module not available. Install the `anthropic` package.")
+        except Exception as exc:
+            st.error(f"Commentary generation failed: {exc}")
+            st.caption("This may be a transient API issue. Try again in a moment.")
+
+st.divider()
+
+# =========================================================================== #
+#  Section 2: Cross-Run Forecast Comparison
+# =========================================================================== #
+st.header("Forecast Comparison")
+
+uploaded_external = st.file_uploader(
+    "Upload external forecast (CSV or Parquet)",
+    type=["csv", "parquet"],
+    key="external_forecast_upload",
+)
+
+model_forecast = st.session_state.get("forecast_df")
+
+external_df = None
+if uploaded_external is not None:
+    try:
+        raw = uploaded_external.getvalue()
+        if uploaded_external.name.endswith(".parquet"):
+            external_df = pl.read_parquet(io.BytesIO(raw))
+        else:
+            external_df = pl.read_csv(io.BytesIO(raw), try_parse_dates=True)
+        st.success(
+            f"Loaded external forecast: {external_df.shape[0]:,} rows x "
+            f"{external_df.shape[1]} columns."
+        )
+    except Exception as exc:
+        st.error(f"Failed to load external forecast: {exc}")
+
+if model_forecast is not None and external_df is not None:
+    try:
+        from src.analytics.comparator import ForecastComparator
+
+        comparator = ForecastComparator()
+        with st.spinner("Comparing forecasts..."):
+            comparison = comparator.compare(
+                model_forecast=model_forecast,
+                external_forecasts=external_df,
+            )
+            summary = comparator.summary(comparison)
+
+        # Overlay chart
+        st.subheader("Forecast Overlay")
+        comp_pd = polars_to_pandas(comparison)
+        time_col = "week" if "week" in comp_pd.columns else comp_pd.columns[0]
+
+        fig = go.Figure()
+        if "forecast" in comp_pd.columns:
+            fig.add_trace(go.Scatter(
+                x=comp_pd[time_col],
+                y=comp_pd["forecast"],
+                mode="lines",
+                name="Model Forecast",
+                line=dict(color=COLORS["primary"]),
+            ))
+        if "external_forecast" in comp_pd.columns:
+            fig.add_trace(go.Scatter(
+                x=comp_pd[time_col],
+                y=comp_pd["external_forecast"],
+                mode="lines",
+                name="External Forecast",
+                line=dict(color=COLORS["accent"]),
+            ))
+        fig.update_layout(
+            xaxis_title="Period",
+            yaxis_title="Forecast",
+            height=400,
+            margin=dict(t=30, b=40, l=50, r=20),
+        )
+        st.plotly_chart(fig, use_container_width=True)
+
+        # Summary table
+        st.subheader("Comparison Summary")
+        st.dataframe(polars_to_pandas(summary), use_container_width=True)
+
+    except ImportError:
+        st.warning("ForecastComparator module not available.")
+    except Exception as exc:
+        st.error(f"Forecast comparison failed: {exc}")
+        st.caption("Check that both forecasts have matching columns and time ranges.")
+
+elif model_forecast is not None:
+    st.info(
+        "Model forecast loaded from session. Upload an external forecast above "
+        "to generate a comparison."
+    )
+elif external_df is not None:
+    st.info(
+        "External forecast loaded. Run a forecast on the Data Onboarding page "
+        "to generate a model forecast for comparison."
+    )
+else:
+    st.info(
+        "No forecasts available. Run a forecast on the Data Onboarding page "
+        "and/or upload an external forecast to compare."
+    )
+
+st.divider()
+
+# =========================================================================== #
+#  Section 3: Model Governance
+# =========================================================================== #
+st.header("Model Governance")
+
+try:
+    from src.analytics.governance import ForecastLineage, ModelCardRegistry
+
+    # Model Cards
+    st.subheader("Model Cards")
+    registry = ModelCardRegistry(base_path=str(DATA_DIR / "model_cards"))
+    cards_df = registry.all_cards()
+
+    if cards_df is not None and not cards_df.is_empty():
+        st.dataframe(polars_to_pandas(cards_df), use_container_width=True)
+
+        model_names = cards_df["model_name"].to_list() if "model_name" in cards_df.columns else []
+        if model_names:
+            selected_model = st.selectbox(
+                "Select a model to view details",
+                options=model_names,
+                key="governance_model_select",
+            )
+            card = registry.get(selected_model)
+            if card is not None:
+                with st.expander(f"Model Card: {card.model_name}", expanded=True):
+                    col_v, col_w, col_s = st.columns(3)
+                    col_v.metric("Version", card.version)
+                    col_w.metric("Training Window", card.training_window)
+                    col_s.metric("Series Count", format_number(card.n_series, 0))
+
+                    if card.metrics:
+                        st.markdown("**Metrics**")
+                        metric_cols = st.columns(min(len(card.metrics), 4))
+                        for i, (k, v) in enumerate(card.metrics.items()):
+                            with metric_cols[i % len(metric_cols)]:
+                                st.metric(k, format_number(v))
+
+                    if card.features:
+                        st.markdown(f"**Features**: {', '.join(card.features)}")
+
+                    if card.config_hash:
+                        st.caption(f"Config hash: `{card.config_hash}`")
+    else:
+        st.info(
+            "No model cards found. Model cards are generated during backtest "
+            "and forecast pipeline runs."
+        )
+
+    # Forecast Lineage
+    st.subheader("Forecast Lineage")
+    lineage = ForecastLineage(base_path=str(DATA_DIR / "lineage"))
+    lineage_df = lineage.history()
+
+    if lineage_df is not None and not lineage_df.is_empty():
+        st.dataframe(polars_to_pandas(lineage_df), use_container_width=True)
+    else:
+        st.info("No lineage records found. Run a forecast pipeline to generate lineage.")
+
+except ImportError:
+    st.warning("Governance module not available. Check that `src.analytics.governance` is installed.")
+except Exception as exc:
+    st.error(f"Failed to load governance data: {exc}")
+    st.caption("This is expected if no pipeline runs have been completed yet.")
+
+st.divider()
+
+# =========================================================================== #
+#  Section 4: BI Export
+# =========================================================================== #
+st.header("BI Export")
+st.caption("Export data in Hive-partitioned Parquet format for Power BI / Tableau.")
+
+export_lob = st.text_input("Line of Business", value="retail", key="export_lob")
+
+col_e1, col_e2, col_e3 = st.columns(3)
+
+with col_e1:
+    if st.button("Export Forecast vs Actual", key="export_fva"):
+        try:
+            from src.analytics.bi_export import BIExporter
+
+            forecast_df = st.session_state.get("forecast_df")
+            actuals_df = st.session_state.get("actuals_df")
+
+            if forecast_df is None or actuals_df is None:
+                st.warning(
+                    "Both forecast and actuals data are required. "
+                    "Run a forecast on the Data Onboarding page first."
+                )
+            else:
+                exporter = BIExporter(base_path=str(DATA_DIR / "bi_exports"))
+                with st.spinner("Exporting forecast vs actual..."):
+                    out_path = exporter.export_forecast_vs_actual(
+                        forecasts=forecast_df,
+                        actuals=actuals_df,
+                        lob=export_lob,
+                    )
+                st.success(f"Exported to: `{out_path}`")
+        except ImportError:
+            st.warning("BIExporter module not available.")
+        except Exception as exc:
+            st.error(f"Export failed: {exc}")
+
+with col_e2:
+    if st.button("Export Leaderboard", key="export_lb"):
+        try:
+            from src.analytics.bi_export import BIExporter
+
+            exporter = BIExporter(base_path=str(DATA_DIR / "bi_exports"))
+            store = MetricStore(base_path=metrics_dir)
+            with st.spinner("Exporting leaderboard..."):
+                out_path = exporter.export_leaderboard(
+                    metric_store=store,
+                    lob=export_lob,
+                )
+            st.success(f"Exported to: `{out_path}`")
+        except ImportError:
+            st.warning("BIExporter module not available.")
+        except Exception as exc:
+            st.error(f"Export failed: {exc}")
+
+with col_e3:
+    if st.button("Export Bias Report", key="export_bias"):
+        try:
+            from src.analytics.bi_export import BIExporter
+
+            exporter = BIExporter(base_path=str(DATA_DIR / "bi_exports"))
+            store = MetricStore(base_path=metrics_dir)
+            with st.spinner("Exporting bias report..."):
+                out_path = exporter.export_bias_report(
+                    metric_store=store,
+                    lob=export_lob,
+                )
+            st.success(f"Exported to: `{out_path}`")
+        except ImportError:
+            st.warning("BIExporter module not available.")
+        except Exception as exc:
+            st.error(f"Export failed: {exc}")

--- a/forecasting-platform/streamlit/utils.py
+++ b/forecasting-platform/streamlit/utils.py
@@ -240,17 +240,63 @@ TREND_ICONS = {
 # ---------------------------------------------------------------------------
 #  AI helpers
 # ---------------------------------------------------------------------------
-def ai_available() -> bool:
-    """Check whether the Anthropic API key is configured."""
+def _sync_api_key_to_env():
+    """Push the session-state API key into ``os.environ`` so backend classes pick it up."""
     import os
+    key = st.session_state.get("anthropic_api_key", "").strip()
+    if key:
+        os.environ["ANTHROPIC_API_KEY"] = key
+    elif "ANTHROPIC_API_KEY" not in os.environ:
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+
+
+def render_api_key_sidebar():
+    """Render a sidebar widget for entering the Anthropic API key.
+
+    The key is stored in ``st.session_state["anthropic_api_key"]`` and
+    automatically synced into ``os.environ["ANTHROPIC_API_KEY"]`` so that
+    every downstream consumer (``AIFeatureBase``, ``LLMAnalyzer``,
+    ``ai_available()``) picks it up without any extra wiring.
+
+    Call this once at the top of any page that uses AI features.
+    """
+    import os
+
+    with st.sidebar:
+        st.markdown("---")
+        st.markdown("**AI Settings**")
+        # Pre-fill from env var if user hasn't entered one yet
+        default = st.session_state.get(
+            "anthropic_api_key",
+            os.environ.get("ANTHROPIC_API_KEY", ""),
+        )
+        st.text_input(
+            "Anthropic API Key",
+            value=default,
+            type="password",
+            key="anthropic_api_key",
+            help="Entered key is used for this session only and is never stored to disk.",
+        )
+    _sync_api_key_to_env()
+
+
+def ai_available() -> bool:
+    """Check whether the Anthropic API key is configured.
+
+    Checks both ``os.environ`` and Streamlit session state so it works
+    whether the key was set via env var, ``.env`` file, or the sidebar widget.
+    """
+    import os
+    if st.session_state.get("anthropic_api_key", "").strip():
+        return True
     return bool(os.environ.get("ANTHROPIC_API_KEY"))
 
 
 def render_ai_unavailable_notice():
     """Show a standard info box when AI features are unavailable."""
     st.info(
-        "AI features require the `ANTHROPIC_API_KEY` environment variable "
-        "and the `anthropic` package. Set the key to enable AI-powered insights."
+        "AI features require an Anthropic API key. "
+        "Enter it in the sidebar or set the `ANTHROPIC_API_KEY` environment variable."
     )
 
 

--- a/forecasting-platform/streamlit/utils.py
+++ b/forecasting-platform/streamlit/utils.py
@@ -207,6 +207,78 @@ def format_duration(seconds: float) -> str:
     return f"{h}h {m}m {s}s"
 
 
+# ---------------------------------------------------------------------------
+#  Domain-specific colour maps
+# ---------------------------------------------------------------------------
+DEMAND_CLASS_COLORS = {
+    "Smooth": COLORS["success"],
+    "Intermittent": COLORS["warning"],
+    "Erratic": COLORS["accent"],
+    "Lumpy": COLORS["danger"],
+    "insufficient_data": COLORS["neutral"],
+}
+
+RISK_COLORS = {
+    "low": COLORS["success"],
+    "medium": COLORS["warning"],
+    "high": COLORS["danger"],
+}
+
+CONFIDENCE_BADGE_COLORS = {
+    "high": COLORS["success"],
+    "medium": COLORS["warning"],
+    "low": COLORS["danger"],
+}
+
+TREND_ICONS = {
+    "improving": "\u2191",
+    "stable": "\u2192",
+    "degrading": "\u2193",
+}
+
+
+# ---------------------------------------------------------------------------
+#  AI helpers
+# ---------------------------------------------------------------------------
+def ai_available() -> bool:
+    """Check whether the Anthropic API key is configured."""
+    import os
+    return bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+
+def render_ai_unavailable_notice():
+    """Show a standard info box when AI features are unavailable."""
+    st.info(
+        "AI features require the `ANTHROPIC_API_KEY` environment variable "
+        "and the `anthropic` package. Set the key to enable AI-powered insights."
+    )
+
+
+def render_ai_confidence_badge(confidence: str):
+    """Render a coloured confidence badge."""
+    color = CONFIDENCE_BADGE_COLORS.get(confidence, COLORS["neutral"])
+    st.markdown(
+        f'<span style="background-color:{color}20;color:{color};'
+        f'padding:2px 8px;border-radius:4px;font-weight:bold">'
+        f'{confidence.upper()}</span>',
+        unsafe_allow_html=True,
+    )
+
+
+def render_metric_card_with_trend(name: str, value, unit: str = "", trend: str = ""):
+    """Render a metric card with optional trend arrow."""
+    arrow = TREND_ICONS.get(trend, "")
+    trend_color = {
+        "improving": COLORS["success"],
+        "degrading": COLORS["danger"],
+        "stable": COLORS["neutral"],
+    }.get(trend, COLORS["neutral"])
+    display = f"{value}{unit}"
+    if arrow:
+        display += f" {arrow}"
+    st.metric(name, display)
+
+
 # Sample CSV template for data onboarding guidance
 CSV_TEMPLATE = """\
 week,store_id,product_id,quantity


### PR DESCRIPTION
Reorder pages to follow the end-to-end data science workflow:
Data → Understand → Prepare → Structure → Model → Forecast → Monitor → Report

New pages:
- Page 2 (Series Explorer): SBC demand classification, structural break
  detection, data quality deep-dive, cleansing audit, regressor screening,
  and AI natural-language Q&A
- Page 3 (SKU Transitions): SKU mapping pipeline with phase 1/2 support,
  planner override management with approval workflow, transition visualization
- Page 4 (Hierarchy Manager): hierarchy tree visualization (sunburst),
  aggregation explorer, forecast reconciliation (bottom-up/MinT/OLS/WLS)
- Page 8 (S&OP Meeting Prep): AI executive commentary generation,
  cross-run forecast comparison, model governance, BI export

Enhanced existing pages:
- Page 1 (Data Onboarding): demand cleansing preview, regressor screening,
  structural break summary
- Page 5 (Backtest Results, was 2): prediction interval calibration,
  SHAP feature attribution, AI configuration recommendations
- Page 6 (Forecast Viewer, was 3): AI natural-language Q&A, forecast
  comparison overlay, constrained forecast toggle
- Page 7 (Platform Health, was 4): AI anomaly triage for drift alerts,
  audit log viewer, cost-per-series efficiency tracking

AI features are contextual (woven into relevant pages), not isolated.
All AI features gracefully degrade when ANTHROPIC_API_KEY is unset.

https://claude.ai/code/session_01Ws3WScabNmBHngeQjg88jf