### PR TITLE
fix: frontend E2E pipeline fixes + weekly demo dataset

### DIFF
--- a/forecasting-product/configs/weekly_demo_config.yaml
+++ b/forecasting-product/configs/weekly_demo_config.yaml
@@ -1,0 +1,35 @@
+# Weekly retail demo config — fast E2E testing
+# 5 series, 3 models, 12-week horizon, 2 backtest folds
+
+lob: "weekly_retail"
+
+forecast:
+  frequency: "W"
+  horizon_weeks: 12
+  target_column: "quantity"
+  time_column: "week"
+  series_id_column: "series_id"
+  forecasters:
+    - "naive_seasonal"
+    - "auto_ets"
+    - "lgbm_direct"
+  quantiles: [0.1, 0.5, 0.9]
+  sparse_detection: false
+
+backtest:
+  n_folds: 2
+  val_periods: 4
+  primary_metric: "wmape"
+  secondary_metric: "normalized_bias"
+  selection_strategy: "best_metric"
+
+data_quality:
+  validation:
+    enabled: true
+  cleansing:
+    enabled: true
+    outlier_method: "iqr"
+
+output:
+  metrics_path: "data/metrics"
+  forecast_path: "data/forecasts"

--- a/forecasting-product/frontend/src/app/data-onboarding/page.tsx
+++ b/forecasting-product/frontend/src/app/data-onboarding/page.tsx
@@ -18,10 +18,12 @@ import type { AnalysisResponse } from "@/lib/types";
 export default function DataOnboardingPage() {
   const [lobName, setLobName] = useState("retail");
   const [llmEnabled, setLlmEnabled] = useState(false);
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const analyzeMutation = useAnalyze();
   const result: AnalysisResponse | undefined = analyzeMutation.data;
 
   const handleFileSelect = (file: File) => {
+    setUploadedFile(file);
     analyzeMutation.mutate({ file, lobName, llmEnabled });
   };
 
@@ -207,7 +209,7 @@ export default function DataOnboardingPage() {
           <MultiFilePanel lobName={lobName} />
 
           {/* Pipeline Execution */}
-          <PipelineExecutionPanel lobName={lobName} />
+          <PipelineExecutionPanel lobName={lobName} initialFile={uploadedFile} configYaml={result.recommended_config_yaml} />
         </>
       )}
 

--- a/forecasting-product/frontend/src/components/pipeline/pipeline-execution-panel.tsx
+++ b/forecasting-product/frontend/src/components/pipeline/pipeline-execution-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { FileUpload } from "@/components/data/file-upload";
 import { DataTable } from "@/components/data/data-table";
 import { MetricCard } from "@/components/shared/metric-card";
@@ -10,16 +10,26 @@ import { useAsyncOperation } from "@/hooks/use-async-operation";
 import { api } from "@/lib/api-client";
 import type { PipelineRunResponse } from "@/lib/types";
 
