### PR TITLE
Shared LOB state, gated dev auth, no-data guides

### DIFF
--- a/forecasting-product/frontend/src/app/backtest/page.tsx
+++ b/forecasting-product/frontend/src/app/backtest/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useLob } from "@/providers/lob-provider";
 import { LeaderboardBar } from "@/components/charts/leaderboard-bar";
 import { FVACascade } from "@/components/charts/fva-cascade";
 import { CalibrationPlot } from "@/components/charts/calibration-plot";
 import { ConfigTunerPanel } from "@/components/ai/config-tuner-panel";
 import { MetricCard } from "@/components/shared/metric-card";
 import { ErrorDisplay } from "@/components/shared/error-boundary";
+import { NoDataGuide } from "@/components/shared/no-data-guide";
 import { ChartSkeleton } from "@/components/shared/loading-skeleton";
 import { DataTable } from "@/components/data/data-table";
 import { useLeaderboard } from "@/hooks/use-leaderboard";
@@ -15,7 +17,7 @@ import { formatPct } from "@/lib/utils";
 import type { FVAResponse, CalibrationResponse, ShapResponse } from "@/lib/types";
 
 export default function BacktestPage() {
-  const [lob, setLob] = useState("retail");
+  const { lob, setLob } = useLob();
   const [runType, setRunType] = useState("backtest");
   const { data, isLoading, error, refetch } = useLeaderboard(lob, runType);
 
@@ -122,7 +124,11 @@ export default function BacktestPage() {
       <section className="space-y-3">
         <h2 className="text-lg font-semibold">Model Leaderboard</h2>
         {isLoading && <ChartSkeleton />}
-        {error && <ErrorDisplay message={error.message} onRetry={() => refetch()} />}
+        {error && (error.message.includes("404") ? (
+          <NoDataGuide lob={lob} dataType="backtest" />
+        ) : (
+          <ErrorDisplay message={error.message} onRetry={() => refetch()} />
+        ))}
         {data && (
           <>
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">

--- a/forecasting-product/frontend/src/app/forecast/page.tsx
+++ b/forecasting-product/frontend/src/app/forecast/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { useLob } from "@/providers/lob-provider";
 import { TimeSeriesLine } from "@/components/charts/time-series-line";
 import { FanChart } from "@/components/charts/fan-chart";
 import { NLQueryPanel } from "@/components/ai/nl-query-panel";
 import { MetricCard } from "@/components/shared/metric-card";
 import { ErrorDisplay } from "@/components/shared/error-boundary";
+import { NoDataGuide } from "@/components/shared/no-data-guide";
 import { ChartSkeleton } from "@/components/shared/loading-skeleton";
 import { DecompositionPanel } from "@/components/forecast/decomposition-panel";
 import { ComparisonPanel } from "@/components/forecast/comparison-panel";
@@ -15,7 +17,7 @@ import { formatNumber } from "@/lib/utils";
 import { COLORS } from "@/lib/constants";
 
 export default function ForecastPage() {
-  const [lob, setLob] = useState("retail");
+  const { lob, setLob } = useLob();
   const [selectedSeries, setSelectedSeries] = useState("");
   const { data, isLoading, error, refetch } = useForecast(lob);
 
@@ -94,9 +96,17 @@ export default function ForecastPage() {
       </div>
 
       {isLoading && <ChartSkeleton />}
-      {error && <ErrorDisplay message={error.message} onRetry={() => refetch()} />}
+      {error && (error.message.includes("404") ? (
+        <NoDataGuide lob={lob} dataType="forecast" />
+      ) : (
+        <ErrorDisplay message={error.message} onRetry={() => refetch()} />
+      ))}
 
-      {data && (
+      {data && data.points.length === 0 && (
+        <NoDataGuide lob={lob} dataType="forecast" />
+      )}
+
+      {data && data.points.length > 0 && (
         <>
           {/* Summary */}
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">

--- a/forecasting-product/frontend/src/app/health/page.tsx
+++ b/forecasting-product/frontend/src/app/health/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useLob } from "@/providers/lob-provider";
+import { NoDataGuide } from "@/components/shared/no-data-guide";
 import { DriftHistogram } from "@/components/charts/drift-histogram";
 import { TriagePanel } from "@/components/ai/triage-panel";
 import { DataTable } from "@/components/data/data-table";
@@ -144,7 +146,7 @@ function ManifestsTabContent({ lob }: { lob: string }) {
 }
 
 export default function HealthPage() {
-  const [lob, setLob] = useState("retail");
+  const { lob, setLob } = useLob();
   const [activeTab, setActiveTab] = useState<"drift" | "audit" | "manifests">("drift");
   const [auditAction, setAuditAction] = useState("");
   const [auditLimit, setAuditLimit] = useState(100);
@@ -204,9 +206,11 @@ export default function HealthPage() {
       {activeTab === "drift" && (
         <div className="space-y-6">
           {drift.isLoading && <ChartSkeleton />}
-          {drift.error && (
+          {drift.error && (drift.error.message.includes("404") ? (
+            <NoDataGuide lob={lob} dataType="drift" />
+          ) : (
             <ErrorDisplay message={drift.error.message} onRetry={() => drift.refetch()} />
-          )}
+          ))}
           {drift.data && (
             <>
               <div className="grid grid-cols-3 gap-3">

--- a/forecasting-product/frontend/src/app/layout.tsx
+++ b/forecasting-product/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from "@/components/layout/sidebar";
 import { Header } from "@/components/layout/header";
 import { QueryProvider } from "@/providers/query-provider";
 import { AuthProvider } from "@/providers/auth-provider";
+import { LobProvider } from "@/providers/lob-provider";
 
 export const metadata: Metadata = {
   title: "Forecasting Product",
@@ -20,13 +21,15 @@ export default function RootLayout({
       <body className="font-sans antialiased">
         <QueryProvider>
           <AuthProvider>
-            <div className="flex h-screen overflow-hidden">
-              <Sidebar />
-              <div className="flex flex-1 flex-col overflow-hidden">
-                <Header />
-                <main className="flex-1 overflow-y-auto p-6">{children}</main>
+            <LobProvider>
+              <div className="flex h-screen overflow-hidden">
+                <Sidebar />
+                <div className="flex flex-1 flex-col overflow-hidden">
+                  <Header />
+                  <main className="flex-1 overflow-y-auto p-6">{children}</main>
+                </div>
               </div>
-            </div>
+            </LobProvider>
           </AuthProvider>
         </QueryProvider>
       </body>

--- a/forecasting-product/frontend/src/app/series-explorer/page.tsx
+++ b/forecasting-product/frontend/src/app/series-explorer/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useState, useEffect, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
+import { useLob } from "@/providers/lob-provider";
 import { NLQueryPanel } from "@/components/ai/nl-query-panel";
 import { MetricCard } from "@/components/shared/metric-card";
 import { DataTable } from "@/components/data/data-table";
@@ -9,6 +10,7 @@ import { Skeleton } from "@/components/shared/loading-skeleton";
 import { DEMAND_CLASS_COLORS } from "@/lib/constants";
 import { BreakTimeline } from "@/components/charts/break-timeline";
 import { CleansingOverlay } from "@/components/charts/cleansing-overlay";
+import { NoDataGuide } from "@/components/shared/no-data-guide";
 import { api } from "@/lib/api-client";
 import type {
   SeriesItem,
@@ -51,7 +53,14 @@ export default function SeriesExplorerPage() {
 
 function SeriesExplorerContent() {
   const searchParams = useSearchParams();
-  const [lob, setLob] = useState(searchParams.get("lob") || "retail");
+  const { lob: sharedLob, setLob: setSharedLob } = useLob();
+  const [lob, setLobLocal] = useState(searchParams.get("lob") || sharedLob);
+
+  // Sync local changes to shared context
+  const setLob = useCallback((value: string) => {
+    setLobLocal(value);
+    setSharedLob(value);
+  }, [setSharedLob]);
 
   // Series list state
   const [seriesList, setSeriesList] = useState<SeriesItem[]>([]);
@@ -208,7 +217,11 @@ function SeriesExplorerContent() {
           </>
         ) : seriesError ? (
           <div className="col-span-4">
-            <ErrorMessage message={seriesError} />
+            {seriesError.includes("404") ? (
+              <NoDataGuide lob={lob} dataType="series" />
+            ) : (
+              <ErrorMessage message={seriesError} />
+            )}
           </div>
         ) : (
           <>

--- a/forecasting-product/frontend/src/app/sop/page.tsx
+++ b/forecasting-product/frontend/src/app/sop/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
 import { CommentaryPanel } from "@/components/ai/commentary-panel";
+import { useLob } from "@/providers/lob-provider";
 import { MetricCard } from "@/components/shared/metric-card";
 import { CrossRunComparisonPanel } from "@/components/forecast/cross-run-comparison-panel";
 import { ModelCardsPanel } from "@/components/governance/model-cards-panel";
@@ -9,7 +9,7 @@ import { LineagePanel } from "@/components/governance/lineage-panel";
 import { BIExportPanel } from "@/components/governance/bi-export-panel";
 
 export default function SOPPage() {
-  const [lob, setLob] = useState("retail");
+  const { lob, setLob } = useLob();
 
   return (
     <div className="mx-auto max-w-6xl space-y-8">

--- a/forecasting-product/frontend/src/components/shared/no-data-guide.tsx
+++ b/forecasting-product/frontend/src/components/shared/no-data-guide.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Info } from "lucide-react";
+import Link from "next/link";
+
+interface NoDataGuideProps {
+  lob: string;
+  dataType: "forecast" | "backtest" | "series" | "metrics" | "drift";
+}
+
+const GUIDES: Record<
+  NoDataGuideProps["dataType"],
+  { title: string; message: string; nextStep: string; nextHref: string }
+> = {
+  forecast: {
+    title: "No forecast data yet",
+    message: "Run a forecast pipeline first to generate predictions for this LOB.",
+    nextStep: "Go to Data Onboarding",
+    nextHref: "/data-onboarding",
+  },
+  backtest: {
+    title: "No backtest results yet",
+    message: "Run a backtest to evaluate models and generate a leaderboard for this LOB.",
+    nextStep: "Go to Data Onboarding",
+    nextHref: "/data-onboarding",
+  },
+  series: {
+    title: "No series data found",
+    message: "Upload actuals data to start exploring series for this LOB.",
+    nextStep: "Go to Data Onboarding",
+    nextHref: "/data-onboarding",
+  },
+  metrics: {
+    title: "No metric data available",
+    message: "Metrics are generated when you run a backtest. Run one first for this LOB.",
+    nextStep: "Go to Data Onboarding",
+    nextHref: "/data-onboarding",
+  },
+  drift: {
+    title: "No drift alerts",
+    message: "Drift detection requires backtest metrics. Run a backtest first for this LOB.",
+    nextStep: "Go to Data Onboarding",
+    nextHref: "/data-onboarding",
+  },
+};
+
+export function NoDataGuide({ lob, dataType }: NoDataGuideProps) {
+  const guide = GUIDES[dataType];
+
+  return (
+    <div className="rounded-lg border border-blue-200 bg-blue-50/50 p-6 text-center dark:border-blue-900 dark:bg-blue-950/20">
+      <Info className="mx-auto mb-3 h-8 w-8 text-blue-500" />
+      <h3 className="font-semibold text-blue-700 dark:text-blue-400">{guide.title}</h3>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {guide.message}
+      </p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        LOB: <span className="font-mono">{lob}</span>
+      </p>
+      <Link
+        href={guide.nextHref}
+        className="mt-4 inline-block rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 transition-colors"
+      >
+        {guide.nextStep}
+      </Link>
+    </div>
+  );
+}

--- a/forecasting-product/frontend/src/providers/lob-provider.tsx
+++ b/forecasting-product/frontend/src/providers/lob-provider.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  type ReactNode,
+} from "react";
+
+const LOB_STORAGE_KEY = "selected_lob";
+const DEFAULT_LOB = "retail";
+
+interface LobContextValue {
+  lob: string;
+  setLob: (lob: string) => void;
+}
+
+const LobContext = createContext<LobContextValue>({
+  lob: DEFAULT_LOB,
+  setLob: () => {},
+});
+
+export function LobProvider({ children }: { children: ReactNode }) {
+  const [lob, setLobState] = useState(DEFAULT_LOB);
+
+  // Restore from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(LOB_STORAGE_KEY);
+    if (stored) {
+      setLobState(stored);
+    }
+  }, []);
+
+  const setLob = useCallback((value: string) => {
+    setLobState(value);
+    localStorage.setItem(LOB_STORAGE_KEY, value);
+  }, []);
+
+  return (
+    <LobContext.Provider value={{ lob, setLob }}>
+      {children}
+    </LobContext.Provider>
+  );
+}
+
+export function useLob() {
+  return useContext(LobContext);
+}

--- a/forecasting-product/src/api/app.py
+++ b/forecasting-product/src/api/app.py
@@ -207,22 +207,24 @@ def create_app(
         """Liveness probe — returns 200 OK when the service is running."""
         return HealthResponse(status="ok", version=_API_VERSION)
 
-    @app.post("/auth/token", tags=["auth"])
-    def create_auth_token(
-        username: str = Query(..., description="Username"),
-        role: str = Query("viewer", description="Role"),
-    ):
-        """Issue a JWT token (development endpoint)."""
-        if not auth_enabled:
-            return {"detail": "Auth is disabled. All endpoints are open."}
-        from ..auth.token import create_token
-        token = create_token(
-            user_id=username,
-            email=f"{username}@example.com",
-            role=role,
-            secret_key=jwt_secret,
-        )
-        return {"access_token": token, "token_type": "bearer"}
+    # Dev token endpoint — only registered when API_DEV_MODE=1
+    if os.environ.get("API_DEV_MODE", "1" if not auth_enabled else "0") == "1":
+        @app.post("/auth/token", tags=["auth"])
+        def create_auth_token(
+            username: str = Query(..., description="Username"),
+            role: str = Query("viewer", description="Role"),
+        ):
+            """Issue a JWT token (development only — set API_DEV_MODE=0 to disable)."""
+            if not auth_enabled:
+                return {"detail": "Auth is disabled. All endpoints are open."}
+            from ..auth.token import create_token
+            token = create_token(
+                user_id=username,
+                email=f"{username}@example.com",
+                role=role,
+                secret_key=jwt_secret,
+            )
+            return {"access_token": token, "token_type": "bearer"}
 
     @app.get("/audit", tags=["audit"])
     def get_audit_log(


### PR DESCRIPTION
## Summary

- **Shared LOB selection across pages**: New `LobProvider` context persists selected LOB in localStorage. All 5 LOB-dependent pages (forecast, backtest, series-explorer, health, sop) use `useLob()` instead of independent `useState("retail")`. User selects LOB once, it carries everywhere.
- **Gated dev auth endpoint**: `POST /auth/token` now only registers when `API_DEV_MODE=1`. Defaults to enabled in dev, disabled when auth is on. Set `API_DEV_MODE=0` in production to remove the endpoint entirely.
- **No-data-yet guide indicators**: New `NoDataGuide` component shows friendly blue info card with LOB name and "Go to Data Onboarding" link when 404 errors occur. Added to forecast, backtest, series-explorer, and health pages.

Also includes prior commit: security hardening (path traversal prevention, upload size limits, narrowed exceptions, API retry, JWT expiry checks, 26 security tests).

## Test plan

- [x] Next.js frontend builds cleanly
- [x] 56/57 API tests pass (1 pre-existing `test_fva` failure)
- [x] 26/26 security tests pass
- [ ] Manual: change LOB on one page, navigate to another — LOB persists
- [ ] Manual: set `API_DEV_MODE=0`, verify `/auth/token` returns 404
- [ ] Manual: enter nonexistent LOB on forecast page — see NoDataGuide with link

https://claude.ai/code/session_01EcVS8mryLGwYrKpt9twP4a