### PR TITLE
Update all documentation for 8-page Streamlit expansion and Next.js f…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,7 +65,8 @@ graph TD
 
     subgraph Consumers["Consumers"]
         API["FastAPI REST<br/><small>auth-protected</small>"]
-        ST["Streamlit Dashboard<br/><small>4 pages</small>"]
+        ST["Streamlit Dashboard<br/><small>8 pages</small>"]
+        NX["Next.js Frontend<br/><small>8 pages, REST client</small>"]
         AI["AI Features<br/><small>NL Query, Triage,<br/>Commentary, Config Tuner</small>"]
     end
 
@@ -575,9 +576,13 @@ graph TD
 
     subgraph Dashboard["Streamlit Pages"]
         P1["1. Data Onboarding<br/><small>upload → classify →<br/>merge → config</small>"]
-        P2["2. Backtest Results<br/><small>leaderboard, FVA,<br/>champion map</small>"]
-        P3["3. Forecast Viewer<br/><small>fan chart, decomposition,<br/>narrative</small>"]
-        P4["4. Platform Health<br/><small>manifests, drift,<br/>cost tracking</small>"]
+        P2["2. Series Explorer<br/><small>SBC, breaks, quality,<br/>cleansing, AI Q&A</small>"]
+        P3["3. SKU Transitions<br/><small>mapping, overrides,<br/>transition viz</small>"]
+        P4["4. Hierarchy Manager<br/><small>tree, aggregation,<br/>reconciliation</small>"]
+        P5["5. Backtest Results<br/><small>leaderboard, FVA,<br/>champion map</small>"]
+        P6["6. Forecast Viewer<br/><small>fan chart, decomposition,<br/>narrative</small>"]
+        P7["7. Platform Health<br/><small>manifests, drift,<br/>cost tracking</small>"]
+        P8["8. S&OP Meeting<br/><small>commentary, governance,<br/>BI export</small>"]
     end
 
     subgraph DataStores["Data Stores"]
@@ -595,13 +600,14 @@ graph TD
     AN --> P1
     AIE1 & AIE2 & AIE3 & AIE4 --> CLAUDE2
 
-    P1 -.->|session_state| P2
-    P2 -.->|selected_series_id| P3
-    P4 -.->|drift_alerts| P3
+    P1 -.->|session_state| P5
+    P5 -.->|selected_series_id| P6
+    P7 -.->|drift_alerts| P6
 
