### PR TITLE
Enable CORS middleware to support cross-origin requests

### DIFF
--- a/forecasting-product/src/api/app.py
+++ b/forecasting-product/src/api/app.py
@@ -129,6 +129,17 @@ def create_app(
         redoc_url="/redoc",
     )
 
+    # ── CORS — allow cross-origin requests from frontend (Next.js / Streamlit)
+    from fastapi.middleware.cors import CORSMiddleware
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
     # ── Shared state (attached to app for testability) ─────────────────────
     app.state.data_dir    = Path(data_dir)
     app.state.metrics_dir = Path(metrics_dir)


### PR DESCRIPTION
## Summary
Added CORS (Cross-Origin Resource Sharing) middleware to the FastAPI application to allow cross-origin requests from frontend clients (Next.js and Streamlit).

## Key Changes
- Imported `CORSMiddleware` from `fastapi.middleware.cors`
- Configured and registered CORS middleware with permissive settings:
  - `allow_origins=["*"]` — accepts requests from any origin
  - `allow_credentials=True` — allows credentials in cross-origin requests
  - `allow_methods=["*"]` — permits all HTTP methods
  - `allow_headers=["*"]` — allows all headers

## Implementation Details
The middleware is added early in the application initialization (after OpenAPI configuration) to ensure CORS headers are applied to all API responses. The permissive configuration allows the frontend applications to communicate with the API without origin restrictions.

https://claude.ai/code/session_01VctKA8956k9F9fP9xHti3s