### PR TITLE
docs: sync frontend architecture docs with code

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,7 +65,7 @@ graph TD
 
     subgraph Consumers["Consumers"]
         API["FastAPI REST<br/><small>auth-protected</small>"]
-        NX["Next.js Frontend<br/><small>8 pages, REST client</small>"]
+        NX["Next.js Frontend<br/><small>10 pages, REST client</small>"]
         AI["AI Features<br/><small>NL Query, Triage,<br/>Commentary, Config Tuner</small>"]
     end
 
@@ -605,19 +605,19 @@ graph TD
 
 ### Deep Dive: Next.js Frontend
 
-The Next.js frontend communicates with the FastAPI backend over REST. It provides the 8-page workflow UI and runs as a standalone Node.js application.
+The Next.js frontend communicates with the FastAPI backend over REST. It provides the 10-page workflow UI (login + 9 workflow pages) and runs as a standalone Node.js application.
 
 ```mermaid
 graph TB
     subgraph NextJS["Next.js Frontend (port 3000)"]
         direction TB
-        NL["Login"] --> NP["8 Workflow Pages"]
+        NL["Login"] --> NP["9 Workflow Pages"]
         NP --> NH["React Query Hooks"]
         NH --> NC["API Client<br/><small>typed fetch + JWT</small>"]
     end
 
     subgraph API["FastAPI Backend (port 8000)"]
-        EP["12 REST Endpoints"]
+        EP["41 REST Endpoints"]
     end
 
     NC -->|HTTP/JSON| EP

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ forecasting-product/
 │   ├── spark/              # PySpark distributed execution layer
 │   └── utils/              # Logger, config utilities
 ├── frontend/               # Next.js 15 frontend (TypeScript, Tailwind, Recharts)
-│   ├── src/app/            # App Router pages (login + 8 workflow pages)
+│   ├── src/app/            # App Router pages (login + 9 workflow pages)
 │   ├── src/components/     # Reusable components (charts, AI panels, layout, shared)
 │   │   ├── forecast/       # Decomposition, comparison, constrained forecast panels
 │   │   ├── governance/     # Model cards, lineage, BI export panels
@@ -1008,7 +1008,7 @@ python -m pytest forecasting-product/tests/ \
 
 ## Next.js Frontend
 
-A production-grade UI built with Next.js 15 (App Router), TypeScript, and Tailwind CSS. Provides an 8-page workflow and communicates with the FastAPI backend over REST.
+A production-grade UI built with Next.js 15 (App Router), TypeScript, and Tailwind CSS. Provides a 10-page workflow (login + 9 workflow pages) and communicates with the FastAPI backend over REST.
 
 | Feature | Details |
 |---------|---------|
@@ -1017,7 +1017,7 @@ A production-grade UI built with Next.js 15 (App Router), TypeScript, and Tailwi
 | **Charts** | Recharts (bar, line, pie, area), Plotly (fan chart, sunburst, SBC scatter) |
 | **Data fetching** | TanStack React Query with typed API client |
 | **Auth** | NextAuth.js wrapping existing JWT/RBAC (5 roles) |
-| **Pages** | Login + 8 workflow pages |
+| **Pages** | Login + 9 workflow pages |
 | **Dark mode** | Toggle with localStorage persistence |
 
 **Live features** (connected to existing API): file upload/analysis, model leaderboard, drift alerts, audit log, AI explain/triage/config-tuner/commentary.

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -57,7 +57,7 @@ src/components/
     config-tuner-panel # AI-recommended config changes
     commentary-panel   # Executive S&OP commentary generation
     confidence-badge   # High/Medium/Low confidence indicator
-  charts/              # 11 components — Data visualization
+  charts/              # 12 components — Data visualization
     time-series-line   # Basic time series line chart (Recharts)
     fan-chart          # Forecast with prediction intervals
     leaderboard-bar    # Model accuracy comparison bars

--- a/forecasting-product/frontend/README.md
+++ b/forecasting-product/frontend/README.md
@@ -26,23 +26,24 @@ src/
     sop/                # S&OP dashboard: FVA, comparison, constraints, AI commentary
     health/             # System health + audit log
   components/
+    ai/                 # AI panels (NL query, triage, config tuner, commentary, confidence badge)
     charts/             # Recharts + Plotly visualizations (fan-chart, sunburst, etc.)
+    data/               # File upload, data table, config viewer
     forecast/           # Decomposition, comparison, constrained forecast panels
     governance/         # Model cards, lineage, BI export
-    pipeline/           # Multi-file analysis, pipeline execution
-    sku/                # SKU mapping, override management
     layout/             # Sidebar, header
-    shared/             # DataTable, LoadingCard, ComingSoon
-    ui/                 # shadcn/ui primitives
+    pipeline/           # Multi-file analysis, pipeline execution
+    shared/             # workflow-nav, metric-card, loading-skeleton, error-boundary, no-data-guide, coming-soon
+    sku/                # SKU mapping, override management
   hooks/                # React Query hooks + useAsyncOperation
   lib/                  # API client, auth, types, constants
-  providers/            # AuthProvider (JWT + RBAC)
+  providers/            # QueryProvider, AuthProvider (JWT + RBAC), LobProvider
 ```
 
 ## Key Dependencies
 
 - **Next.js 15** (React 19, App Router, TypeScript)
-- **Tailwind CSS** + **shadcn/ui** (Radix primitives)
+- **Tailwind CSS** + Radix UI primitives (with `class-variance-authority` + `tailwind-merge`)
 - **Recharts** (line, bar, composed charts)
 - **Plotly.js** via `react-plotly.js` (fan charts, sunburst) with `next/dynamic` SSR-off
 - **@tanstack/react-query** (server state)


### PR DESCRIPTION
Corrected inaccuracies discovered by auditing docs against the actual frontend source:

- Page count: frontend has 10 routes (login + 9 workflow pages), not 8

- REST endpoints: api-client.ts covers 41 endpoints, not 12

- charts/ folder has 12 components, not 11

- forecasting-product/frontend/README.md: added missing ai/ and data/ component folders, removed nonexistent ui/ folder and shadcn/ui reference, corrected shared/ file list, listed all 3 providers (Query, Auth, Lob), replaced shadcn dependency with actual Radix + CVA + tailwind-merge stack