-    P2 --> MS2
-    P3 --> FS2
-    P4 --> MF2 & MS2
+    P5 --> MS2
+    P6 --> FS2
+    P7 --> MF2 & MS2
+    P8 --> CLAUDE2
 ```
 
 ### Deep Dive: API Endpoint Map
@@ -630,26 +636,70 @@ graph LR
         AR["analysis_report"]
     end
 
-    subgraph Page2["Page 2: Backtest Results"]
+    subgraph Page2["Page 2: Series Explorer"]
+        SQ["series_quality"]
+        BC["break_candidates"]
+    end
+
+    subgraph Page5["Page 5: Backtest Results"]
         CB["Config Banner<br/><small>shows accepted_config</small>"]
         SS["selected_series_id"]
     end
 
-    subgraph Page3["Page 3: Forecast Viewer"]
+    subgraph Page6["Page 6: Forecast Viewer"]
         PS["Pre-select series<br/><small>from selected_series_id</small>"]
         DI["Drift indicators<br/><small>from drift_alerts</small>"]
     end
 
-    subgraph Page4["Page 4: Platform Health"]
+    subgraph Page7["Page 7: Platform Health"]
         DA["drift_alerts"]
         SL["Series links<br/><small>→ Forecast Viewer</small>"]
     end
 
+    subgraph Page8["Page 8: S&OP Meeting"]
+        CM["commentary"]
+    end
+
     AC -->|session_state| CB
     AR -->|session_state| CB
+    AR -->|session_state| SQ
     SS -->|session_state| PS
     DA -->|session_state| DI
     SL -->|session_state| PS
+```
+
+### Deep Dive: Next.js Frontend
+
+The Next.js frontend is an alternative UI that communicates with the same FastAPI backend over REST. It mirrors the 8-page workflow but runs as a standalone Node.js application.
+
+```mermaid
+graph TB
+    subgraph NextJS["Next.js Frontend (port 3000)"]
+        direction TB
+        NL["Login"] --> NP["8 Workflow Pages"]
+        NP --> NH["React Query Hooks"]
+        NH --> NC["API Client<br/><small>typed fetch + JWT</small>"]
+    end
+
+    subgraph API["FastAPI Backend (port 8000)"]
+        EP["12 REST Endpoints"]
+    end
+
+    NC -->|HTTP/JSON| EP
+
+    subgraph LiveFeatures["Live (API-connected)"]
+        LF1["File upload / analysis"]
+        LF2["Model leaderboard"]
+        LF3["Drift alerts + audit log"]
+        LF4["AI: explain, triage, config, commentary"]
+    end
+
+    subgraph Placeholder["Coming Soon (no endpoint yet)"]
+        PH1["Multi-file classification"]
+        PH2["Pipeline execution"]
+        PH3["Hierarchy / SKU ops"]
+        PH4["SHAP / BI export"]
+    end
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ python forecasting-platform/scripts/serve.py --port 8000 --data-dir data/
 # Start Streamlit dashboard
 streamlit run forecasting-platform/streamlit/app.py
 
+# Start Next.js frontend (alternative UI)
+cd forecasting-platform/frontend && npm install && npm run dev
+
 # Docker quick-start (API + Streamlit)
 docker compose up
 
@@ -106,6 +109,11 @@ forecasting-platform/
 │       ├── 6_Forecast_Viewer.py    # Fan chart, decomposition, AI NL query, comparison, constraints
 │       ├── 7_Platform_Health.py    # Manifests, drift + AI triage, audit log, cost tracking
 │       └── 8_SOP_Meeting.py        # AI commentary, cross-run comparison, governance, BI export
+├── frontend/               # Next.js 15 frontend (TypeScript, Tailwind, Recharts)
+│   ├── src/app/            # App Router pages (login + 8 workflow pages)
+│   ├── src/components/     # Reusable components (charts, AI panels, layout, shared)
+│   ├── src/hooks/          # React Query hooks for each API endpoint
+│   └── src/lib/            # API client, auth, types, constants
 ├── tests/                  # 1030+ tests (pytest)
 ├── configs/                # YAML configuration files
 ├── scripts/                # Entry points (run_backtest, run_forecast, serve, spark_*)
@@ -157,14 +165,13 @@ Helper functions: `get_frequency_profile(freq)` returns the profile dict; `freq_
 - Helper fixtures use `_make_*` factory functions (e.g., `_make_weekly_actuals`)
 - Skip `test_metrics.py` and `test_feature_engineering.py` (legacy/slow)
 - 1030+ tests across 48 test files
-- Key test modules: `test_platform.py` (85 tests), `test_ai_*.py` (73), `test_forecast_explainability.py` (59), `test_intermittent_demand.py` (55), `test_file_classifier.py` (26), `test_file_merger.py` (20)
-- 980+ tests across 46 test files
-- Key test modules: `test_platform.py` (85 tests), `test_sku_mapping.py` (81), `test_ai_*.py` (66), `test_forecast_explainability.py` (59), `test_intermittent_demand.py` (55), `test_observability.py` (41)
+- Key test modules: `test_platform.py` (85 tests), `test_sku_mapping.py` (81), `test_ai_*.py` (73), `test_forecast_explainability.py` (59), `test_intermittent_demand.py` (55), `test_observability.py` (41), `test_file_classifier.py` (26), `test_file_merger.py` (20)
 
 ## Key Dependencies
 
 Core: polars, statsforecast, mlforecast, lightgbm, xgboost, scikit-learn, fastapi, pyyaml, duckdb
 Dashboard: streamlit, plotly
+Frontend: next, react, typescript, tailwindcss, recharts, @tanstack/react-query, next-auth
 Optional: neuralforecast, pyspark, shap, pyjwt, bcrypt, holidays, delta-spark, azure-identity
 
 ## Documentation Convention

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -211,9 +211,15 @@ Forecasting platforms generate data (metrics, drift alerts, leaderboards) that p
 
 ### Streamlit Dashboard
 
