### PR TITLE
test: add M5 baseline-driven regression gates

### DIFF
--- a/forecasting-product/scripts/bless_m5_baseline.py
+++ b/forecasting-product/scripts/bless_m5_baseline.py
@@ -1,0 +1,228 @@
+"""Bless a new M5 integration baseline.
+
+Runs the same pipeline that the integration tests exercise, then writes
+the observed champion WMAPE, per-model WMAPE, FVA vs naive, and fixture
+hashes to ``tests/integration/baselines/m5_<frequency>_baseline.json``.
+
+The resulting JSON is the ground truth against which subsequent PRs are
+gated — see ``tests/integration/baseline.py`` for the tolerance policy.
+
+Usage
+-----
+    python scripts/bless_m5_baseline.py --frequency daily
+    python scripts/bless_m5_baseline.py --frequency daily --notes "+ xgboost_direct"
+    python scripts/bless_m5_baseline.py --frequency daily --dry-run
+
+The ``--dry-run`` flag prints the captured numbers without writing the
+baseline file, useful for previewing before committing.
+
+Only ``daily`` is wired today; weekly/monthly hooks are in place but
+skipped until their pytest suites are added.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Make ``src`` importable when this script is invoked directly.
+_REPO = Path(__file__).resolve().parent.parent
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from tests.integration.baseline import baseline_path, sha256_file  # noqa: E402
+
+# ── Supported configurations ──────────────────────────────────────────────────
+FIXTURES_DIR = _REPO / "tests" / "integration" / "fixtures"
+
+SUPPORTED: dict[str, dict[str, Path | str]] = {
+    "daily": {
+        "fixture": FIXTURES_DIR / "m5_daily_sample.csv",
+        "config": FIXTURES_DIR / "m5_daily_config.yaml",
+        "lob": "walmart_m5_daily",
+    },
+    # Stubs — enable once pytest integration suites exist.
+    "weekly": {
+        "fixture": FIXTURES_DIR / "m5_weekly_sample.csv",
+        "config": FIXTURES_DIR / "m5_weekly_config.yaml",
+        "lob": "walmart_m5_weekly",
+    },
+    "monthly": {
+        "fixture": FIXTURES_DIR / "m5_monthly_sample.csv",
+        "config": FIXTURES_DIR / "m5_monthly_config.yaml",
+        "lob": "walmart_m5_monthly",
+    },
+}
+
+DEFAULT_SEED = 42
+
+
+def _run_backtest(fixture: Path, config: Path, lob: str) -> dict:
+    """Drive ``POST /pipeline/backtest`` the same way the integration tests do.
+
+    Returns the parsed JSON response containing the leaderboard + champion.
+    """
+    import tempfile
+
+    from fastapi.testclient import TestClient
+    import polars as pl
+
+    from src.api.app import create_app
+
+    tmpdir = Path(tempfile.mkdtemp(prefix="bless_m5_"))
+    data_dir = tmpdir / "data"
+    metrics_dir = tmpdir / "metrics"
+    data_dir.mkdir(parents=True)
+    metrics_dir.mkdir(parents=True)
+
+    # Pre-populate history (mirrors the test's ``setUpClass``).
+    df = pl.read_csv(fixture, try_parse_dates=True)
+    hist_dir = data_dir / "history" / lob
+    hist_dir.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(hist_dir / "actuals.parquet")
+
+    app = create_app(
+        data_dir=str(data_dir),
+        metrics_dir=str(metrics_dir),
+        auth_enabled=False,
+    )
+    client = TestClient(app)
+
+    resp = client.post(
+        f"/pipeline/backtest?lob={lob}",
+        files={
+            "file": (fixture.name, fixture.read_bytes(), "text/csv"),
+            "config_file": (config.name, config.read_bytes(), "application/x-yaml"),
+        },
+    )
+    if resp.status_code != 200:
+        raise RuntimeError(f"Backtest failed: {resp.status_code} {resp.text}")
+    return resp.json()
+
+
+def _extract_metrics(backtest_result: dict) -> dict:
+    """Distil the backtest JSON into baseline fields."""
+    leaderboard = backtest_result.get("leaderboard") or []
+    per_model: dict[str, float] = {}
+    for entry in leaderboard:
+        model_id = entry.get("model_id") or entry.get("model")
+        wmape = entry.get("wmape")
+        if model_id and wmape is not None:
+            per_model[str(model_id)] = float(wmape)
+
+    champion_model = backtest_result.get("champion_model")
+    champion_wmape = backtest_result.get("best_wmape")
+
+    # Naive WMAPE drives the FVA gate. Match by model id containing "naive"
+    # so the script is resilient to ``naive_seasonal`` vs ``seasonal_naive``.
+    naive_wmape = None
+    for mid, w in per_model.items():
+        if "naive" in mid.lower():
+            naive_wmape = w
+            break
+
+    fva = None
+    if naive_wmape is not None and champion_wmape is not None:
+        fva = round(float(naive_wmape) - float(champion_wmape), 6)
+
+    return {
+        "per_model_wmape": {k: round(v, 6) for k, v in per_model.items()},
+        "champion_model": champion_model,
+        "champion_wmape": (
+            round(float(champion_wmape), 6) if champion_wmape is not None else None
+        ),
+        "naive_wmape": round(float(naive_wmape), 6) if naive_wmape is not None else None,
+        "fva_vs_naive": fva,
+    }
+
+
+def bless(frequency: str, notes: str, dry_run: bool) -> int:
+    if frequency not in SUPPORTED:
+        print(f"ERROR: unsupported frequency '{frequency}'. "
+              f"Choose one of: {', '.join(SUPPORTED)}.", file=sys.stderr)
+        return 2
+
+    spec = SUPPORTED[frequency]
+    fixture = Path(spec["fixture"])
+    config = Path(spec["config"])
+    lob = str(spec["lob"])
+
+    if not fixture.exists():
+        print(f"ERROR: fixture not found at {fixture}.", file=sys.stderr)
+        if frequency == "daily":
+            print("  Run: python -m tests.integration.prepare_m5_daily",
+                  file=sys.stderr)
+        else:
+            print(f"  No fixture preparation pipeline wired for '{frequency}' yet.",
+                  file=sys.stderr)
+        return 2
+    if not config.exists():
+        print(f"ERROR: config not found at {config}.", file=sys.stderr)
+        return 2
+
+    print(f"Running backtest for '{frequency}' (lob={lob})…")
+    backtest_result = _run_backtest(fixture, config, lob)
+    metrics = _extract_metrics(backtest_result)
+
+    if metrics["champion_wmape"] is None:
+        print("ERROR: pipeline did not return a champion WMAPE; refusing to bless.",
+              file=sys.stderr)
+        print(json.dumps(backtest_result, indent=2, default=str)[:2000], file=sys.stderr)
+        return 3
+
+    baseline = {
+        "frequency": frequency,
+        "fixture": str(fixture.relative_to(_REPO)).replace("\\", "/"),
+        "config": str(config.relative_to(_REPO)).replace("\\", "/"),
+        "fixture_sha256": sha256_file(fixture),
+        "config_sha256": sha256_file(config),
+        "seed": DEFAULT_SEED,
+        "blessed_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "notes": notes,
+        **metrics,
+    }
+
+    print("\nCaptured baseline:")
+    print(json.dumps(baseline, indent=2))
+
+    if dry_run:
+        print("\n[dry-run] not writing baseline file.")
+        return 0
+
+    out = baseline_path(frequency)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8") as f:
+        json.dump(baseline, f, indent=2)
+        f.write("\n")
+    print(f"\nWrote {out}")
+    return 0
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--frequency",
+        choices=sorted(SUPPORTED),
+        required=True,
+        help="Which M5 baseline to bless.",
+    )
+    parser.add_argument(
+        "--notes",
+        default="",
+        help="Free-form note recorded in the baseline JSON.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print captured numbers without writing the baseline file.",
+    )
+    args = parser.parse_args()
+    return bless(args.frequency, args.notes, args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/forecasting-product/tests/integration/baseline.py
+++ b/forecasting-product/tests/integration/baseline.py
@@ -1,0 +1,244 @@
+"""Baseline-driven quality gates for M5 integration tests.
+
+Replaces hand-waved sanity bounds (e.g. ``best_wmape < 2.0``) with
+empirical, versioned baselines captured by ``scripts/bless_m5_baseline.py``.
+
+Each baseline JSON records:
+  * ``fixture_sha256`` / ``config_sha256`` — detect silent fixture drift
+  * ``seed`` — deterministic models only
+  * ``per_model_wmape`` — champion + every ranked model
+  * ``champion_model`` / ``champion_wmape`` / ``naive_wmape``
+  * ``fva_vs_naive`` — championWmape improvement over naive_seasonal
+  * Optional calibration coverage fields
+
+Tests import :func:`load_baseline`, :func:`verify_fixture_hash`, and
+:func:`assert_no_regression` to assert structural + numerical invariants.
+
+If a baseline file is missing, tests skip (not fail) so a fresh checkout
+without a blessed baseline doesn't red-CI-break. Running
+``python scripts/bless_m5_baseline.py --frequency daily`` populates it.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+BASELINES_DIR = Path(__file__).resolve().parent / "baselines"
+
+# ── Tolerances (can be tightened once baselines are stable) ───────────────────
+# Champion WMAPE may degrade by at most this fraction before the gate fires.
+CHAMPION_REGRESSION_TOLERANCE = 0.05  # 5 % relative
+# Any model's WMAPE may degrade by at most this fraction.
+PER_MODEL_REGRESSION_TOLERANCE = 0.10  # 10 % relative
+# Minimum FVA (naive - champion) that must be preserved; 0.0 means "champion
+# must at least match the recorded improvement over naive".
+MIN_FVA_RATIO = 0.80  # accept ≥ 80 % of the blessed FVA improvement
+# P90 coverage must stay within this many percentage points of baseline.
+CALIBRATION_TOLERANCE_PP = 0.05
+
+
+# ── Data model ────────────────────────────────────────────────────────────────
+
+@dataclass
+class Baseline:
+    """Parsed baseline JSON with convenience accessors."""
+
+    frequency: str
+    fixture_sha256: str
+    config_sha256: str
+    seed: int
+    per_model_wmape: dict[str, float]
+    champion_model: str
+    champion_wmape: float
+    naive_wmape: float | None = None
+    fva_vs_naive: float | None = None
+    calibration_p50_coverage: float | None = None
+    calibration_p90_coverage: float | None = None
+    notes: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Baseline":
+        return cls(
+            frequency=data["frequency"],
+            fixture_sha256=data["fixture_sha256"],
+            config_sha256=data["config_sha256"],
+            seed=int(data.get("seed", 42)),
+            per_model_wmape={k: float(v) for k, v in data["per_model_wmape"].items()},
+            champion_model=data["champion_model"],
+            champion_wmape=float(data["champion_wmape"]),
+            naive_wmape=_opt_float(data.get("naive_wmape")),
+            fva_vs_naive=_opt_float(data.get("fva_vs_naive")),
+            calibration_p50_coverage=_opt_float(data.get("calibration_p50_coverage")),
+            calibration_p90_coverage=_opt_float(data.get("calibration_p90_coverage")),
+            notes=data.get("notes", ""),
+            raw=data,
+        )
+
+
+def _opt_float(v: Any) -> float | None:
+    return None if v is None else float(v)
+
+
+# ── File IO + hashing ─────────────────────────────────────────────────────────
+
+def sha256_file(path: Path) -> str:
+    """Return the hex SHA-256 of a file, streamed to tolerate large fixtures."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def baseline_path(frequency: str) -> Path:
+    """Return the canonical baseline JSON path for a given frequency."""
+    return BASELINES_DIR / f"m5_{frequency}_baseline.json"
+
+
+def load_baseline(frequency: str) -> Baseline | None:
+    """Load the blessed baseline for *frequency* or return ``None`` if absent."""
+    p = baseline_path(frequency)
+    if not p.exists():
+        return None
+    with p.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return Baseline.from_dict(data)
+
+
+def require_baseline(frequency: str, testcase: unittest.TestCase) -> Baseline:
+    """Load the baseline or ``testcase.skipTest`` with a helpful message."""
+    bl = load_baseline(frequency)
+    if bl is None:
+        testcase.skipTest(
+            f"No baseline at {baseline_path(frequency)}. "
+            f"Run: python scripts/bless_m5_baseline.py --frequency {frequency}"
+        )
+    return bl  # type: ignore[return-value]
+
+
+# ── Assertion helpers ─────────────────────────────────────────────────────────
+
+def verify_fixture_hash(
+    testcase: unittest.TestCase,
+    baseline: Baseline,
+    fixture_path: Path,
+    config_path: Path,
+) -> None:
+    """Fail if fixture or config contents have drifted from the blessed hashes.
+
+    A hash mismatch means the baseline is stale; re-bless intentionally via
+    the bless script rather than weakening the gate silently.
+    """
+    fixture_hash = sha256_file(fixture_path)
+    config_hash = sha256_file(config_path)
+    testcase.assertEqual(
+        fixture_hash,
+        baseline.fixture_sha256,
+        f"Fixture {fixture_path.name} has changed since baseline was blessed.\n"
+        f"  baseline: {baseline.fixture_sha256}\n"
+        f"  current:  {fixture_hash}\n"
+        "If intentional, re-run scripts/bless_m5_baseline.py.",
+    )
+    testcase.assertEqual(
+        config_hash,
+        baseline.config_sha256,
+        f"Config {config_path.name} has changed since baseline was blessed.\n"
+        f"  baseline: {baseline.config_sha256}\n"
+        f"  current:  {config_hash}\n"
+        "If intentional, re-run scripts/bless_m5_baseline.py.",
+    )
+
+
+def assert_no_regression(
+    testcase: unittest.TestCase,
+    baseline: Baseline,
+    observed_champion_wmape: float,
+    observed_per_model_wmape: dict[str, float],
+) -> None:
+    """Layered regression gates against a blessed baseline.
+
+    1. Champion WMAPE must not exceed ``baseline.champion_wmape *
+       (1 + CHAMPION_REGRESSION_TOLERANCE)``.
+    2. Every blessed model's WMAPE must not exceed its baseline value by more
+       than ``PER_MODEL_REGRESSION_TOLERANCE`` (relative). Models absent from
+       the observed run are reported but skipped (non-determinism or model
+       pruning is caller's responsibility).
+    """
+    champion_limit = baseline.champion_wmape * (1 + CHAMPION_REGRESSION_TOLERANCE)
+    testcase.assertLessEqual(
+        observed_champion_wmape,
+        champion_limit,
+        f"Champion WMAPE regression: observed={observed_champion_wmape:.4f} "
+        f"> baseline×{1 + CHAMPION_REGRESSION_TOLERANCE:.2f}={champion_limit:.4f} "
+        f"(baseline={baseline.champion_wmape:.4f}).",
+    )
+
+    for model, baseline_wmape in baseline.per_model_wmape.items():
+        if model not in observed_per_model_wmape:
+            continue
+        observed = observed_per_model_wmape[model]
+        limit = baseline_wmape * (1 + PER_MODEL_REGRESSION_TOLERANCE)
+        testcase.assertLessEqual(
+            observed,
+            limit,
+            f"Model '{model}' WMAPE regression: observed={observed:.4f} "
+            f"> baseline×{1 + PER_MODEL_REGRESSION_TOLERANCE:.2f}={limit:.4f} "
+            f"(baseline={baseline_wmape:.4f}).",
+        )
+
+
+def assert_fva_preserved(
+    testcase: unittest.TestCase,
+    baseline: Baseline,
+    observed_naive_wmape: float,
+    observed_champion_wmape: float,
+) -> None:
+    """Assert that the champion still beats the naive baseline by a meaningful
+    margin (≥ ``MIN_FVA_RATIO`` of the blessed improvement, and strictly > 0).
+
+    This is the *business-value* gate: forecasting must add value over the
+    dumbest baseline, not just converge.
+    """
+    observed_fva = observed_naive_wmape - observed_champion_wmape
+    testcase.assertGreater(
+        observed_fva,
+        0.0,
+        f"Champion ({observed_champion_wmape:.4f}) did not beat naive "
+        f"({observed_naive_wmape:.4f}) — forecast value added is non-positive.",
+    )
+    if baseline.fva_vs_naive is None or baseline.fva_vs_naive <= 0:
+        return  # no blessed FVA improvement to compare against
+    required = baseline.fva_vs_naive * MIN_FVA_RATIO
+    testcase.assertGreaterEqual(
+        observed_fva,
+        required,
+        f"FVA regression: observed improvement over naive={observed_fva:.4f} "
+        f"< {MIN_FVA_RATIO:.0%} of baseline improvement={baseline.fva_vs_naive:.4f} "
+        f"(required ≥ {required:.4f}).",
+    )
+
+
+def assert_calibration_preserved(
+    testcase: unittest.TestCase,
+    baseline: Baseline,
+    observed_p90_coverage: float,
+) -> None:
+    """Assert that P90 interval coverage is within tolerance of baseline.
+
+    Skipped when the baseline does not record calibration.
+    """
+    if baseline.calibration_p90_coverage is None:
+        testcase.skipTest("Baseline does not record P90 calibration coverage.")
+    delta = abs(observed_p90_coverage - baseline.calibration_p90_coverage)
+    testcase.assertLessEqual(
+        delta,
+        CALIBRATION_TOLERANCE_PP,
+        f"P90 coverage drift: observed={observed_p90_coverage:.3f}, "
+        f"baseline={baseline.calibration_p90_coverage:.3f}, "
+        f"delta={delta:.3f} > tol={CALIBRATION_TOLERANCE_PP}.",
+    )

--- a/forecasting-product/tests/integration/baselines/README.md
+++ b/forecasting-product/tests/integration/baselines/README.md
@@ -1,0 +1,45 @@
+# M5 Integration Baselines
+
+This directory holds **blessed accuracy baselines** for the M5 end-to-end
+integration tests. Each baseline is the ground truth against which PRs are
+gated: no magic numbers, no hand-waved thresholds.
+
+## Files
+
+| File | Frequency | Fixture |
+|------|-----------|---------|
+| `m5_daily_baseline.json` | Daily | `tests/integration/fixtures/m5_daily_sample.csv` |
+
+Weekly and monthly baselines will be added when the corresponding pytest
+integration suites are added.
+
+## Workflow
+
+1. **A test compares the observed pipeline output against the baseline**
+   (champion WMAPE, per-model WMAPE, FVA vs naive, calibration). Tolerances
+   live in `tests/integration/baseline.py`.
+2. **Fixture + config hashes are verified first** — if they drift, the
+   baseline is considered stale and the test fails with a clear pointer to
+   the bless script.
+3. **To intentionally update** (new model, improved features):
+   ```bash
+   python scripts/bless_m5_baseline.py --frequency daily
+   git diff tests/integration/baselines/m5_daily_baseline.json
+   ```
+   The diff is a reviewable record of "what this platform now delivers".
+
+## Field reference
+
+| Field | Meaning |
+|-------|---------|
+| `frequency` | `daily` \| `weekly` \| `monthly` |
+| `fixture_sha256` | SHA-256 of the CSV fixture at bless time |
+| `config_sha256` | SHA-256 of the YAML config at bless time |
+| `seed` | Deterministic-seed value used by the pipeline |
+| `per_model_wmape` | `{model_id: wmape}` for every ranked model |
+| `champion_model` / `champion_wmape` | Winner of the walk-forward backtest |
+| `naive_wmape` | Seasonal-naive WMAPE, used for FVA |
+| `fva_vs_naive` | `naive_wmape - champion_wmape` (must stay positive) |
+| `calibration_p50_coverage`, `calibration_p90_coverage` | Optional PI coverage |
+| `blessed_at` | ISO-8601 UTC timestamp |
+| `notes` | Free-form rationale for this bless |

--- a/forecasting-product/tests/integration/test_m5_daily_backend.py
+++ b/forecasting-product/tests/integration/test_m5_daily_backend.py
@@ -245,6 +245,64 @@ class TestBacktestPipeline(unittest.TestCase):
             self.assertGreater(data["best_wmape"], 0)
             self.assertLess(data["best_wmape"], 2.0)  # sanity — not absurdly high
 
+    def test_baseline_no_regression(self):
+        """Champion + per-model WMAPE must not regress against the blessed baseline.
+
+        Skipped if ``tests/integration/baselines/m5_daily_baseline.json`` is absent
+        (run ``python scripts/bless_m5_baseline.py --frequency daily`` to capture).
+        """
+        from tests.integration.baseline import (
+            assert_no_regression,
+            require_baseline,
+            verify_fixture_hash,
+        )
+
+        baseline = require_baseline("daily", self)
+        verify_fixture_hash(self, baseline, SAMPLE_CSV, CONFIG_YAML)
+
+        data = self._backtest_result
+        if data.get("best_wmape") is None:
+            self.skipTest("Pipeline did not return best_wmape; cannot check regression.")
+
+        per_model = {
+            entry["model_id"]: float(entry["wmape"])
+            for entry in data.get("leaderboard", [])
+            if entry.get("model_id") and entry.get("wmape") is not None
+        }
+        assert_no_regression(
+            self,
+            baseline,
+            observed_champion_wmape=float(data["best_wmape"]),
+            observed_per_model_wmape=per_model,
+        )
+
+    def test_baseline_fva_preserved(self):
+        """Champion must still beat naive by ≥ MIN_FVA_RATIO of the blessed margin."""
+        from tests.integration.baseline import assert_fva_preserved, require_baseline
+
+        baseline = require_baseline("daily", self)
+        data = self._backtest_result
+        leaderboard = data.get("leaderboard", [])
+
+        by_id = {
+            e["model_id"]: float(e["wmape"])
+            for e in leaderboard
+            if e.get("model_id") and e.get("wmape") is not None
+        }
+        naive_wmape = next(
+            (w for mid, w in by_id.items() if "naive" in mid.lower()),
+            None,
+        )
+        if naive_wmape is None or data.get("best_wmape") is None:
+            self.skipTest("Naive or champion WMAPE missing; cannot check FVA.")
+
+        assert_fva_preserved(
+            self,
+            baseline,
+            observed_naive_wmape=naive_wmape,
+            observed_champion_wmape=float(data["best_wmape"]),
+        )
+
     def test_leaderboard(self):
         """Leaderboard contains all 3 configured models ranked by WMAPE."""
         data = self._backtest_result


### PR DESCRIPTION
Replaces the hand-waved 'best_wmape < 2.0' sanity check with empirical, fixture-hashed baselines that gate PRs on:

1. No-regression of champion WMAPE (<= baseline * 1.05)

2. No-regression of every ranked model's WMAPE (<= baseline * 1.10)

3. FVA preserved — champion beats naive by >= 80%% of blessed margin, and strictly > 0

Adds:

- tests/integration/baseline.py (Baseline dataclass, fixture/config SHA-256 verification, layered assertion helpers, calibration hook)

- tests/integration/baselines/README.md (field reference, update workflow)

- scripts/bless_m5_baseline.py (runs the pipeline, writes baseline JSON, --dry-run and --notes supported)

- 2 new tests in test_m5_daily_backend.py: test_baseline_no_regression, test_baseline_fva_preserved

The tests gracefully skip when no baseline JSON is present, so this PR is safe to merge before the baseline is captured. To activate the gates:

  python scripts/bless_m5_baseline.py --frequency daily

Weekly/monthly hooks are in place but disabled until their pytest integration suites are added.