-export function PipelineExecutionPanel({ lobName }: { lobName: string }) {
-  const [pipelineFile, setPipelineFile] = useState<File | null>(null);
+export function PipelineExecutionPanel({ lobName, initialFile, configYaml }: { lobName: string; initialFile?: File | null; configYaml?: string }) {
+  const [pipelineFile, setPipelineFile] = useState<File | null>(initialFile ?? null);
+
+  // Sync with the initialFile prop when it changes (e.g., user uploaded a file in the parent section)
+  useEffect(() => {
+    if (initialFile) setPipelineFile(initialFile);
+  }, [initialFile]);
   const backtest = useAsyncOperation<PipelineRunResponse>();
   const forecast = useAsyncOperation<PipelineRunResponse>();
   const [error, setError] = useState<string | null>(null);
 
+  const makeConfigFile = (): File | undefined => {
+    if (!configYaml) return undefined;
+    return new File([configYaml], "config.yaml", { type: "text/yaml" });
+  };
+
   const handleRunBacktest = () => {
     if (!pipelineFile) return;
     setError(null);
-    backtest.run(() => api.runBacktest(pipelineFile, lobName)).catch((err) =>
+    backtest.run(() => api.runBacktest(pipelineFile, lobName, makeConfigFile())).catch((err) =>
       setError(err instanceof Error ? err.message : "Backtest failed")
     );
   };
@@ -27,7 +37,8 @@ export function PipelineExecutionPanel({ lobName }: { lobName: string }) {
   const handleRunForecast = () => {
     if (!pipelineFile) return;
     setError(null);
-    forecast.run(() => api.runForecast(pipelineFile, lobName)).catch((err) =>
+    const configFile = makeConfigFile();
+    forecast.run(() => api.runForecast(pipelineFile, lobName, { configFile })).catch((err) =>
       setError(err instanceof Error ? err.message : "Forecast failed")
     );
   };
@@ -45,6 +56,11 @@ export function PipelineExecutionPanel({ lobName }: { lobName: string }) {
         onFileSelect={(file) => setPipelineFile(file)}
         label="Pipeline Data File"
       />
+      {pipelineFile && (
+        <p className="text-xs text-muted-foreground">
+          Using: <span className="font-medium">{pipelineFile.name}</span> ({(pipelineFile.size / 1024).toFixed(1)} KB)
+        </p>
+      )}
       <div className="flex flex-wrap gap-3">
         <button
           onClick={handleRunBacktest}

--- a/forecasting-product/frontend/test-weekly-e2e.js
+++ b/forecasting-product/frontend/test-weekly-e2e.js
@@ -1,0 +1,193 @@
+/**
+ * E2E test — Visit all UI pages with weekly_retail LOB data and capture screenshots.
+ * 
+ * Prerequisites:
+ *   - Backend running on :8000 with backtest + forecast data for "weekly_retail"
+ *   - Frontend running on :3000
+ *   - npx playwright install chromium (already done)
+ *
+ * Run: node test-weekly-e2e.js
+ */
+const { chromium } = require('playwright');
+const path = require('path');
+
+const BASE = 'http://localhost:3000';
+const RESULTS_DIR = path.join(__dirname, 'test-results', 'weekly');
+const LOB = 'weekly_retail';
+
+async function ensureDir(dir) {
+  const fs = require('fs');
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+async function screenshot(page, name) {
+  await page.screenshot({ path: path.join(RESULTS_DIR, `${name}.png`), fullPage: true });
+  console.log(`  📸 ${name}.png`);
+}
+
+async function main() {
+  await ensureDir(RESULTS_DIR);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+  const page = await context.newPage();
+
+  // ──────────────── 1. DATA ONBOARDING ────────────────
+  console.log('\n1. Data Onboarding — Upload + Analyze');
+  await page.goto(`${BASE}/data-onboarding`);
+  await page.waitForLoadState('networkidle');
+
+  // Set LOB name
+  const lobInput = page.locator('input[type="text"]').first();
+  await lobInput.fill(LOB);
+
+  // Upload CSV — this auto-triggers analysis via onFileSelect
+  const csvPath = path.resolve(__dirname, '..', 'data', 'demo', 'weekly_retail.csv');
+  const fileInput = page.locator('input[type="file"]').first();
+  await fileInput.setInputFiles(csvPath);
+  console.log('  File uploaded, analysis auto-started...');
+
+  // Wait for analysis results to appear (auto-triggered by file select)
+  await page.waitForSelector('text=/Schema Detection|Forecastability|series/i', { timeout: 60000 });
+  await page.waitForTimeout(1500);
+  await screenshot(page, '01-onboarding-analyzed-top');
+
+  // Scroll to see forecastability + demand classification
+  await page.evaluate(() => window.scrollBy(0, 600));
+  await page.waitForTimeout(500);
+  await screenshot(page, '02-onboarding-forecastability');
+
+  // Scroll more to see config reasoning + hypotheses
+  await page.evaluate(() => window.scrollBy(0, 600));
+  await page.waitForTimeout(500);
+  await screenshot(page, '03-onboarding-config');
+
+  // Scroll to bottom — Pipeline Execution panel
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.waitForTimeout(500);
+  await screenshot(page, '04-onboarding-pipeline-panel');
+
+  // ──────────────── 1b. RUN BACKTEST FROM UI ────────────────
+  console.log('\n1b. Pipeline Execution — Run Backtest from UI');
+  // The pipeline panel now auto-receives the uploaded file
+  // Scroll to the pipeline panel and wait for file to be ready
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.waitForTimeout(1000);
+  
+  const backtestBtn = page.getByRole('button', { name: /run backtest/i });
+  if (await backtestBtn.isVisible()) {
+    // Wait for the button to become enabled (file should be auto-loaded)
+    try {
+      await backtestBtn.waitFor({ state: 'attached', timeout: 5000 });
+      const isDisabled = await backtestBtn.isDisabled();
+      if (isDisabled) {
+        console.log('  ⚠️ Run Backtest button still disabled — file may not be passed to Pipeline panel');
+        await screenshot(page, '05-pipeline-btn-disabled');
+      } else {
+        await backtestBtn.click();
+        console.log('  Running backtest... (this may take a while)');
+        try {
+          await page.waitForSelector('text=/completed|champion|Backtest Result/i', { timeout: 180000 });
+          await page.waitForTimeout(1500);
+          await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+          await page.waitForTimeout(500);
+          await screenshot(page, '05-pipeline-backtest-done');
+        } catch (e) {
+          console.log('  ⚠️ Backtest completion not detected in time');
+          await screenshot(page, '05-pipeline-backtest-timeout');
+        }
+      }
+    } catch (e) {
+      console.log('  ⚠️ Run Backtest button not ready');
+    }
+  } else {
+    console.log('  ⚠️ Run Backtest button not found');
+  }
+
+  // ──────────────── 2. BACKTEST RESULTS ────────────────
+  console.log('\n2. Backtest Results');
+  await page.goto(`${BASE}/backtest`);
+  await page.waitForLoadState('networkidle');
+
+  // Enter LOB name and load
+  const btLob = page.locator('input[type="text"]').first();
+  await btLob.fill(LOB);
+  const loadBtn = page.getByRole('button', { name: 'Load', exact: true });
+  if (await loadBtn.isVisible()) {
+    await loadBtn.click();
+    // Wait for the leaderboard data to render (Recharts + metric cards)
+    try {
+      await page.waitForSelector('text=/Model Leaderboard/i', { timeout: 5000 });
+      // Give Recharts time to render the chart
+      await page.waitForTimeout(3000);
+    } catch (e) {
+      console.log('  ⚠️ Leaderboard data not detected');
+    }
+  }
+  await screenshot(page, '06-backtest-loaded');
+
+  // Scroll for full leaderboard
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.waitForTimeout(500);
+  await screenshot(page, '07-backtest-bottom');
+
+  // ──────────────── 3. FORECAST VIEWER ────────────────
+  console.log('\n3. Forecast Viewer');
+  await page.goto(`${BASE}/forecast`);
+  await page.waitForLoadState('networkidle');
+
+  const fcLob = page.locator('input[type="text"]').first();
+  await fcLob.fill(LOB);
+  const loadFcBtn = page.getByRole('button', { name: 'Load Forecasts', exact: true });
+  if (await loadFcBtn.isVisible()) {
+    await loadFcBtn.click();
+    try {
+      // Wait for forecast data to load and render (Recharts needs time)
+      await page.waitForSelector('text=/Series Count|Forecast Origin|forecast/i', { timeout: 15000 });
+      await page.waitForTimeout(3000);
+    } catch (e) {
+      console.log('  ⚠️ Forecast data not detected');
+    }
+  }
+  await screenshot(page, '08-forecast-loaded');
+
+  // Scroll for more content
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.waitForTimeout(500);
+  await screenshot(page, '09-forecast-bottom');
+
+  // ──────────────── 4. SERIES EXPLORER ────────────────
+  console.log('\n4. Series Explorer');
+  await page.goto(`${BASE}/series-explorer`);
+  await page.waitForLoadState('networkidle');
+  await screenshot(page, '10-series-explorer');
+
+  // ──────────────── 5. HIERARCHY ────────────────
+  console.log('\n5. Hierarchy Manager');
+  await page.goto(`${BASE}/hierarchy`);
+  await page.waitForLoadState('networkidle');
+  await screenshot(page, '11-hierarchy');
+
+  // ──────────────── 6. SKU TRANSITIONS ────────────────
+  console.log('\n6. SKU Transitions');
+  await page.goto(`${BASE}/sku-transitions`);
+  await page.waitForLoadState('networkidle');
+  await screenshot(page, '12-sku-transitions');
+
+  // ──────────────── 7. PLATFORM HEALTH ────────────────
+  console.log('\n7. Platform Health');
+  await page.goto(`${BASE}/health`);
+  await page.waitForLoadState('networkidle');
+  await screenshot(page, '13-health');
+
+  // ──────────────── 8. S&OP MEETING ────────────────
+  console.log('\n8. S&OP Meeting');
+  await page.goto(`${BASE}/sop`);
+  await page.waitForLoadState('networkidle');
+  await screenshot(page, '14-sop');
+
+  // ──────────────── DONE ────────────────
+  await browser.close();
+  console.log(`\n✅ All screenshots saved to ${RESULTS_DIR}`);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/forecasting-product/scripts/generate_weekly_demo.py
+++ b/forecasting-product/scripts/generate_weekly_demo.py
@@ -1,0 +1,66 @@
+"""Generate a small weekly retail demo dataset for E2E UI testing.
+
+Creates 5 weekly retail series with realistic patterns:
+  - trend, seasonality, noise, promotions
+  - 2 years of history (~104 weeks)
+  - Varying demand levels (high, medium, low)
+
+Output: data/demo/weekly_retail.csv
+"""
+import math
+import random
+import csv
+from datetime import datetime, timedelta
+from pathlib import Path
+
+random.seed(42)
+
+SERIES = [
+    {"id": "GROCERY_001", "category": "grocery", "base": 800, "trend": 2.0, "noise": 0.10},
+    {"id": "DAIRY_002",   "category": "dairy",   "base": 400, "trend": 1.0, "noise": 0.12},
+    {"id": "SNACKS_003",  "category": "snacks",  "base": 250, "trend": 0.5, "noise": 0.08},
+    {"id": "BAKERY_004",  "category": "bakery",  "base": 150, "trend": -0.3,"noise": 0.15},
+    {"id": "FROZEN_005",  "category": "frozen",  "base": 600, "trend": 1.5, "noise": 0.09},
+]
+
+N_WEEKS = 104  # 2 years
+START = datetime(2022, 1, 3)  # Monday
+
+out_dir = Path(__file__).resolve().parent.parent / "data" / "demo"
+out_dir.mkdir(parents=True, exist_ok=True)
+
+rows = []
+for s in SERIES:
+    for w in range(N_WEEKS):
+        dt = START + timedelta(weeks=w)
+        # Trend
+        value = s["base"] + s["trend"] * w
+        # Annual seasonality (peak in Nov-Dec for holidays)
+        week_of_year = dt.isocalendar()[1]
+        seasonal = 0.15 * math.sin(2 * math.pi * (week_of_year - 10) / 52)
+        value *= (1 + seasonal)
+        # Holiday bump (weeks 47-52)
+        if 47 <= week_of_year <= 52:
+            value *= 1.25
+        # Random promo (~15% of weeks)
+        promo = 1 if random.random() < 0.15 else 0
+        if promo:
+            value *= 1.20
+        # Noise
+        value *= (1 + random.gauss(0, s["noise"]))
+        value = max(0, round(value))
+        rows.append({
+            "series_id": s["id"],
+            "week": dt.strftime("%Y-%m-%d"),
+            "quantity": value,
+            "category": s["category"],
+            "promo": promo,
+        })
+
+out_file = out_dir / "weekly_retail.csv"
+with open(out_file, "w", newline="") as f:
+    writer = csv.DictWriter(f, fieldnames=["series_id", "week", "quantity", "category", "promo"])
+    writer.writeheader()
+    writer.writerows(rows)
+
+print(f"Wrote {len(rows)} rows ({len(SERIES)} series × {N_WEEKS} weeks) to {out_file}")

--- a/forecasting-product/src/pipeline/forecast.py
+++ b/forecasting-product/src/pipeline/forecast.py
@@ -161,6 +161,9 @@ class ForecastPipeline:
                 id_col=fc.series_id_column,
                 time_col=fc.time_column,
             )
+        # Tag forecast rows with the model name
+        if "model" not in forecast.columns:
+            forecast = forecast.with_columns(pl.lit(forecaster.name).alias("model"))
         self._emitter.gauge("forecast_rows", float(len(forecast)))
 
         # Step 4b: Quantile forecasts (if configured)
@@ -333,7 +336,7 @@ class ForecastPipeline:
         self, forecast: pl.DataFrame, forecast_origin: Optional[date]
     ) -> pl.DataFrame:
         """Write forecast to output path."""
-        output_path = Path(self.config.output.forecast_path)
+        output_path = Path(self.config.output.forecast_path) / self.config.lob
         output_path.mkdir(parents=True, exist_ok=True)
 
         origin_str = (


### PR DESCRIPTION
Bug fixes (backend):
- forecast.py: save forecast parquet into {lob}/ subdirectory (GET /forecast/{lob} expected subdirectory but pipeline wrote flat)
- forecast.py: add 'model' column to forecast output (Forecast Viewer was showing 'Model: unknown')

UX fixes (frontend):
- PipelineExecutionPanel: accept initialFile + configYaml props, auto-pass uploaded file and recommended YAML config to backtest/forecast
- data-onboarding page: track uploaded file in state, pass it and recommended config YAML to PipelineExecutionPanel

Demo data & tooling:
- generate_weekly_demo.py: 5 weekly retail series, 2 years, realistic patterns
- weekly_demo_config.yaml: 3 models, 2 folds, 12-week horizon
- test-weekly-e2e.js: Playwright script testing all 8 UI pages with real data