-A forecasting platform that only data scientists can operate is incomplete — demand planners need to see forecasts, compare models, and review exceptions; platform admins need to monitor health and drift. The Streamlit dashboard provides a browser-based interface with four pages mapped to three user personas: Data Onboarding (upload data, assess forecastability, get a recommended config), Backtest Results (model leaderboard with FVA cascade), Forecast Viewer (interactive fan chart with seasonal decomposition), and Platform Health (drift alerts, pipeline manifests, compute cost). It imports platform classes directly — no API round-trip — so a `docker compose up` gives a working demo in under two minutes.
+A forecasting platform that only data scientists can operate is incomplete — demand planners need to see forecasts, compare models, and review exceptions; platform admins need to monitor health and drift. The Streamlit dashboard provides a browser-based interface with eight pages mapped to four user personas: Data Onboarding (upload data, assess forecastability, get a recommended config), Series Explorer (SBC classification, structural breaks, cleansing audit, AI Q&A), SKU Transitions (predecessor matching, planner overrides), Hierarchy Manager (tree visualization, reconciliation), Backtest Results (model leaderboard with FVA cascade), Forecast Viewer (interactive fan chart with seasonal decomposition), Platform Health (drift alerts, pipeline manifests, compute cost), and S&OP Meeting (AI commentary, cross-run comparison, governance, BI export). It imports platform classes directly — no API round-trip — so a `docker compose up` gives a working demo in under two minutes.
 
-*Implementation: `streamlit/` — `app.py`, `pages/1_Data_Onboarding.py`, `pages/2_Backtest_Results.py`, `pages/3_Forecast_Viewer.py`, `pages/4_Platform_Health.py`*
+*Implementation: `streamlit/` — `app.py`, `pages/1_Data_Onboarding.py` through `pages/8_SOP_Meeting.py`*
+
+### Next.js Frontend
+
+The Streamlit dashboard is ideal for rapid prototyping and direct Python class access, but production teams often need a richer client experience — role-based routing, dark mode, responsive layouts, and offline-capable caching. The Next.js frontend mirrors the same 8-page workflow but communicates with the FastAPI backend over REST, using TypeScript, Tailwind CSS, and React Query. Features that require direct Python class access (e.g., hierarchy reconciliation, SKU mapping) show "Coming Soon" placeholders until corresponding API endpoints are added.
+
+*Implementation: `frontend/` — Next.js 15 App Router, `src/app/` (pages), `src/components/` (charts, AI panels, layout), `src/hooks/` (React Query), `src/lib/` (API client, auth, types)*
 
 ### Multi-File Upload Classification
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -35,7 +35,7 @@ Open **http://localhost:8501** in your browser.
 
 ## What to do next
 
-Once the app is open, follow these four pages in order:
+Once the app is open, follow these eight pages in order:
 
 ### 1. Data Onboarding
 
@@ -45,7 +45,19 @@ You'll see: schema detection (columns, frequency, date range), a forecastability
 
 <!-- screenshot: Data Onboarding page with forecastability gauge and config -->
 
-### 2. Run a backtest
+### 2. Series Explorer
+
+Click **Series Explorer** to see demand classification (SBC scatter: smooth, intermittent, erratic, lumpy), structural break detection, data quality audit, and cleansing before/after views. Use the AI Q&A panel to ask questions about individual series.
+
+### 3. SKU Transitions
+
+Click **SKU Transitions** to manage new/discontinued product mapping. The pipeline finds predecessors using attribute matching, naming conventions, curve fitting, and temporal co-movement. Planners can review and override mappings.
+
+### 4. Hierarchy Manager
+
+Click **Hierarchy Manager** to visualize the product/location hierarchy tree, configure aggregation levels, and select reconciliation methods (bottom-up, top-down, MinT, OLS, WLS).
+
+### 5. Run a backtest
 
 After onboarding, run a backtest to evaluate model performance. The command depends on how you started the platform:
 
@@ -63,11 +75,11 @@ python forecasting-platform/scripts/run_backtest.py \
   --lob uploaded
 ```
 
-Then switch to the **Backtest Results** page in the sidebar to see the model leaderboard, FVA cascade chart, and per-series champion map.
+Then switch to the **Backtest Results** page (page 5) in the sidebar to see the model leaderboard, FVA cascade chart, and per-series champion map.
 
 <!-- screenshot: FVA cascade bar chart with ADDS_VALUE / DESTROYS_VALUE annotations -->
 
-### 3. Run a forecast
+### 6. Run a forecast
 
 Similarly, generate predictions:
 
@@ -85,15 +97,19 @@ python forecasting-platform/scripts/run_forecast.py \
   --lob uploaded
 ```
 
