### PR TITLE
fix: WMAPE returns None (not inf) when actuals are all zero

### DIFF
--- a/forecasting-product/src/api/routers/pipeline.py
+++ b/forecasting-product/src/api/routers/pipeline.py
@@ -88,10 +88,16 @@ async def run_backtest(
                     if isinstance(v, float) and (math.isinf(v) or math.isnan(v)):
                         row[k] = None
             summary["leaderboard"] = rows
-            # Best WMAPE from first leaderboard entry (sorted ascending)
+            # Best WMAPE from first leaderboard entry (sorted ascending).
+            # Column can be entirely null when WMAPE is undefined for every
+            # model (e.g. all validation windows had zero actuals).
             if "wmape" in leaderboard.columns:
-                best = float(leaderboard["wmape"].min())
-                summary["best_wmape"] = best if math.isfinite(best) else None
+                min_val = leaderboard["wmape"].min()
+                if min_val is None:
+                    summary["best_wmape"] = None
+                else:
+                    best = float(min_val)
+                    summary["best_wmape"] = best if math.isfinite(best) else None
 
         champions = results.get("champions")
         if champions is not None and hasattr(champions, "to_dicts") and not champions.is_empty():

--- a/forecasting-product/src/metrics/definitions.py
+++ b/forecasting-product/src/metrics/definitions.py
@@ -17,7 +17,7 @@ import polars as pl
 
 # ── Metric functions ──────────────────────────────────────────────────────────
 
-def wmape(actual: pl.Series, forecast: pl.Series) -> float:
+def wmape(actual: pl.Series, forecast: pl.Series) -> Optional[float]:
     """
     Weighted Mean Absolute Percentage Error.
 
@@ -26,11 +26,15 @@ def wmape(actual: pl.Series, forecast: pl.Series) -> float:
     - Volume-weighted: high-movers naturally dominate.
     - Handles zeros better than MAPE (no per-row division).
     - Range: [0, ∞), lower is better.
+
+    Returns ``None`` when the actuals are entirely zero on the evaluation
+    window — WMAPE is undefined in that case (any forecast error divided by
+    zero volume is meaningless). Callers/aggregators skip nulls.
     """
     abs_error = (actual - forecast).abs().sum()
     abs_actual = actual.abs().sum()
     if abs_actual == 0:
-        return float("inf")
+        return None
     return float(abs_error / abs_actual)
 
 
@@ -51,17 +55,18 @@ def normalized_bias(actual: pl.Series, forecast: pl.Series) -> float:
     return float(signed_error / abs_actual)
 
 
-def mape(actual: pl.Series, forecast: pl.Series) -> float:
+def mape(actual: pl.Series, forecast: pl.Series) -> Optional[float]:
     """
     Mean Absolute Percentage Error.
 
     MAPE = mean(|actual - forecast| / |actual|)
 
     Excluded where actual == 0 to avoid division by zero.
+    Returns ``None`` if every row has actual == 0 (MAPE undefined).
     """
     mask = actual != 0
     if mask.sum() == 0:
-        return float("inf")
+        return None
     pct_errors = ((actual - forecast).abs() / actual.abs()).filter(mask)
     return float(pct_errors.mean())
 

--- a/forecasting-product/src/metrics/fva.py
+++ b/forecasting-product/src/metrics/fva.py
@@ -55,14 +55,19 @@ def compute_fva_between_layers(
     parent_metrics = compute_layer_metrics(actual, parent_forecast)
     child_metrics = compute_layer_metrics(actual, child_forecast)
 
+    # WMAPE can be None when actuals are all zero on the window.
+    p_w = parent_metrics["wmape"]
+    c_w = child_metrics["wmape"]
+    fva_val = (p_w - c_w) if (p_w is not None and c_w is not None) else None
+
     return {
-        "parent_wmape": parent_metrics["wmape"],
-        "child_wmape": child_metrics["wmape"],
-        "fva_wmape": parent_metrics["wmape"] - child_metrics["wmape"],
+        "parent_wmape": p_w,
+        "child_wmape": c_w,
+        "fva_wmape": fva_val,
         "parent_bias": parent_metrics["bias"],
         "child_bias": child_metrics["bias"],
         "fva_bias": abs(parent_metrics["bias"]) - abs(child_metrics["bias"]),
-        "fva_class": classify_fva(parent_metrics["wmape"] - child_metrics["wmape"]),
+        "fva_class": classify_fva(fva_val) if fva_val is not None else "undefined",
     }
 
 
@@ -146,5 +151,9 @@ def compute_total_fva(
 
     baseline_wmape = wmape(actual, forecasts[available[0]])
     final_wmape = wmape(actual, forecasts[available[-1]])
+
+    # WMAPE is undefined when actuals are all zero. Treat as "no value added".
+    if baseline_wmape is None or final_wmape is None:
+        return 0.0
 
     return baseline_wmape - final_wmape

--- a/forecasting-product/tests/test_platform.py
+++ b/forecasting-product/tests/test_platform.py
@@ -428,6 +428,52 @@ class TestMetrics:
         assert "wmape" in result
         assert "normalized_bias" in result
 
+    def test_wmape_none_when_actuals_all_zero(self):
+        """Regression: WMAPE must return None (not inf) when actuals are
+        entirely zero. Returning inf poisoned downstream .mean() aggregations
+        and caused the leaderboard to report null for every model that had
+        even one all-zero validation window (common in M5/retail)."""
+        from src.metrics.definitions import wmape
+        actual = pl.Series([0.0, 0.0, 0.0])
+        forecast = pl.Series([1.0, 2.0, 3.0])
+        assert wmape(actual, forecast) is None
+
+    def test_leaderboard_aggregate_ignores_undefined_wmape(self):
+        """Regression: a single all-zero-actuals series must not poison the
+        per-model WMAPE aggregate. Polars .mean() skips nulls, so as long as
+        wmape() returns None (not inf) the aggregate stays finite."""
+        from src.metrics.store import MetricStore, METRIC_SCHEMA
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = MetricStore(tmpdir)
+            n = 3
+            records = pl.DataFrame({
+                "run_id": ["r1"] * n,
+                "run_type": ["backtest"] * n,
+                "run_date": [date(2024, 1, 1)] * n,
+                "lob": ["retail"] * n,
+                "model_id": ["m1"] * n,
+                "fold": [0] * n,
+                "grain_level": ["series"] * n,
+                "series_id": ["s1", "s2", "s3"],
+                "channel": ["consumer"] * n,
+                "target_week": [date(2024, 1, 8)] * n,
+                "forecast_step": [1] * n,
+                "actual": [100.0, 200.0, 0.0],
+                "forecast": [110.0, 180.0, 5.0],
+                "wmape": [0.10, 0.20, None],  # None = undefined (zero-actual window)
+                "normalized_bias": [0.01, 0.02, 0.0],
+                "mape": [0.10, 0.10, None],
+                "mae": [10.0, 20.0, 5.0],
+                "rmse": [10.0, 20.0, 5.0],
+                "mase": [None, None, None],
+            }, schema=METRIC_SCHEMA)
+            store.write(records, run_type="backtest", lob="retail")
+            board = store.leaderboard(run_type="backtest", lob="retail")
+            assert not board.is_empty()
+            assert board["wmape"][0] is not None
+            # Mean of 0.10 and 0.20 = 0.15 (None skipped by Polars .mean())
+            assert abs(board["wmape"][0] - 0.15) < 1e-9
+
 
 class TestMetricStore:
     def test_write_and_read(self):


### PR DESCRIPTION
When the evaluation window has zero total actuals, WMAPE is mathematically undefined. Previously we returned float('inf'), which poisoned downstream Polars .mean() aggregations: any model with even one all-zero-actuals series in its backtest had its leaderboard WMAPE collapse to null after JSON sanitization. In practice this silently broke the /pipeline/backtest endpoint on any retail fixture with intermittent SKUs (e.g. Walmart M5).

Changes:
- wmape() and mape() in src/metrics/definitions.py now return None when the denominator is zero. Polars .mean() naturally skips nulls, so a few undefined series no longer poison the model aggregate.
- fva.compute_fva_between_layers and compute_total_fva handle None gracefully (fva_wmape=None, fva_class='undefined', total=0.0).
- api/routers/pipeline.py guards against an all-null leaderboard column in best_wmape extraction (float(None) would TypeError).
- Added two regression tests in test_platform.py:
  - test_wmape_none_when_actuals_all_zero
  - test_leaderboard_aggregate_ignores_undefined_wmape

Surfaced by the M5 baseline-capture run: leaderboard showed wmape=null for every model despite normalized_bias being computed correctly.