### PR TITLE
fix: frequency-aware TransitionConfig, config validation, and min_series_length

### DIFF
--- a/forecasting-product/src/config/loader.py
+++ b/forecasting-product/src/config/loader.py
@@ -95,7 +95,10 @@ def _dict_to_config(d: Dict[str, Any]) -> PlatformConfig:
 
     tr_raw = d.get("transition", {})
     transition = TransitionConfig(
-        transition_window_weeks=tr_raw.get("transition_window_weeks", 13),
+        transition_window_weeks=tr_raw.get(
+            "transition_window_periods",
+            tr_raw.get("transition_window_weeks", 13),
+        ),
         ramp_shape=tr_raw.get("ramp_shape", "linear"),
         enable_overrides=tr_raw.get("enable_overrides", True),
         override_store_path=tr_raw.get(

--- a/forecasting-product/src/config/schema.py
+++ b/forecasting-product/src/config/schema.py
@@ -7,9 +7,12 @@ model selections, and reconciliation strategies are all configuration, never
 hard-coded to a specific LOB.
 """
 
+import logging
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any, Dict, List, Optional
+
+_logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -243,6 +246,17 @@ class ForecastConfig:
         """Default ML lag set for the configured frequency."""
         return list(get_frequency_profile(self.frequency)["default_lags"])
 
+    def __post_init__(self):
+        if self.frequency not in FREQUENCY_PROFILES:
+            raise ValueError(
+                f"Unsupported frequency {self.frequency!r}. "
+                f"Choose from: {sorted(FREQUENCY_PROFILES)}"
+            )
+        if self.horizon_weeks < 1:
+            raise ValueError(
+                f"horizon_weeks must be >= 1, got {self.horizon_weeks}"
+            )
+
 
 @dataclass
 class HorizonBucket:
@@ -280,14 +294,47 @@ class BacktestConfig:
         """Alias for ``gap_weeks`` (periods, frequency-agnostic)."""
         return self.gap_weeks
 
+    def __post_init__(self):
+        if self.n_folds < 1:
+            raise ValueError(f"n_folds must be >= 1, got {self.n_folds}")
+        if self.val_weeks < 1:
+            raise ValueError(f"val_weeks must be >= 1, got {self.val_weeks}")
+        if self.gap_weeks < 0:
+            raise ValueError(f"gap_weeks must be >= 0, got {self.gap_weeks}")
+
+
+VALID_RAMP_SHAPES = frozenset({"linear", "scurve", "step"})
+
 
 @dataclass
 class TransitionConfig:
-    """Product transition stitching settings."""
-    transition_window_weeks: int = 13    # 3-month overlap window
+    """Product transition stitching settings.
+
+    ``transition_window_weeks`` represents *periods* (not calendar weeks)
+    when the platform runs at non-weekly frequencies.  Name is kept for
+    backward-compatible YAML loading; use :pyattr:`transition_window_periods`
+    alias for clarity.
+    """
+    transition_window_weeks: int = 13    # periods (name kept for YAML compat)
     ramp_shape: str = "linear"           # "linear" | "scurve" | "step"
     enable_overrides: bool = True        # read planner overrides from store
     override_store_path: str = "data/overrides.duckdb"
+
+    @property
+    def transition_window_periods(self) -> int:
+        """Alias for ``transition_window_weeks`` (periods, frequency-agnostic)."""
+        return self.transition_window_weeks
+
+    def __post_init__(self):
+        if self.ramp_shape not in VALID_RAMP_SHAPES:
+            raise ValueError(
+                f"Unknown ramp_shape {self.ramp_shape!r}. "
+                f"Supported: {sorted(VALID_RAMP_SHAPES)}"
+            )
+        if self.transition_window_weeks < 1:
+            raise ValueError(
+                f"transition_window_weeks must be >= 1, got {self.transition_window_weeks}"
+            )
 
 
 @dataclass
@@ -365,6 +412,23 @@ class DataQualityConfig:
     @property
     def min_series_length(self) -> int:
         """Alias for ``min_series_length_weeks`` (periods, frequency-agnostic)."""
+        return self.min_series_length_weeks
+
+    def effective_min_series_length(self, frequency: str) -> int:
+        """Return frequency-aware minimum series length.
+
+        If ``min_series_length_weeks`` is the default (52), return the
+        profile-recommended value for the given frequency.  If the user
+        explicitly set a non-default value, respect it as-is.
+
+        Parameters
+        ----------
+        frequency : str
+            One of ``"D"``, ``"W"``, ``"M"``, ``"Q"``.
+        """
+        profile_min = get_frequency_profile(frequency)["min_series_length"]
+        if self.min_series_length_weeks == 52:
+            return profile_min
         return self.min_series_length_weeks
     validation: ValidationConfig = field(default_factory=ValidationConfig)
     cleansing: CleansingConfig = field(default_factory=CleansingConfig)

--- a/forecasting-product/src/data/quality_report.py
+++ b/forecasting-product/src/data/quality_report.py
@@ -132,7 +132,7 @@ class DataQualityAnalyzer:
             report.series_with_gaps = int(gaps.filter(pl.col("missing") > 0).height)
 
         # Short series
-        min_len = dq.min_series_length_weeks
+        min_len = dq.effective_min_series_length(self.config.forecast.frequency)
         if min_len > 0:
             report.short_series_count = int(
                 per_series_weeks.filter(pl.col("n_weeks") < min_len).height

--- a/forecasting-product/src/series/builder.py
+++ b/forecasting-product/src/series/builder.py
@@ -35,7 +35,7 @@ class SeriesBuilder:
     def __init__(self, config: PlatformConfig):
         self.config = config
         self._frequency = config.forecast.frequency
-        self._transition_engine = TransitionEngine(config.transition)
+        self._transition_engine = TransitionEngine(config.transition, frequency=config.forecast.frequency)
         self._last_validation_report = None
         self._last_cleansing_report = None
         self._last_break_report = None
@@ -172,13 +172,14 @@ class SeriesBuilder:
                 logger.warning("Data quality: %s", w)
 
         # Step 3a: Drop short series
-        if dq.min_series_length_weeks > 0:
+        effective_min_len = dq.effective_min_series_length(fc.frequency)
+        if effective_min_len > 0:
             series_lengths = (
                 df.group_by(sid_col)
                 .agg(pl.col(time_col).count().alias("_len"))
             )
             valid_ids = series_lengths.filter(
-                pl.col("_len") >= dq.min_series_length_weeks
+                pl.col("_len") >= effective_min_len
             )[sid_col].to_list()
             df = df.filter(pl.col(sid_col).is_in(valid_ids))
 

--- a/forecasting-product/src/series/transition.py
+++ b/forecasting-product/src/series/transition.py
@@ -25,7 +25,7 @@ from typing import Dict, List, Optional, Tuple
 
 import polars as pl
 
-from ..config.schema import TransitionConfig
+from ..config.schema import TransitionConfig, freq_timedelta
 
 VALID_RAMP_SHAPES = frozenset({"linear", "scurve", "step"})
 
@@ -62,8 +62,9 @@ class TransitionEngine:
     >>> stitched = engine.stitch_series(actuals, plans)
     """
 
-    def __init__(self, config: TransitionConfig):
-        self.window_weeks = config.transition_window_weeks
+    def __init__(self, config: TransitionConfig, frequency: str = "W"):
+        self.window_periods = config.transition_window_periods
+        self.frequency = frequency
         self.ramp_shape = config.ramp_shape
         if self.ramp_shape not in VALID_RAMP_SHAPES:
             raise ValueError(
@@ -112,7 +113,7 @@ class TransitionEngine:
                 key = (row["old_sku"], row["new_sku"])
                 override_map[key] = row
 
-        horizon_end = forecast_origin + timedelta(weeks=horizon_weeks)
+        horizon_end = forecast_origin + freq_timedelta(self.frequency, horizon_weeks)
         plans: List[TransitionPlan] = []
 
         for row in mapping_table.iter_rows(named=True):
@@ -146,11 +147,11 @@ class TransitionEngine:
                 ))
             elif new_launch <= horizon_end:
                 # Scenario B — launches within horizon
-                ramp_start = new_launch - timedelta(
-                    weeks=self.window_weeks // 2
+                ramp_start = new_launch - freq_timedelta(
+                    self.frequency, self.window_periods // 2
                 )
-                ramp_end = new_launch + timedelta(
-                    weeks=self.window_weeks // 2
+                ramp_end = new_launch + freq_timedelta(
+                    self.frequency, self.window_periods // 2
                 )
                 plans.append(TransitionPlan(
                     old_sku=old_sku,

--- a/forecasting-product/tests/test_config_validation.py
+++ b/forecasting-product/tests/test_config_validation.py
@@ -1,0 +1,251 @@
+"""Tests for config validation, frequency-aware defaults, and TransitionEngine frequency support."""
+
+from datetime import date, timedelta
+
+import polars as pl
+import pytest
+
+from src.config.schema import (
+    BacktestConfig,
+    DataQualityConfig,
+    ForecastConfig,
+    FREQUENCY_PROFILES,
+    PlatformConfig,
+    TransitionConfig,
+    VALID_RAMP_SHAPES,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ===========================================================================
+# ForecastConfig validation
+# ===========================================================================
+
+
+class TestForecastConfigValidation:
+    """__post_init__ validates frequency and horizon."""
+
+    def test_valid_frequencies_accepted(self):
+        for freq in ("D", "W", "M", "Q"):
+            cfg = ForecastConfig(frequency=freq)
+            assert cfg.frequency == freq
+
+    def test_invalid_frequency_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported frequency"):
+            ForecastConfig(frequency="X")
+
+    def test_zero_horizon_rejected(self):
+        with pytest.raises(ValueError, match="horizon_weeks must be >= 1"):
+            ForecastConfig(horizon_weeks=0)
+
+    def test_negative_horizon_rejected(self):
+        with pytest.raises(ValueError, match="horizon_weeks must be >= 1"):
+            ForecastConfig(horizon_weeks=-5)
+
+    def test_valid_horizon_accepted(self):
+        cfg = ForecastConfig(horizon_weeks=12)
+        assert cfg.horizon_periods == 12
+
+
+# ===========================================================================
+# BacktestConfig validation
+# ===========================================================================
+
+
+class TestBacktestConfigValidation:
+    """__post_init__ validates folds, val_weeks, gap_weeks."""
+
+    def test_zero_folds_rejected(self):
+        with pytest.raises(ValueError, match="n_folds must be >= 1"):
+            BacktestConfig(n_folds=0)
+
+    def test_zero_val_weeks_rejected(self):
+        with pytest.raises(ValueError, match="val_weeks must be >= 1"):
+            BacktestConfig(val_weeks=0)
+
+    def test_negative_gap_rejected(self):
+        with pytest.raises(ValueError, match="gap_weeks must be >= 0"):
+            BacktestConfig(gap_weeks=-1)
+
+    def test_zero_gap_accepted(self):
+        cfg = BacktestConfig(gap_weeks=0)
+        assert cfg.gap_periods == 0
+
+    def test_valid_config_accepted(self):
+        cfg = BacktestConfig(n_folds=5, val_weeks=4, gap_weeks=1)
+        assert cfg.val_periods == 4
+
+
+# ===========================================================================
+# TransitionConfig validation
+# ===========================================================================
+
+
+class TestTransitionConfigValidation:
+    """__post_init__ validates ramp_shape and window."""
+
+    def test_invalid_ramp_shape_rejected(self):
+        with pytest.raises(ValueError, match="Unknown ramp_shape"):
+            TransitionConfig(ramp_shape="banana")
+
+    def test_valid_ramp_shapes_accepted(self):
+        for shape in VALID_RAMP_SHAPES:
+            cfg = TransitionConfig(ramp_shape=shape)
+            assert cfg.ramp_shape == shape
+
+    def test_zero_window_rejected(self):
+        with pytest.raises(ValueError, match="transition_window_weeks must be >= 1"):
+            TransitionConfig(transition_window_weeks=0)
+
+    def test_transition_window_periods_alias(self):
+        cfg = TransitionConfig(transition_window_weeks=8)
+        assert cfg.transition_window_periods == 8
+
+
+# ===========================================================================
+# DataQualityConfig.effective_min_series_length
+# ===========================================================================
+
+
+class TestEffectiveMinSeriesLength:
+    """Frequency-aware minimum series length."""
+
+    def test_default_52_returns_profile_value(self):
+        """When user hasn't overridden the default, use the profile value."""
+        dq = DataQualityConfig()
+        assert dq.min_series_length_weeks == 52  # default
+
+        for freq in ("D", "W", "M", "Q"):
+            expected = FREQUENCY_PROFILES[freq]["min_series_length"]
+            assert dq.effective_min_series_length(freq) == expected
+
+    def test_weekly_default_unchanged(self):
+        dq = DataQualityConfig()
+        assert dq.effective_min_series_length("W") == 52
+
+    def test_daily_default_is_90(self):
+        dq = DataQualityConfig()
+        assert dq.effective_min_series_length("D") == 90
+
+    def test_monthly_default_is_24(self):
+        dq = DataQualityConfig()
+        assert dq.effective_min_series_length("M") == 24
+
+    def test_quarterly_default_is_8(self):
+        dq = DataQualityConfig()
+        assert dq.effective_min_series_length("Q") == 8
+
+    def test_explicit_override_respected(self):
+        """When user explicitly sets a value, use it regardless of frequency."""
+        dq = DataQualityConfig(min_series_length_weeks=100)
+        assert dq.effective_min_series_length("D") == 100
+        assert dq.effective_min_series_length("W") == 100
+        assert dq.effective_min_series_length("M") == 100
+
+
+# ===========================================================================
+# TransitionEngine frequency-awareness
+# ===========================================================================
+
+
+class TestTransitionEngineFrequency:
+    """TransitionEngine uses freq_timedelta instead of timedelta(weeks=...)."""
+
+    def _make_mapping(self, old_sku="OLD", new_sku="NEW", proportion=1.0):
+        return pl.DataFrame({
+            "old_sku": [old_sku],
+            "new_sku": [new_sku],
+            "proportion": [proportion],
+        })
+
+    def _make_product_master(self, sku_id, launch_date):
+        return pl.DataFrame({
+            "sku_id": [sku_id],
+            "launch_date": [launch_date],
+        }).with_columns(pl.col("launch_date").cast(pl.Date))
+
+    def test_weekly_transition_window_uses_weeks(self):
+        """Weekly frequency: window_periods=4 → ramp spans ~4 weeks."""
+        from src.series.transition import TransitionEngine, TransitionScenario
+
+        config = TransitionConfig(transition_window_weeks=4)
+        engine = TransitionEngine(config, frequency="W")
+
+        origin = date(2024, 1, 1)
+        launch = date(2024, 2, 1)  # within horizon
+
+        plans = engine.compute_plans(
+            self._make_mapping(),
+            self._make_product_master("NEW", launch),
+            origin,
+            horizon_weeks=13,
+        )
+
+        assert len(plans) == 1
+        plan = plans[0]
+        assert plan.scenario == TransitionScenario.B_IN_HORIZON
+        # 4 weeks / 2 = 2 weeks = 14 days
+        assert plan.ramp_start == launch - timedelta(weeks=2)
+        assert plan.ramp_end == launch + timedelta(weeks=2)
+
+    def test_daily_transition_window_uses_days(self):
+        """Daily frequency: window_periods=10 → ramp spans ~10 days."""
+        from src.series.transition import TransitionEngine, TransitionScenario
+
+        config = TransitionConfig(transition_window_weeks=10)
+        engine = TransitionEngine(config, frequency="D")
+
+        origin = date(2024, 1, 1)
+        launch = date(2024, 1, 15)
+
+        plans = engine.compute_plans(
+            self._make_mapping(),
+            self._make_product_master("NEW", launch),
+            origin,
+            horizon_weeks=30,
+        )
+
+        assert len(plans) == 1
+        plan = plans[0]
+        assert plan.scenario == TransitionScenario.B_IN_HORIZON
+        # 10 days / 2 = 5 days
+        assert plan.ramp_start == launch - timedelta(days=5)
+        assert plan.ramp_end == launch + timedelta(days=5)
+
+    def test_daily_horizon_uses_days(self):
+        """Daily frequency: horizon_weeks=30 → 30 days, not 30 weeks."""
+        from src.series.transition import TransitionEngine, TransitionScenario
+
+        config = TransitionConfig(transition_window_weeks=4)
+        engine = TransitionEngine(config, frequency="D")
+
+        origin = date(2024, 1, 1)
+        # Launch at day 20 — within 30-day horizon
+        launch_in = date(2024, 1, 21)
+        # Launch at day 40 — beyond 30-day horizon
+        launch_out = date(2024, 2, 10)
+
+        plans_in = engine.compute_plans(
+            self._make_mapping(),
+            self._make_product_master("NEW", launch_in),
+            origin,
+            horizon_weeks=30,
+        )
+        assert plans_in[0].scenario == TransitionScenario.B_IN_HORIZON
+
+        plans_out = engine.compute_plans(
+            self._make_mapping(),
+            self._make_product_master("NEW", launch_out),
+            origin,
+            horizon_weeks=30,
+        )
+        assert plans_out[0].scenario == TransitionScenario.C_BEYOND_HORIZON
+
+    def test_default_frequency_is_weekly(self):
+        """Backward compat: TransitionEngine without explicit frequency defaults to 'W'."""
+        from src.series.transition import TransitionEngine
+
+        config = TransitionConfig(transition_window_weeks=13)
+        engine = TransitionEngine(config)
+        assert engine.frequency == "W"


### PR DESCRIPTION
Three related fixes making the config system fully frequency-aware (D/W/M/Q):

**#3 TransitionEngine** — uses freq_timedelta() instead of timedelta(weeks=...) for ramp windows and horizon. Daily frequency with window=10 now means 10 days, not 10 weeks.

**#4 Config validation** — ForecastConfig, BacktestConfig, TransitionConfig now validate in __post_init__() (frequency, horizon>0, folds>0, ramp_shape). Invalid configs fail fast with clear messages instead of crashing deep in pipeline.

**#5 min_series_length** — DataQualityConfig.effective_min_series_length(freq) returns profile-aware defaults: D=90, W=52, M=24, Q=8. Explicit user overrides are respected.

24 new tests. All 21 existing transition tests pass. Fully backward compatible.