-Then switch to the **Forecast Viewer** page to see an interactive chart with P10/P90 confidence intervals. Add actuals to overlay historical data and see the seasonal decomposition (trend, seasonal, residual).
+Then switch to the **Forecast Viewer** page (page 6) to see an interactive chart with P10/P90 confidence intervals. Add actuals to overlay historical data and see the seasonal decomposition (trend, seasonal, residual).
 
 <!-- screenshot: Fan chart with actuals overlay -->
 
-### 4. Platform Health
+### 7. Platform Health
 
 Monitor pipeline runs, drift alerts, data quality, and compute cost. Drift alerts are colour-coded by severity (warning, critical).
 
 <!-- screenshot: Drift alerts table with severity colouring -->
+
+### 8. S&OP Meeting
+
+The final page generates AI executive commentary, enables cross-run forecast comparison, shows model governance (model cards, lineage), and provides BI export for downstream tools.
 
 ## Optional: AI features
 
@@ -102,6 +118,19 @@ Set `ANTHROPIC_API_KEY` to enable Claude-powered features (natural-language expl
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
 ```
+
+## Alternative: Next.js Frontend
+
+If you prefer a production-grade React UI over Streamlit, the Next.js frontend mirrors the same 8-page workflow:
+
+```bash
+cd forecasting-platform/frontend
+npm install
+npm run dev
+# → Open http://localhost:3000
+```
+
+Set `NEXT_PUBLIC_API_URL=http://localhost:8000` in `.env.local`. The FastAPI backend must be running (Path A or B above).
 
 ## Next steps
 

--- a/README.md
+++ b/README.md
@@ -825,14 +825,18 @@ python -m pytest forecasting-platform/tests/ \
 
 ## Streamlit Dashboard
 
-A 4-page interactive dashboard that puts the platform in a browser for data scientists, demand planners, and platform admins.
+An 8-page interactive dashboard that puts the platform in a browser for data scientists, demand planners, and platform admins.
 
 | Page | Persona | What it does |
 |------|---------|-------------|
-| **Data Onboarding** | Data Scientist | Upload CSV → auto-detect schema, hierarchy, forecastability scores → recommended config with optional LLM narrative |
-| **Backtest Results** | Data Scientist / Manager | Model leaderboard, FVA cascade chart (naive → statistical → ML), per-series champion map, layer leaderboard with Keep/Review/Remove |
-| **Forecast Viewer** | Demand Planner | Series selector → forecast line with P10/P90 fan chart, actuals overlay, seasonal decomposition, explainer narrative |
-| **Platform Health** | Platform Admin | Pipeline manifests, drift alerts (severity-coloured), data quality summary, compute cost tracking |
+| **1. Data Onboarding** | Data Scientist | Upload CSV → auto-detect schema, hierarchy, forecastability scores → recommended config with optional LLM narrative |
+| **2. Series Explorer** | Data Scientist | SBC demand classification, structural break detection, data quality audit, cleansing before/after, AI Q&A |
+| **3. SKU Transitions** | Data Scientist / Planner | SKU mapping pipeline (predecessor matching), planner overrides, transition visualization |
+| **4. Hierarchy Manager** | Data Scientist | Hierarchy tree visualization, aggregation, reconciliation method selection (MinT/OLS/WLS) |
+| **5. Backtest Results** | Data Scientist / Manager | Model leaderboard, FVA cascade chart (naive → statistical → ML), per-series champion map, layer leaderboard with Keep/Review/Remove |
+| **6. Forecast Viewer** | Demand Planner | Series selector → forecast line with P10/P90 fan chart, actuals overlay, seasonal decomposition, explainer narrative |
+| **7. Platform Health** | Platform Admin | Pipeline manifests, drift alerts (severity-coloured), data quality summary, compute cost tracking |
+| **8. S&OP Meeting** | Manager / S&OP Leader | AI executive commentary, cross-run forecast comparison, model governance, BI export |
 
 **Run locally:**
 ```bash
@@ -846,6 +850,36 @@ docker compose up
 ```
 
 The Streamlit app imports platform classes directly (DataAnalyzer, MetricStore, FVAAnalyzer, ForecastExplainer, etc.) — no network overhead, no dual-service dependency for development. Charts use Plotly for hover/zoom/pan interactivity.
+
+---
+
+## Next.js Frontend
+
+A production-grade alternative UI built with Next.js 15 (App Router), TypeScript, and Tailwind CSS. Mirrors the same 8-page workflow as the Streamlit dashboard but communicates with the FastAPI backend over REST instead of importing Python classes directly.
+
+| Feature | Details |
+|---------|---------|
+| **Framework** | Next.js 15, React 19, TypeScript 5.7 |
+| **Styling** | Tailwind CSS, Radix UI primitives |
+| **Charts** | Recharts (bar, line, pie, area), Plotly (fan chart, sunburst, SBC scatter) |
+| **Data fetching** | TanStack React Query with typed API client |
+| **Auth** | NextAuth.js wrapping existing JWT/RBAC (5 roles) |
+| **Pages** | Login + 8 workflow pages matching Streamlit |
+| **Dark mode** | Toggle with localStorage persistence |
+
+**Live features** (connected to existing API): file upload/analysis, model leaderboard, drift alerts, audit log, AI explain/triage/config-tuner/commentary.
+
+**Placeholder features** (marked "Coming Soon" until new API endpoints): multi-file classification, pipeline execution, SHAP, hierarchy ops, SKU mapping, BI export.
+
+**Run locally:**
+```bash
+cd forecasting-platform/frontend
+npm install
+npm run dev
+# → Open http://localhost:3000
+```
+
+Set `NEXT_PUBLIC_API_URL=http://localhost:8000` in `.env.local` to connect to the FastAPI backend.
 
 ---
 
@@ -870,6 +904,16 @@ fastapi + uvicorn           # REST API
 ```
 streamlit >= 1.30.0         # Interactive web UI
 plotly >= 5.18.0            # Interactive charts (fan charts, gauges, bar charts)
+```
+
+**Frontend** (Node.js 18+):
+```
+next >= 15.1.0              # React framework (App Router)
+react >= 19.0.0             # UI library
+tailwindcss >= 4.0.0        # Utility-first CSS
+recharts >= 2.15.0          # Chart components
+@tanstack/react-query       # Server state management
+next-auth >= 4.24.0         # Authentication (JWT wrapper)
 ```
 
 **Optional:**

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -86,6 +86,33 @@ streamlit run forecasting-platform/streamlit/app.py
 
 Opens at http://localhost:8501.
 
+### Start the Next.js Frontend (Alternative UI)
+
+Requires Node.js 18+. The frontend connects to the FastAPI backend over REST.
+
+```bash
+cd forecasting-platform/frontend
+npm install
+npm run dev
+```
+
+Opens at http://localhost:3000.
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `NEXT_PUBLIC_API_URL` | `http://localhost:8000` | FastAPI backend URL |
+| `NEXTAUTH_SECRET` | (required for production) | Secret for NextAuth.js session encryption |
+| `NEXTAUTH_URL` | `http://localhost:3000` | Canonical URL of the frontend |
+
+For production builds:
+
+```bash
+npm run build
+npm start          # starts production server on port 3000
+```
+
+> **Note:** The Docker Compose setup currently runs the API and Streamlit dashboard only. To add the Next.js frontend to Docker, a separate service definition is needed in `docker-compose.yml`.
+
 ---
 
 ## Running Pipelines

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -365,3 +365,35 @@ pip install holidays          # for holiday calendar generation
 pip install PyJWT             # for JWT authentication
 pip install anthropic         # for AI features
 ```
+
+---
+
+## Next.js Frontend Issues
+
+### Frontend can't connect to API
+
+**Issue:** Pages show "Network Error" or data doesn't load.
+
+**Fix:**
+1. Ensure the FastAPI backend is running (`python forecasting-platform/scripts/serve.py --port 8000`)
+2. Check `.env.local` has `NEXT_PUBLIC_API_URL=http://localhost:8000`
+3. If running on different hosts/ports, check for CORS — the API must allow the frontend's origin
+
+### `npm install` fails
+
+**Issue:** Dependency installation errors.
+
+**Fix:** Ensure Node.js 18+ is installed (`node --version`). Delete `node_modules` and `package-lock.json`, then retry:
+```bash
+rm -rf node_modules package-lock.json
+npm install
+```
+
+### Login doesn't work
+
+**Issue:** Login form submits but redirects back or shows error.
+
+**Fix:**
+1. Ensure the API is running and `POST /auth/token` returns a response
+2. Check that `NEXTAUTH_SECRET` is set in `.env.local` for production
+3. In development, NextAuth uses a default secret — verify the API returns valid JWT tokens

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -341,7 +341,33 @@ Upload CSV files, auto-detect schema, preview data quality, and get a recommende
 - Forecastability scoring (0-1 scale per series)
 - Recommended YAML config output
 
-### Page 2: Backtest Results
+### Page 2: Series Explorer
+
+Explore individual series characteristics and data quality before modelling.
+
+- **SBC Classification** — ADI vs CV² scatter (smooth, intermittent, erratic, lumpy)
+- **Structural Breaks** — CUSUM/PELT changepoint detection with visual markers
+- **Data Quality Audit** — Gap analysis, zero-run detection, short series warnings
+- **Cleansing Before/After** — Side-by-side comparison of raw vs cleansed data
+- **AI Q&A** — Ask natural language questions about a selected series
+
+### Page 3: SKU Transitions
+
+Manage new and discontinued product mapping.
+
+- **SKU Mapping Pipeline** — Predecessor matching via attribute, naming, curve fitting, temporal co-movement
+- **Planner Overrides** — Manual review and correction of auto-detected mappings
+- **Transition Visualization** — Ramp shape charts showing old→new product share over time
+
+### Page 4: Hierarchy Manager
+
+Configure and visualize the product/location hierarchy.
+
+- **Hierarchy Tree** — Interactive sunburst or tree visualization
+- **Aggregation** — Roll up series to any hierarchy level
+- **Reconciliation** — Select method (bottom-up, top-down, middle-out, OLS, WLS, MinT) and preview results
+
+### Page 5: Backtest Results
 
 Evaluate model performance after running a backtest.
 
@@ -349,8 +375,9 @@ Evaluate model performance after running a backtest.
 - **FVA Cascade** — Accuracy improvement at each model layer
 - **Champion Map** — Which model won for which series/product group
 - **Layer Leaderboard** — Keeps/Review/Remove recommendations per layer
+- **AI Config Tuner** — Claude-powered config recommendations based on backtest results
 
-### Page 3: Forecast Viewer
+### Page 6: Forecast Viewer
 
 Explore forecasts for individual series.
 
@@ -359,12 +386,30 @@ Explore forecasts for individual series.
 - P10/P90 fan chart (prediction intervals)
 - Seasonal decomposition (trend + seasonal + residual)
 - Explainer narrative (natural language description)
+- Forecast comparison (upload external forecast for overlay)
 
-### Page 4: Platform Health
+### Page 7: Platform Health
 
 Monitor pipeline runs and system health.
 
 - Pipeline manifests (provenance for each run)
 - Drift alerts (severity-colored: warning/critical)
+- AI anomaly triage (ranked alerts with impact scores)
+- Audit log viewer
 - Data quality summary (validation + cleansing reports)
 - Compute cost tracking per model
+
+### Page 8: S&OP Meeting
+
+Prepare materials for S&OP review meetings.
+
+- **AI Executive Commentary** — Claude-generated narrative summarizing forecast performance, exceptions, and action items
+- **Cross-Run Comparison** — Overlay forecasts from different pipeline runs
+- **Model Governance** — Model cards, lineage tracking, approval workflows
+- **BI Export** — Download data for Excel, Power BI, or other downstream tools
+
+---
+
+### Next.js Frontend (Alternative)
+
+The same 8-page workflow is also available as a Next.js frontend at `forecasting-platform/frontend/`. It connects to the FastAPI backend over REST and provides dark mode, responsive layout, and role-based navigation. See [DEPLOYMENT.md](DEPLOYMENT.md) for setup instructions.


### PR DESCRIPTION
…rontend

- Fix "4 pages" → "8 pages" across README, CONCEPTS, ARCHITECTURE, QUICKSTART, USER_GUIDE
- Add Next.js frontend sections to README, CONCEPTS, ARCHITECTURE, QUICKSTART, DEPLOYMENT, USER_GUIDE, TROUBLESHOOTING
- Add 4 missing Streamlit page docs (Series Explorer, SKU Transitions, Hierarchy Manager, S&OP Meeting) to USER_GUIDE
- Update ARCHITECTURE.md Mermaid diagrams (system overview, dashboard subgraph, session state flow)
- Fix duplicate test count in CLAUDE.md, add frontend to architecture tree and dependencies
- Add frontend deployment instructions and troubleshooting FAQ entries

https://claude.ai/code/session_01Ws3WScabNmBHngeQjg88jf