### PR TITLE
Fix CSV parsing failure on mixed-type columns

### DIFF
--- a/forecasting-product/streamlit/utils.py
+++ b/forecasting-product/streamlit/utils.py
@@ -68,14 +68,14 @@ def _read_csv_robust(source: io.BytesIO) -> pl.DataFrame:
 
     First attempts with ``infer_schema_length=10_000`` so Polars samples
     enough rows to detect mixed-type columns (e.g. StateHoliday containing
-    both integers and strings).  If that still fails, retries scanning
-    *all* rows (``infer_schema_length=0``) as a last resort.
+    both integers and strings).  If that still fails, retries with
+    ``infer_schema_length=None`` which scans *every* row for type inference.
     """
     try:
         return pl.read_csv(source, try_parse_dates=True, infer_schema_length=10_000)
     except Exception:
         source.seek(0)
-        return pl.read_csv(source, try_parse_dates=True, infer_schema_length=0)
+        return pl.read_csv(source, try_parse_dates=True, infer_schema_length=None)
 
 
 def load_uploaded_csv(uploaded_file) -> pl.DataFrame:
@@ -106,11 +106,7 @@ def load_sample_data() -> pl.DataFrame:
     """
     if SAMPLE_DATA.exists():
         try:
-            return pl.read_csv(
-                str(SAMPLE_DATA),
-                try_parse_dates=True,
-                infer_schema_length=10000,
-            )
+            return _read_csv_robust(io.BytesIO(SAMPLE_DATA.read_bytes()))
         except Exception:
             pass  # fall through to synthetic
     return _generate_synthetic_retail()


### PR DESCRIPTION
## Summary
- Fix Polars CSV parsing error ("could not parse `a` as dtype `i64` at column 'StateHoliday'") when uploading files with mixed-type columns (e.g., Rossmann `train.csv`)
- Add `_read_csv_robust()` helper that tries `infer_schema_length=10_000` first, then falls back to `infer_schema_length=None` (full-scan inference) for correct type detection
- Update `load_sample_data()` to reuse the same robust reader
- Improve error message in Data Onboarding page with actionable hints

## Test plan
- [ ] Upload Rossmann `train.csv` via Data Onboarding — should load without error
- [ ] Verify `StateHoliday` column is inferred as `String` (not `i64`)
- [ ] Click "Use sample data" button — should also load correctly
- [ ] Upload a clean CSV without mixed types — should still work on first attempt (no fallback needed)

https://claude.ai/code/session_01NJTT65fsvDKTHPBbJQyuE8